### PR TITLE
Error formatting: support for non-JS Error exceptions, with special support for tagged errors + cleanups

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/builtin/timeout.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/timeout.rs
@@ -75,7 +75,7 @@ async fn scheduled_task(
             .unwrap_or_else(|e| {
                 panic!(
                     "Failed to run scheduled task:\n{}",
-                    format_caught_error(&ctx, e)
+                    format_caught_error(e)
                 )
             });
     } else {
@@ -89,7 +89,7 @@ async fn scheduled_task(
                 .unwrap_or_else(|e| {
                     panic!(
                         "Failed to run scheduled task:\n{}",
-                        format_caught_error(&ctx, e)
+                        format_caught_error(e)
                     )
                 });
 

--- a/crates/wasm-rquickjs/skeleton/src/internal.rs
+++ b/crates/wasm-rquickjs/skeleton/src/internal.rs
@@ -54,12 +54,12 @@ impl JsState {
                     Symbol.dispose = dispose;
                     "#)
                 ).catch(&ctx)
-                .unwrap_or_else(|e| panic!("Failed to evaluate dispose module initialization:\n{}", format_caught_error(&ctx, e)))
+                .unwrap_or_else(|e| panic!("Failed to evaluate dispose module initialization:\n{}", format_caught_error(e)))
                 .finish::<()>()
                 .catch(&ctx)
-                .unwrap_or_else(|e| panic!("Failed to finish dispose module initialization:\n{}", format_caught_error(&ctx, e)));
+                .unwrap_or_else(|e| panic!("Failed to finish dispose module initialization:\n{}", format_caught_error(e)));
             })
-            .await;
+                .await;
             rt.idle().await;
 
             let mut resolver = BuiltinResolver::default().with_module(crate::JS_EXPORT_MODULE_NAME);
@@ -101,21 +101,21 @@ impl JsState {
                     "#, crate::JS_EXPORT_MODULE_NAME),
                 )
                 .catch(&ctx)
-                .unwrap_or_else(|e| panic!("Failed to evaluate module initialization:\n{}", format_caught_error(&ctx, e)))
+                .unwrap_or_else(|e| panic!("Failed to evaluate module initialization:\n{}", format_caught_error(e)))
                 .finish::<()>()
                 .catch(&ctx)
-                .unwrap_or_else(|e| panic!("Failed to finish module initialization:\n{}", format_caught_error(&ctx, e)));
+                .unwrap_or_else(|e| panic!("Failed to finish module initialization:\n{}", format_caught_error(e)));
 
                 for (name, _) in crate::JS_ADDITIONAL_MODULES.iter() {
                   Module::import(&ctx, name.to_string())
                      .catch(&ctx)
-                     .unwrap_or_else(|e| panic!("Failed to import user module {name}:\n{}", format_caught_error(&ctx, e)))
+                     .unwrap_or_else(|e| panic!("Failed to import user module {name}:\n{}", format_caught_error(e)))
                      .finish::<()>()
                      .catch(&ctx)
-                     .unwrap_or_else(|e| panic!("Failed to finish importing user module {name}:\n{}", format_caught_error(&ctx, e)));
+                     .unwrap_or_else(|e| panic!("Failed to finish importing user module {name}:\n{}", format_caught_error(e)));
                 }
             })
-            .await;
+                .await;
             rt.idle().await;
 
             let (resource_drop_queue_tx, resource_drop_queue_rx) =
@@ -256,7 +256,7 @@ where
                 if let Some(result) = try_map_exception(&ctx, &exception) {
                     result
                 } else {
-                    panic! ("Exception during call of {fun}:\n{exception}", fun = function_path.join("."), exception = format_js_exception(&ctx, exception));
+                    panic! ("Exception during call of {fun}:\n{exception}", fun = function_path.join("."), exception = format_js_exception(exception));
                 }
             }
             Err(e) => {
@@ -277,7 +277,7 @@ where
                                     if let Some(result) = try_map_exception(&ctx, &exception) {
                                         result
                                     } else {
-                                        panic! ("Exception during awaiting call result for {function_path}:\n{exception}", function_path=function_path.join("."), exception = format_js_exception(&ctx, exception))
+                                        panic! ("Exception during awaiting call result for {function_path}:\n{exception}", function_path=function_path.join("."), exception = format_js_exception(exception))
                                     }
                                 }
                                 _ => {
@@ -330,7 +330,7 @@ where
         match result {
             Err(Error::Exception) => {
                 let exception = ctx.catch();
-                panic! ("Exception during call of constructor {path}:\n{exception}", path= resource_path.join("."), exception = format_js_exception(&ctx, exception));
+                panic! ("Exception during call of constructor {path}:\n{exception}", path= resource_path.join("."), exception = format_js_exception(exception));
             }
             Err(e) => {
                 panic! ("Error during call of constructor {path}: {e:?}", path= resource_path.join("."));
@@ -463,7 +463,7 @@ where
                 if let Some(result) = try_map_exception(&ctx, &exception) {
                     result
                 } else {
-                    panic!("Exception during call of method {name} in {path}:\n{exception}", path=resource_path.join("."), exception = format_js_exception(&ctx, exception));
+                    panic!("Exception during call of method {name} in {path}:\n{exception}", path=resource_path.join("."), exception = format_js_exception(exception));
                 }
             }
             Err(e) => {
@@ -484,7 +484,7 @@ where
                                     if let Some(result) = try_map_exception(&ctx, &exception) {
                                         result
                                     } else {
-                                        panic!("Exception during awaiting call result of method {name} in {path}:\n{exception:?}", path=resource_path.join("."), exception = format_js_exception(&ctx, exception));
+                                        panic!("Exception during awaiting call result of method {name} in {path}:\n{exception:?}", path=resource_path.join("."), exception = format_js_exception(exception));
                                     }
                                 }
                                 _ => {
@@ -657,28 +657,79 @@ fn dump_cannot_find_method(
     panic_message
 }
 
-pub fn format_js_exception<'js>(ctx: &Ctx<'js>, exc: Value<'js>) -> String {
-    if let Ok(obj) = Object::from_js(ctx, exc.clone()) {
-        let message: Option<String> = obj.get("message").ok();
-        let stack: Option<String> = obj.get("stack").ok();
-
-        match (message, stack) {
-            (Some(msg), Some(st)) => format!("JavaScript Error: {msg}\nStack:\n{st}"),
-            (Some(msg), None) => format!("JavaScript Error: {msg}"),
-            (None, Some(st)) => format!("JavaScript Error (no message)\nStack:\n{st}"),
-            _ => format!("JavaScript exception: {exc:?}"),
-        }
-    } else {
-        format!("JavaScript exception (non-object): {exc:?}")
+pub fn format_js_exception(exc: Value) -> String {
+    match exc.as_object() {
+        Some(obj) => try_format_js_error(obj)
+            .or_else(|| try_format_tagged_error(obj))
+            .unwrap_or_else(|| {
+                let formatted_exc = pretty_stringify_or_debug_print(&exc);
+                if formatted_exc.contains("\n") {
+                    format!("JavaScript exception:\n{formatted_exc}",)
+                } else {
+                    format!("JavaScript exception: {formatted_exc}",)
+                }
+            }),
+        None => format!("JavaScript exception: {exc:?}"),
     }
 }
 
-pub fn format_caught_error<'js>(ctx: &Ctx<'js>, caught: CaughtError<'js>) -> String {
+pub fn try_format_js_error(obj: &Object) -> Option<String> {
+    let message: Option<String> = obj.get("message").ok();
+    let stack: Option<String> = obj.get("stack").ok();
+
+    match (message, stack) {
+        (Some(msg), Some(st)) => Some(format!("JavaScript error: {msg}\nStack:\n{st}")),
+        (Some(msg), None) => Some(format!("JavaScript error: {msg}")),
+        (None, Some(st)) => Some(format!("JavaScript error: <no message>\nStack:\n{st}")),
+        _ => None,
+    }
+}
+
+pub fn try_format_tagged_error(obj: &Object) -> Option<String> {
+    let tag: Option<String> = obj.get("tag").ok();
+    let val: Option<Value> = obj.get("val").ok();
+
+    match (tag, val) {
+        (Some(tag), Some(val)) => {
+            let formatted_val = pretty_stringify_or_debug_print(&val);
+            if formatted_val.contains("\n") {
+                Some(format!("Error: {tag}:\n{formatted_val}"))
+            } else {
+                Some(format!("Error: {tag}: {formatted_val}"))
+            }
+        }
+        (Some(tag), None) => Some(format!("Error: {tag}")),
+        _ => None,
+    }
+}
+
+fn pretty_stringify_or_debug_print(val: &Value) -> String {
+    if let Some(formatted) = try_pretty_stringify(val) {
+        formatted
+    } else {
+        format!("{val:#?}")
+    }
+}
+
+fn try_pretty_stringify(val: &Value) -> Option<String> {
+    // Return string as they are
+    if let Some(str) = val.as_string() {
+        return str.to_string().ok();
+    }
+
+    // For other values try to use JSON.stringify()
+    let json: Object = val.ctx().globals().get("JSON").ok()?;
+    let stringify: Function = json.get("stringify").ok()?;
+    let res: Result<String, Error> = stringify.call((val, rquickjs::Undefined, 2));
+    res.ok()
+}
+
+pub fn format_caught_error(caught: CaughtError) -> String {
     match caught {
         CaughtError::Error(e) => {
             format!("Host error: {e:?}")
         }
-        CaughtError::Exception(exc) => format_js_exception(ctx, exc.into_value()),
-        CaughtError::Value(val) => format_js_exception(ctx, val),
+        CaughtError::Exception(exc) => format_js_exception(exc.into_value()),
+        CaughtError::Value(val) => format_js_exception(val),
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/golemcloud/wasm-rquickjs/issues/54

After the switch to throwing errors on import / export boundaries many errors become `JavaScript exception: Object(0x1faab0)`. The PR adds more heuristics for error formatting:
 - first try to match as JS Error (message, stack)
 - after that tries `{ tag: "error-name", val: "optional details"}`, where val is also formatted (if string, then shown, as it is, otherwise tried to be formatted with JSON.stringify)
 - then tries to use JSON.stringfy
 - and only after that falls back to debug print of the Value from Rust
 
 Some examples using golem-cli (note that red highlight will come in a separate PR in golem):
 
 <img width="630" height="134" alt="image" src="https://github.com/user-attachments/assets/c4f208cf-2923-4431-84ae-6f5e46166fff" />

<img width="647" height="202" alt="image" src="https://github.com/user-attachments/assets/4c8c3be9-6d5c-4aee-8821-b54dc84c279b" />

<img width="639" height="214" alt="image" src="https://github.com/user-attachments/assets/d563f816-307a-4a75-b3be-90c1c0169077" />

<img width="634" height="89" alt="image" src="https://github.com/user-attachments/assets/0880b7f1-4717-46f7-a74b-d115aa2b0d1d" />


<img width="630" height="80" alt="image" src="https://github.com/user-attachments/assets/430b64be-673b-4f81-b693-883894c17043" />

<img width="264" height="36" alt="image" src="https://github.com/user-attachments/assets/63446064-0cd9-47b6-8cdb-92733370e76b" />

and as a final, the previous formatting for JS errors and stacks still works:
<img width="478" height="175" alt="image" src="https://github.com/user-attachments/assets/2ef18a54-6369-419f-81ba-cf4cf119792a" />

