### PR TITLE
Better JS Error detection

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/internal.rs
+++ b/crates/wasm-rquickjs/skeleton/src/internal.rs
@@ -671,7 +671,13 @@ pub fn format_js_exception(exc: &Value) -> String {
 }
 
 pub fn try_format_js_error(err: &Value) -> Option<String> {
+    let error_ctor: Object = err.ctx().globals().get("Error").ok()?;
     let obj = err.as_object()?;
+
+    if !obj.is_instance_of(error_ctor) {
+        return None;
+    }
+
     let message: Option<String> = obj.get("message").ok();
     let stack: Option<String> = obj.get("stack").ok();
 


### PR DESCRIPTION
Use "instanceof" for checking if something is a JS Error.

Relying only on the field detection resulted in information loss by default: if an object - which is not a JS Error - contains a message property we only printed the message part.

E.g: golem-ai-llm http errors were reported as:
```
JavaScript error: Request failed with 429 Too Many Requests
```

With this change they will be printed as:
```
JavaScript exception:
{
  "code": "rate-limit-exceeded",
  "message": "Request failed with 429 Too Many Requests",
  "providerErrorJson": "{\n  \"error\": {\n    \"message\": \"You exceeded your current quota <...>}"
}
``` 