### PR TITLE
Do not use cached env vars in node:process env

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/builtin/process.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/process.rs
@@ -16,12 +16,6 @@ pub mod native_module {
     }
 
     #[rquickjs::function]
-    pub fn get_env_var(key: String) -> Option<String> {
-        let map = get_env();
-        map.get(&key).cloned()
-    }
-
-    #[rquickjs::function]
     pub fn next_tick<'js>(ctx: Ctx<'js>, function: Function<'js>, args: Vec<Value<'js>>) {
         let mut js_args = Args::new(ctx, args.len());
         js_args


### PR DESCRIPTION
By calling the WASI `get_environment` directly we make sure we are not using the Rust standard library's cached value here. This is important for Golem as some environment variables may change during the lifetime of an agent