### PR TITLE
Script injection via data sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,6 +3436,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.235.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.235.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
@@ -3500,6 +3510,8 @@ dependencies = [
  "syn",
  "tokio",
  "toml_edit",
+ "wasm-encoder 0.235.0",
+ "wasmparser 0.235.0",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -3566,8 +3578,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags",
+ "hashbrown 0.15.4",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,10 @@ name = "migrate_config_split"
 harness = false
 
 [[test]]
+name = "binary_inject"
+harness = false
+
+[[test]]
 name = "js_subtest_parser"
 harness = false
 
@@ -140,6 +144,8 @@ wasmtime-wasi = "42.0.1"
 wasmtime-wasi-http = "42.0.1"
 wasmtime-wizer = "42.0.1"
 wit-bindgen-core = "0.43.0"
+wasm-encoder = "0.235.0"
+wasmparser_encoder = { package = "wasmparser", version = "0.235.0" }
 wit-encoder = "0.235.0"
 wit-parser = "0.235.0"
 oxc_parser = "0.115"

--- a/crates/wasm-rquickjs/Cargo.toml
+++ b/crates/wasm-rquickjs/Cargo.toml
@@ -28,6 +28,8 @@ wasmtime = { workspace = true, features = ["async", "component-model"], optional
 wasmtime-wasi = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
 wasmtime-wizer = { workspace = true, features = ["component-model", "wasmtime"], optional = true }
+wasm-encoder = { workspace = true, features = ["wasmparser", "component-model"] }
+wasmparser_encoder = { workspace = true }
 wit-bindgen-core = { workspace = true }
 wit-encoder = { workspace = true }
 wit-parser = { workspace = true }

--- a/crates/wasm-rquickjs/skeleton/src/internal.rs
+++ b/crates/wasm-rquickjs/skeleton/src/internal.rs
@@ -1446,7 +1446,7 @@ impl JsState {
                     dirname: None,
                     include_resolve: true,
                 },
-                crate::JS_EXPORT_MODULE,
+                crate::js_export_module(),
             ),
         );
         for (name, get_module) in crate::JS_ADDITIONAL_MODULES.iter() {

--- a/crates/wasm-rquickjs/skeleton/src/lib.rs
+++ b/crates/wasm-rquickjs/skeleton/src/lib.rs
@@ -6,7 +6,11 @@ mod modules;
 pub mod wrappers;
 
 static JS_EXPORT_MODULE_NAME: &str = "bundle/script_module";
-static JS_EXPORT_MODULE: &str = include_str!("bundle_script_module.js");
+static JS_EXPORT_MODULE_SOURCE: &str = include_str!("bundle_script_module.js");
+
+fn js_export_module() -> &'static str {
+    JS_EXPORT_MODULE_SOURCE
+}
 
 type GetModuleFn = Box<dyn (Fn() -> String) + Send + Sync>;
 

--- a/crates/wasm-rquickjs/src/exports.rs
+++ b/crates/wasm-rquickjs/src/exports.rs
@@ -581,11 +581,99 @@ fn generate_exported_resource_function_impl(
 fn generate_module_defs(js_modules: &[JsModuleSpec]) -> anyhow::Result<TokenStream> {
     if let Some((export_module, additional_modules)) = js_modules.split_first() {
         let export_module_name = LitStr::new(&export_module.name, Span::call_site());
-        let export_module_file_name = LitStr::new(&export_module.file_name(), Span::call_site());
+
+        let export_module_def = match &export_module.mode {
+            EmbeddingMode::BinarySlot => {
+                let slot_file_name = LitStr::new(
+                    &(export_module.name.replace('/', "_") + ".slot"),
+                    Span::call_site(),
+                );
+                quote! {
+                    static JS_EXPORT_MODULE_NAME: &str = #export_module_name;
+                    static JS_EXPORT_MODULE_SLOT: &[u8] = include_bytes!(#slot_file_name);
+
+                    /// Reads JS source from the binary slot using volatile reads to prevent
+                    /// the optimizer from constant-folding the slot contents at compile time.
+                    /// This is essential because the slot is patched post-compilation.
+                    ///
+                    /// The marker layout is: MAGIC(16) + JS_OFFSET(4) + END_MAGIC(16) = 36 bytes.
+                    /// JS_OFFSET is a pointer into linear memory where LEN(4) + JS(LEN) is stored.
+                    /// A JS_OFFSET of 0 means no JS has been injected.
+                    fn read_js_from_slot() -> String {
+                        const MAGIC: &[u8; 16] = b"WASM_RQJS_SLOT\x01\x00";
+                        const END_MAGIC: &[u8; 16] = b"WASM_RQJS_SLTND\x00";
+                        let slot = JS_EXPORT_MODULE_SLOT;
+                        assert!(slot.len() >= 36, "JS injection marker is too small");
+
+                        let slot_ptr = slot.as_ptr();
+                        unsafe {
+                            // Validate magic
+                            let mut magic_buf = [0u8; 16];
+                            for i in 0..16 {
+                                magic_buf[i] = core::ptr::read_volatile(slot_ptr.add(i));
+                            }
+                            assert_eq!(&magic_buf, MAGIC, "invalid JS injection marker header");
+
+                            // Read JS_OFFSET (pointer into linear memory)
+                            let mut offset_bytes = [0u8; 4];
+                            for i in 0..4 {
+                                offset_bytes[i] = core::ptr::read_volatile(slot_ptr.add(16 + i));
+                            }
+                            let js_offset = u32::from_le_bytes(offset_bytes) as usize;
+
+                            assert!(js_offset > 0, "JS injection slot is empty — no JS has been injected. \
+                                Use wasm-rquickjs inject-js to inject JavaScript source into the template.");
+
+                            // Validate end magic
+                            let mut end_magic_buf = [0u8; 16];
+                            for i in 0..16 {
+                                end_magic_buf[i] = core::ptr::read_volatile(slot_ptr.add(20 + i));
+                            }
+                            assert_eq!(&end_magic_buf, END_MAGIC, "JS injection marker footer is corrupted");
+
+                            // Read JS length from linear memory at js_offset
+                            let mem_ptr = js_offset as *const u8;
+                            let mut len_bytes = [0u8; 4];
+                            for i in 0..4 {
+                                len_bytes[i] = core::ptr::read_volatile(mem_ptr.add(i));
+                            }
+                            let len = u32::from_le_bytes(len_bytes) as usize;
+
+                            // Read JS bytes from linear memory at js_offset + 4
+                            let js_ptr = mem_ptr.add(4);
+                            let mut payload = Vec::with_capacity(len);
+                            for i in 0..len {
+                                payload.push(core::ptr::read_volatile(js_ptr.add(i)));
+                            }
+                            String::from_utf8(payload)
+                                .expect("injected JS source is not valid UTF-8")
+                        }
+                    }
+
+                    fn js_export_module() -> &'static str {
+                        static SOURCE: std::sync::LazyLock<String> =
+                            std::sync::LazyLock::new(read_js_from_slot);
+                        SOURCE.as_str()
+                    }
+                }
+            }
+            _ => {
+                let export_module_file_name =
+                    LitStr::new(&export_module.file_name(), Span::call_site());
+                quote! {
+                    static JS_EXPORT_MODULE_NAME: &str = #export_module_name;
+                    static JS_EXPORT_MODULE_SOURCE: &str = include_str!(#export_module_file_name);
+
+                    fn js_export_module() -> &'static str {
+                        JS_EXPORT_MODULE_SOURCE
+                    }
+                }
+            }
+        };
 
         let mut additional_module_pairs = Vec::new();
         for module in additional_modules {
-            match module.mode {
+            match &module.mode {
                 EmbeddingMode::EmbedFile(_) => {
                     let name = LitStr::new(&module.name, Span::call_site());
                     let file_name = LitStr::new(&module.file_name(), Span::call_site());
@@ -597,12 +685,17 @@ fn generate_module_defs(js_modules: &[JsModuleSpec]) -> anyhow::Result<TokenStre
                     additional_module_pairs
                         .push(quote! { (#name, Box::new(|| { crate::bindings::get_script() })) });
                 }
+                EmbeddingMode::BinarySlot => {
+                    return Err(anyhow!(
+                        "BinarySlot mode is only supported for the primary export module, \
+                         not for additional modules"
+                    ));
+                }
             }
         }
 
         Ok(quote! {
-            static JS_EXPORT_MODULE_NAME: &str = #export_module_name;
-            static JS_EXPORT_MODULE: &str = include_str!(#export_module_file_name);
+            #export_module_def
 
             static JS_ADDITIONAL_MODULES: std::sync::LazyLock<Vec<(&str, Box<dyn (Fn() -> String) + Send + Sync>)>> =
               std::sync::LazyLock::new(|| { vec![

--- a/crates/wasm-rquickjs/src/exports.rs
+++ b/crates/wasm-rquickjs/src/exports.rs
@@ -582,6 +582,72 @@ fn generate_module_defs(js_modules: &[JsModuleSpec]) -> anyhow::Result<TokenStre
     if let Some((export_module, additional_modules)) = js_modules.split_first() {
         let export_module_name = LitStr::new(&export_module.name, Span::call_site());
 
+        let any_binary_slot = export_module.mode.is_binary_slot()
+            || additional_modules.iter().any(|m| m.mode.is_binary_slot());
+
+        let slot_helper = if any_binary_slot {
+            quote! {
+                /// Reads JS source from a binary slot marker using volatile reads to prevent
+                /// the optimizer from constant-folding the slot contents at compile time.
+                /// This is essential because the slot is patched post-compilation.
+                ///
+                /// The marker layout is: MAGIC(16) + MODULE_INDEX(4) + JS_OFFSET(4) + END_MAGIC(16) = 40 bytes.
+                /// JS_OFFSET is a pointer into linear memory where LEN(4) + JS(LEN) is stored.
+                /// A JS_OFFSET of 0 means no JS has been injected.
+                fn read_js_from_slot_bytes(slot: &[u8]) -> String {
+                    const MAGIC: &[u8; 16] = b"WASM_RQJS_SLOT\x01\x00";
+                    const END_MAGIC: &[u8; 16] = b"WASM_RQJS_SLTND\x00";
+                    assert!(slot.len() >= 40, "JS injection marker is too small");
+
+                    let slot_ptr = slot.as_ptr();
+                    unsafe {
+                        // Validate magic
+                        let mut magic_buf = [0u8; 16];
+                        for i in 0..16 {
+                            magic_buf[i] = core::ptr::read_volatile(slot_ptr.add(i));
+                        }
+                        assert_eq!(&magic_buf, MAGIC, "invalid JS injection marker header");
+
+                        // Skip MODULE_INDEX (4 bytes at offset 16), read JS_OFFSET (4 bytes at offset 20)
+                        let mut offset_bytes = [0u8; 4];
+                        for i in 0..4 {
+                            offset_bytes[i] = core::ptr::read_volatile(slot_ptr.add(20 + i));
+                        }
+                        let js_offset = u32::from_le_bytes(offset_bytes) as usize;
+
+                        assert!(js_offset > 0, "JS injection slot is empty — no JS has been injected. \
+                            Use wasm-rquickjs inject-js to inject JavaScript source into the template.");
+
+                        // Validate end magic
+                        let mut end_magic_buf = [0u8; 16];
+                        for i in 0..16 {
+                            end_magic_buf[i] = core::ptr::read_volatile(slot_ptr.add(24 + i));
+                        }
+                        assert_eq!(&end_magic_buf, END_MAGIC, "JS injection marker footer is corrupted");
+
+                        // Read JS length from linear memory at js_offset
+                        let mem_ptr = js_offset as *const u8;
+                        let mut len_bytes = [0u8; 4];
+                        for i in 0..4 {
+                            len_bytes[i] = core::ptr::read_volatile(mem_ptr.add(i));
+                        }
+                        let len = u32::from_le_bytes(len_bytes) as usize;
+
+                        // Read JS bytes from linear memory at js_offset + 4
+                        let js_ptr = mem_ptr.add(4);
+                        let mut payload = Vec::with_capacity(len);
+                        for i in 0..len {
+                            payload.push(core::ptr::read_volatile(js_ptr.add(i)));
+                        }
+                        String::from_utf8(payload)
+                            .expect("injected JS source is not valid UTF-8")
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         let export_module_def = match &export_module.mode {
             EmbeddingMode::BinarySlot => {
                 let slot_file_name = LitStr::new(
@@ -592,67 +658,9 @@ fn generate_module_defs(js_modules: &[JsModuleSpec]) -> anyhow::Result<TokenStre
                     static JS_EXPORT_MODULE_NAME: &str = #export_module_name;
                     static JS_EXPORT_MODULE_SLOT: &[u8] = include_bytes!(#slot_file_name);
 
-                    /// Reads JS source from the binary slot using volatile reads to prevent
-                    /// the optimizer from constant-folding the slot contents at compile time.
-                    /// This is essential because the slot is patched post-compilation.
-                    ///
-                    /// The marker layout is: MAGIC(16) + JS_OFFSET(4) + END_MAGIC(16) = 36 bytes.
-                    /// JS_OFFSET is a pointer into linear memory where LEN(4) + JS(LEN) is stored.
-                    /// A JS_OFFSET of 0 means no JS has been injected.
-                    fn read_js_from_slot() -> String {
-                        const MAGIC: &[u8; 16] = b"WASM_RQJS_SLOT\x01\x00";
-                        const END_MAGIC: &[u8; 16] = b"WASM_RQJS_SLTND\x00";
-                        let slot = JS_EXPORT_MODULE_SLOT;
-                        assert!(slot.len() >= 36, "JS injection marker is too small");
-
-                        let slot_ptr = slot.as_ptr();
-                        unsafe {
-                            // Validate magic
-                            let mut magic_buf = [0u8; 16];
-                            for i in 0..16 {
-                                magic_buf[i] = core::ptr::read_volatile(slot_ptr.add(i));
-                            }
-                            assert_eq!(&magic_buf, MAGIC, "invalid JS injection marker header");
-
-                            // Read JS_OFFSET (pointer into linear memory)
-                            let mut offset_bytes = [0u8; 4];
-                            for i in 0..4 {
-                                offset_bytes[i] = core::ptr::read_volatile(slot_ptr.add(16 + i));
-                            }
-                            let js_offset = u32::from_le_bytes(offset_bytes) as usize;
-
-                            assert!(js_offset > 0, "JS injection slot is empty — no JS has been injected. \
-                                Use wasm-rquickjs inject-js to inject JavaScript source into the template.");
-
-                            // Validate end magic
-                            let mut end_magic_buf = [0u8; 16];
-                            for i in 0..16 {
-                                end_magic_buf[i] = core::ptr::read_volatile(slot_ptr.add(20 + i));
-                            }
-                            assert_eq!(&end_magic_buf, END_MAGIC, "JS injection marker footer is corrupted");
-
-                            // Read JS length from linear memory at js_offset
-                            let mem_ptr = js_offset as *const u8;
-                            let mut len_bytes = [0u8; 4];
-                            for i in 0..4 {
-                                len_bytes[i] = core::ptr::read_volatile(mem_ptr.add(i));
-                            }
-                            let len = u32::from_le_bytes(len_bytes) as usize;
-
-                            // Read JS bytes from linear memory at js_offset + 4
-                            let js_ptr = mem_ptr.add(4);
-                            let mut payload = Vec::with_capacity(len);
-                            for i in 0..len {
-                                payload.push(core::ptr::read_volatile(js_ptr.add(i)));
-                            }
-                            String::from_utf8(payload)
-                                .expect("injected JS source is not valid UTF-8")
-                        }
-                    }
-
                     fn js_export_module() -> &'static str {
                         static SOURCE: std::sync::LazyLock<String> =
-                            std::sync::LazyLock::new(read_js_from_slot);
+                            std::sync::LazyLock::new(|| read_js_from_slot_bytes(JS_EXPORT_MODULE_SLOT));
                         SOURCE.as_str()
                     }
                 }
@@ -672,6 +680,7 @@ fn generate_module_defs(js_modules: &[JsModuleSpec]) -> anyhow::Result<TokenStre
         };
 
         let mut additional_module_pairs = Vec::new();
+        let mut additional_slot_defs = Vec::new();
         for module in additional_modules {
             match &module.mode {
                 EmbeddingMode::EmbedFile(_) => {
@@ -686,16 +695,48 @@ fn generate_module_defs(js_modules: &[JsModuleSpec]) -> anyhow::Result<TokenStre
                         .push(quote! { (#name, Box::new(|| { crate::bindings::get_script() })) });
                 }
                 EmbeddingMode::BinarySlot => {
-                    return Err(anyhow!(
-                        "BinarySlot mode is only supported for the primary export module, \
-                         not for additional modules"
-                    ));
+                    let name = LitStr::new(&module.name, Span::call_site());
+                    let slot_file_name = LitStr::new(
+                        &(module.name.replace('/', "_") + ".slot"),
+                        Span::call_site(),
+                    );
+                    let sanitized = module.name.replace(['/', '-'], "_");
+                    let static_name = Ident::new(
+                        &format!("JS_SLOT_{}", sanitized.to_uppercase()),
+                        Span::call_site(),
+                    );
+                    let fn_name =
+                        Ident::new(&format!("read_js_from_slot_{sanitized}"), Span::call_site());
+                    let source_name = Ident::new(
+                        &format!("JS_SLOT_SOURCE_{}", sanitized.to_uppercase()),
+                        Span::call_site(),
+                    );
+
+                    additional_slot_defs.push(quote! {
+                        static #static_name: &[u8] = include_bytes!(#slot_file_name);
+
+                        fn #fn_name() -> String {
+                            read_js_from_slot_bytes(#static_name)
+                        }
+                    });
+
+                    additional_module_pairs.push(quote! {
+                        (#name, Box::new(|| {
+                            static #source_name: std::sync::LazyLock<String> =
+                                std::sync::LazyLock::new(#fn_name);
+                            #source_name.clone()
+                        }))
+                    });
                 }
             }
         }
 
         Ok(quote! {
+            #slot_helper
+
             #export_module_def
+
+            #(#additional_slot_defs)*
 
             static JS_ADDITIONAL_MODULES: std::sync::LazyLock<Vec<(&str, Box<dyn (Fn() -> String) + Send + Sync>)>> =
               std::sync::LazyLock::new(|| { vec![

--- a/crates/wasm-rquickjs/src/inject.rs
+++ b/crates/wasm-rquickjs/src/inject.rs
@@ -8,23 +8,27 @@ pub const SLOT_MAGIC: &[u8; 16] = b"WASM_RQJS_SLOT\x01\x00";
 /// Magic bytes at the end of a marker, used to validate integrity.
 pub const SLOT_END_MAGIC: &[u8; 16] = b"WASM_RQJS_SLTND\x00";
 
-/// Total size of the marker: MAGIC(16) + JS_OFFSET(4) + END_MAGIC(16) = 36 bytes.
-/// The JS_OFFSET field is a pointer into linear memory. Value 0 = no JS injected.
-const MARKER_SIZE: usize = 36;
+/// Total size of the marker: MAGIC(16) + MODULE_INDEX(4) + JS_OFFSET(4) + END_MAGIC(16) = 40 bytes.
+/// MODULE_INDEX identifies which JS module slot this is (0 = primary, 1+ = additional).
+/// JS_OFFSET is a pointer into linear memory. Value 0 = no JS injected.
+const MARKER_SIZE: usize = 40;
 
 const WASM_PAGE_SIZE: u32 = 65536;
 
-/// Creates a 36-byte marker file. Layout:
+/// Creates a 40-byte marker file. Layout:
 ///
 /// ```text
-/// [MAGIC 16 bytes][JS_OFFSET u32 LE = 0][END_MAGIC 16 bytes]
+/// [MAGIC 16 bytes][MODULE_INDEX u32 LE][JS_OFFSET u32 LE = 0][END_MAGIC 16 bytes]
 /// ```
 ///
+/// MODULE_INDEX identifies which JS module this slot is for (0 = primary export module,
+/// 1+ = additional modules in order).
 /// JS_OFFSET=0 indicates no JS has been injected. After injection, JS_OFFSET
 /// points to a memory location containing `[JS_LEN u32 LE][JS bytes]`.
-pub fn create_marker_file() -> Vec<u8> {
+pub fn create_marker_file(module_index: u32) -> Vec<u8> {
     let mut data = Vec::with_capacity(MARKER_SIZE);
     data.extend_from_slice(SLOT_MAGIC);
+    data.extend_from_slice(&module_index.to_le_bytes());
     data.extend_from_slice(&0u32.to_le_bytes()); // js_offset = 0 (not injected)
     data.extend_from_slice(SLOT_END_MAGIC);
     data
@@ -34,22 +38,24 @@ pub fn create_marker_file() -> Vec<u8> {
 /// `EmbeddingMode::BinarySlot`.
 ///
 /// This structurally rewrites the WASM component using `wasmparser` + `wasm-encoder`:
-/// 1. Finds the data segment containing the 36-byte marker and patches the JS_OFFSET
-///    field in-place (no size change, no address shifting).
-/// 2. Grows the core module's memory to fit the new JS data.
-/// 3. Adds a new active data segment at the end of memory containing the JS.
-/// 4. Updates the DataCount section to account for the extra segment.
+/// 1. Finds data segments containing 40-byte markers and records their module indices.
+/// 2. Grows the core module's memory to fit all new JS data segments.
+/// 3. Adds new active data segments at the end of memory containing the JS for each module.
+/// 4. Updates the DataCount section to account for the extra segments.
 ///
-/// There is no capacity limit — the JS can be any size.
+/// There is no capacity limit — each JS source can be any size.
+///
+/// The `js_sources` slice maps by position to marker MODULE_INDEX: the first entry
+/// is injected into the marker with MODULE_INDEX=0, the second into MODULE_INDEX=1, etc.
 pub fn inject_js_into_component(
     input: &Utf8Path,
     output: &Utf8Path,
-    js_source: &str,
+    js_sources: &[&str],
 ) -> anyhow::Result<()> {
     let wasm_bytes = std::fs::read(input.as_std_path())
         .with_context(|| format!("Failed to read input component: {input}"))?;
 
-    let patched = inject_js_into_bytes(&wasm_bytes, js_source)?;
+    let patched = inject_js_into_bytes(&wasm_bytes, js_sources)?;
 
     std::fs::write(output.as_std_path(), &patched)
         .with_context(|| format!("Failed to write output component: {output}"))?;
@@ -57,20 +63,34 @@ pub fn inject_js_into_component(
     Ok(())
 }
 
-/// Injects JavaScript source into WASM component bytes, returning the patched bytes.
-pub fn inject_js_into_bytes(wasm_bytes: &[u8], js_source: &str) -> anyhow::Result<Vec<u8>> {
-    let js_bytes = js_source.as_bytes();
+/// Injects JavaScript sources into WASM component bytes, returning the patched bytes.
+///
+/// Each entry in `js_sources` corresponds to a marker MODULE_INDEX (0, 1, 2, ...).
+pub fn inject_js_into_bytes(wasm_bytes: &[u8], js_sources: &[&str]) -> anyhow::Result<Vec<u8>> {
+    if js_sources.is_empty() {
+        return Err(anyhow!("No JS sources provided for injection"));
+    }
 
-    // Build the JS payload stored in linear memory: LEN(4) + JS bytes
-    let mut js_payload = Vec::with_capacity(4 + js_bytes.len());
-    js_payload.extend_from_slice(&(js_bytes.len() as u32).to_le_bytes());
-    js_payload.extend_from_slice(js_bytes);
+    // Build JS payloads: for each source, LEN(4) + JS bytes
+    let js_payloads: Vec<Vec<u8>> = js_sources
+        .iter()
+        .map(|src| {
+            let js_bytes = src.as_bytes();
+            let mut payload = Vec::with_capacity(4 + js_bytes.len());
+            payload.extend_from_slice(&(js_bytes.len() as u32).to_le_bytes());
+            payload.extend_from_slice(js_bytes);
+            payload
+        })
+        .collect();
+
+    let total_payload_size: usize = js_payloads.iter().map(|p| p.len()).sum();
 
     let mut rewriter = MarkerRewriter {
-        js_payload,
-        marker_found: false,
+        js_payloads,
+        total_payload_size,
+        markers_found: Vec::new(),
         max_data_end: 0,
-        js_mem_offset: 0,
+        js_mem_offsets: Vec::new(),
         original_memory_min: 0,
     };
 
@@ -84,29 +104,49 @@ pub fn inject_js_into_bytes(wasm_bytes: &[u8], js_source: &str) -> anyhow::Resul
             other => anyhow!("Failed to reencode WASM component: {other}"),
         })?;
 
-    if !rewriter.marker_found {
+    if rewriter.markers_found.is_empty() {
         return Err(anyhow!(
-            "No JS injection marker found in the WASM component. \
+            "No JS injection markers found in the WASM component. \
              Was it compiled with EmbeddingMode::BinarySlot?"
         ));
     }
 
+    // Verify all expected markers were found
+    for i in 0..js_sources.len() as u32 {
+        if !rewriter.markers_found.contains(&i) {
+            return Err(anyhow!(
+                "JS injection marker with MODULE_INDEX={i} not found in the WASM component. \
+                 Expected {expected} markers but only found: {found:?}",
+                expected = js_sources.len(),
+                found = rewriter.markers_found,
+            ));
+        }
+    }
+
     let mut output = component.finish();
 
-    // Final binary patch: set JS_OFFSET in the marker to point to the JS data.
-    // We do this as a post-pass because during Reencode we don't know the final
-    // memory offset until after the data section has been fully processed.
-    patch_js_offset_in_output(&mut output, rewriter.js_mem_offset)?;
+    // Final binary patch: set JS_OFFSET in each marker to point to its JS data.
+    patch_js_offsets_in_output(&mut output, &rewriter.js_mem_offsets)?;
 
     Ok(output)
 }
 
-/// Returns true if `data[offset..]` starts with a valid 36-byte marker pattern:
-/// SLOT_MAGIC + any 4 bytes + SLOT_END_MAGIC
+/// Returns true if `data[offset..]` starts with a valid 40-byte marker pattern:
+/// SLOT_MAGIC(16) + MODULE_INDEX(4) + JS_OFFSET(4) + SLOT_END_MAGIC(16)
 fn is_marker_at(data: &[u8], offset: usize) -> bool {
     offset + MARKER_SIZE <= data.len()
         && &data[offset..offset + 16] == SLOT_MAGIC
-        && &data[offset + 20..offset + MARKER_SIZE] == SLOT_END_MAGIC
+        && &data[offset + 24..offset + MARKER_SIZE] == SLOT_END_MAGIC
+}
+
+/// Reads the MODULE_INDEX field from a marker at the given offset.
+fn marker_module_index(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(data[offset + 16..offset + 20].try_into().unwrap())
+}
+
+/// Reads the JS_OFFSET field from a marker at the given offset.
+fn marker_js_offset(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(data[offset + 20..offset + 24].try_into().unwrap())
 }
 
 /// Finds the marker's byte offset within a data segment's raw bytes.
@@ -118,12 +158,16 @@ fn find_marker_in_data(data: &[u8]) -> Option<usize> {
 }
 
 struct MarkerRewriter {
-    js_payload: Vec<u8>,
-    marker_found: bool,
+    /// JS payloads indexed by module index: payloads[0] for MODULE_INDEX=0, etc.
+    js_payloads: Vec<Vec<u8>>,
+    /// Total size of all JS payloads combined (for memory growth calculation).
+    total_payload_size: usize,
+    /// Module indices of markers found during the data section scan.
+    markers_found: Vec<u32>,
     /// Tracks the highest memory address used by existing active data segments.
     max_data_end: u32,
-    /// The memory offset where the JS payload will be placed.
-    js_mem_offset: u32,
+    /// Memory offsets where each JS payload will be placed, indexed by module index.
+    js_mem_offsets: Vec<(u32, u32)>,
     /// The original memory minimum pages (before we grow it).
     original_memory_min: u32,
 }
@@ -141,25 +185,25 @@ impl Reencode for MarkerRewriter {
             memory_index: 0,
             offset_expr,
         } = &datum.kind
+            && let Some(offset) = eval_const_i32(offset_expr)
         {
-            if let Some(offset) = eval_const_i32(offset_expr) {
-                let end = offset.saturating_add(datum.data.len() as u32);
-                self.max_data_end = self.max_data_end.max(end);
-            }
+            let end = offset.saturating_add(datum.data.len() as u32);
+            self.max_data_end = self.max_data_end.max(end);
         }
 
-        // Check if this segment contains the marker
-        if find_marker_in_data(datum.data).is_some() {
-            if self.marker_found {
+        // Check if this segment contains a marker and record its module index
+        if let Some(marker_offset) = find_marker_in_data(datum.data) {
+            let module_index = marker_module_index(datum.data, marker_offset);
+            if self.markers_found.contains(&module_index) {
                 return Err(Error::UserError(anyhow!(
-                    "Found multiple JS injection markers — expected exactly 1"
+                    "Found duplicate JS injection marker with MODULE_INDEX={module_index}"
                 )));
             }
-            self.marker_found = true;
+            self.markers_found.push(module_index);
         }
 
         // Emit segment unchanged — the marker's JS_OFFSET stays 0 for now.
-        // We'll patch JS_OFFSET in the final output via patch_js_offset_in_output.
+        // We'll patch JS_OFFSET in the final output via patch_js_offsets_in_output.
         wasm_encoder::reencode::utils::parse_data(self, data, datum)
     }
 
@@ -171,21 +215,26 @@ impl Reencode for MarkerRewriter {
         // Process all existing segments
         wasm_encoder::reencode::utils::parse_data_section(self, data, section)?;
 
-        if self.marker_found {
-            // Place JS payload page-aligned after all existing data
-            self.js_mem_offset = page_align(self.max_data_end);
+        // For each found marker (sorted by module index), add a data segment
+        let mut current_offset = page_align(self.max_data_end);
+        let mut sorted_indices = self.markers_found.clone();
+        sorted_indices.sort();
 
-            // Add a new active data segment with JS payload at the computed offset
-            let offset = wasm_encoder::ConstExpr::i32_const(self.js_mem_offset as i32);
-            data.active(0, &offset, self.js_payload.iter().copied());
+        for module_index in sorted_indices {
+            if let Some(payload) = self.js_payloads.get(module_index as usize) {
+                let offset_expr = wasm_encoder::ConstExpr::i32_const(current_offset as i32);
+                data.active(0, &offset_expr, payload.iter().copied());
+                self.js_mem_offsets.push((module_index, current_offset));
+                current_offset = page_align(current_offset + payload.len() as u32);
+            }
         }
 
         Ok(())
     }
 
     fn data_count(&mut self, count: u32) -> Result<u32, Error<Self::Error>> {
-        // Add 1 for the extra JS data segment we'll append.
-        Ok(count + 1)
+        // Add 1 for each extra JS data segment we'll append.
+        Ok(count + self.js_payloads.len() as u32)
     }
 
     fn parse_memory_section(
@@ -198,16 +247,15 @@ impl Reencode for MarkerRewriter {
 
             self.original_memory_min = memory.initial as u32;
 
-            // Grow memory to fit the JS payload placed at the end.
-            // We use original_min_pages * PAGE_SIZE as an upper bound for max_data_end
-            // (actual max_data_end computed later, but it can't exceed the original memory).
-            // The JS payload goes at page_align(max_data_end) which is at most
-            // original_min * PAGE_SIZE (already page-aligned).
-            let js_end_upper =
-                self.original_memory_min * WASM_PAGE_SIZE + self.js_payload.len() as u32;
-            let pages_needed = (js_end_upper + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
+            // Grow memory to fit all JS payloads placed at the end.
+            // Upper bound: original memory + total payload size + page alignment padding per payload.
+            let max_padding = self.js_payloads.len() as u32 * WASM_PAGE_SIZE;
+            let js_end_upper = self.original_memory_min * WASM_PAGE_SIZE
+                + self.total_payload_size as u32
+                + max_padding;
+            let pages_needed = js_end_upper.div_ceil(WASM_PAGE_SIZE);
             let new_min = pages_needed.max(memory.initial as u32);
-            let new_max = memory.maximum.map(|m| (m as u64).max(new_min as u64));
+            let new_max = memory.maximum.map(|m| m.max(new_min as u64));
 
             memories.memory(wasm_encoder::MemoryType {
                 minimum: new_min as u64,
@@ -226,10 +274,8 @@ impl ReencodeComponent for MarkerRewriter {}
 /// Evaluate a const expression to an i32 value (handles i32.const only).
 fn eval_const_i32(expr: &wasmparser_encoder::ConstExpr<'_>) -> Option<u32> {
     let mut reader = expr.get_operators_reader();
-    if let Ok(op) = reader.read() {
-        if let wasmparser_encoder::Operator::I32Const { value } = op {
-            return Some(value as u32);
-        }
+    if let Ok(wasmparser_encoder::Operator::I32Const { value }) = reader.read() {
+        return Some(value as u32);
     }
     None
 }
@@ -238,24 +284,37 @@ fn page_align(addr: u32) -> u32 {
     (addr + WASM_PAGE_SIZE - 1) & !(WASM_PAGE_SIZE - 1)
 }
 
-/// Post-pass: find the marker in the output bytes and patch JS_OFFSET from 0
-/// to the actual JS memory offset. This is a 4-byte in-place write.
-fn patch_js_offset_in_output(output: &mut [u8], js_mem_offset: u32) -> anyhow::Result<()> {
-    let mut found = None;
+/// Post-pass: find all markers in the output bytes and patch JS_OFFSET for each.
+/// `offsets` is a list of (module_index, js_mem_offset) pairs.
+fn patch_js_offsets_in_output(output: &mut [u8], offsets: &[(u32, u32)]) -> anyhow::Result<()> {
+    // Collect all marker positions with their module indices
+    let mut marker_positions: Vec<(usize, u32)> = Vec::new();
     for i in 0..output.len().saturating_sub(MARKER_SIZE) {
         if is_marker_at(output, i) {
+            let module_idx = marker_module_index(output, i);
+            let js_off = marker_js_offset(output, i);
             // Only patch markers with JS_OFFSET == 0 (unpatched)
-            let current = u32::from_le_bytes(output[i + 16..i + 20].try_into().unwrap());
-            if current == 0 {
-                if found.is_some() {
-                    return Err(anyhow!("Multiple unpatched markers found in output"));
-                }
-                found = Some(i);
+            if js_off == 0 {
+                marker_positions.push((i, module_idx));
             }
         }
     }
-    let pos = found.ok_or_else(|| anyhow!("Could not find marker in reencoded output"))?;
-    output[pos + 16..pos + 20].copy_from_slice(&js_mem_offset.to_le_bytes());
+
+    for &(module_index, js_mem_offset) in offsets {
+        let pos = marker_positions
+            .iter()
+            .find(|(_, idx)| *idx == module_index)
+            .map(|(pos, _)| *pos)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Could not find unpatched marker with MODULE_INDEX={module_index} \
+                     in reencoded output"
+                )
+            })?;
+        // Patch JS_OFFSET at offset 20 (after MAGIC(16) + MODULE_INDEX(4))
+        output[pos + 20..pos + 24].copy_from_slice(&js_mem_offset.to_le_bytes());
+    }
+
     Ok(())
 }
 
@@ -265,16 +324,21 @@ mod tests {
 
     #[test]
     fn test_create_marker_file() {
-        let marker = create_marker_file();
+        let marker = create_marker_file(0);
         assert_eq!(marker.len(), MARKER_SIZE);
         assert_eq!(&marker[..16], SLOT_MAGIC.as_slice());
-        assert_eq!(u32::from_le_bytes(marker[16..20].try_into().unwrap()), 0);
-        assert_eq!(&marker[20..], SLOT_END_MAGIC.as_slice());
+        assert_eq!(u32::from_le_bytes(marker[16..20].try_into().unwrap()), 0); // module_index
+        assert_eq!(u32::from_le_bytes(marker[20..24].try_into().unwrap()), 0); // js_offset
+        assert_eq!(&marker[24..], SLOT_END_MAGIC.as_slice());
+
+        let marker1 = create_marker_file(1);
+        assert_eq!(u32::from_le_bytes(marker1[16..20].try_into().unwrap()), 1);
+        assert_eq!(u32::from_le_bytes(marker1[20..24].try_into().unwrap()), 0);
     }
 
     #[test]
     fn test_find_marker_in_data() {
-        let marker = create_marker_file();
+        let marker = create_marker_file(0);
         assert_eq!(find_marker_in_data(&marker), Some(0));
 
         // Marker embedded in larger data
@@ -292,12 +356,14 @@ mod tests {
     fn test_inject_no_marker() {
         let component = wasm_encoder::Component::new();
         let bytes = component.finish();
-        let result = inject_js_into_bytes(&bytes, "x");
+        let result = inject_js_into_bytes(&bytes, &["x"]);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("No JS injection marker found"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No JS injection markers found")
+        );
     }
 
     #[test]

--- a/crates/wasm-rquickjs/src/inject.rs
+++ b/crates/wasm-rquickjs/src/inject.rs
@@ -1,0 +1,310 @@
+use anyhow::{Context, anyhow};
+use camino::Utf8Path;
+use wasm_encoder::reencode::{Error, Reencode, ReencodeComponent};
+
+/// Magic bytes identifying a wasm-rquickjs JS injection marker.
+pub const SLOT_MAGIC: &[u8; 16] = b"WASM_RQJS_SLOT\x01\x00";
+
+/// Magic bytes at the end of a marker, used to validate integrity.
+pub const SLOT_END_MAGIC: &[u8; 16] = b"WASM_RQJS_SLTND\x00";
+
+/// Total size of the marker: MAGIC(16) + JS_OFFSET(4) + END_MAGIC(16) = 36 bytes.
+/// The JS_OFFSET field is a pointer into linear memory. Value 0 = no JS injected.
+const MARKER_SIZE: usize = 36;
+
+const WASM_PAGE_SIZE: u32 = 65536;
+
+/// Creates a 36-byte marker file. Layout:
+///
+/// ```text
+/// [MAGIC 16 bytes][JS_OFFSET u32 LE = 0][END_MAGIC 16 bytes]
+/// ```
+///
+/// JS_OFFSET=0 indicates no JS has been injected. After injection, JS_OFFSET
+/// points to a memory location containing `[JS_LEN u32 LE][JS bytes]`.
+pub fn create_marker_file() -> Vec<u8> {
+    let mut data = Vec::with_capacity(MARKER_SIZE);
+    data.extend_from_slice(SLOT_MAGIC);
+    data.extend_from_slice(&0u32.to_le_bytes()); // js_offset = 0 (not injected)
+    data.extend_from_slice(SLOT_END_MAGIC);
+    data
+}
+
+/// Injects JavaScript source code into a compiled WASM component that was built with
+/// `EmbeddingMode::BinarySlot`.
+///
+/// This structurally rewrites the WASM component using `wasmparser` + `wasm-encoder`:
+/// 1. Finds the data segment containing the 36-byte marker and patches the JS_OFFSET
+///    field in-place (no size change, no address shifting).
+/// 2. Grows the core module's memory to fit the new JS data.
+/// 3. Adds a new active data segment at the end of memory containing the JS.
+/// 4. Updates the DataCount section to account for the extra segment.
+///
+/// There is no capacity limit — the JS can be any size.
+pub fn inject_js_into_component(
+    input: &Utf8Path,
+    output: &Utf8Path,
+    js_source: &str,
+) -> anyhow::Result<()> {
+    let wasm_bytes = std::fs::read(input.as_std_path())
+        .with_context(|| format!("Failed to read input component: {input}"))?;
+
+    let patched = inject_js_into_bytes(&wasm_bytes, js_source)?;
+
+    std::fs::write(output.as_std_path(), &patched)
+        .with_context(|| format!("Failed to write output component: {output}"))?;
+
+    Ok(())
+}
+
+/// Injects JavaScript source into WASM component bytes, returning the patched bytes.
+pub fn inject_js_into_bytes(wasm_bytes: &[u8], js_source: &str) -> anyhow::Result<Vec<u8>> {
+    let js_bytes = js_source.as_bytes();
+
+    // Build the JS payload stored in linear memory: LEN(4) + JS bytes
+    let mut js_payload = Vec::with_capacity(4 + js_bytes.len());
+    js_payload.extend_from_slice(&(js_bytes.len() as u32).to_le_bytes());
+    js_payload.extend_from_slice(js_bytes);
+
+    let mut rewriter = MarkerRewriter {
+        js_payload,
+        marker_found: false,
+        max_data_end: 0,
+        js_mem_offset: 0,
+        original_memory_min: 0,
+    };
+
+    let parser = wasmparser_encoder::Parser::new(0);
+    let mut component = wasm_encoder::Component::new();
+    rewriter
+        .parse_component(&mut component, parser, wasm_bytes)
+        .map_err(|e| match e {
+            Error::UserError(e) => e,
+            Error::ParseError(e) => anyhow!("Failed to parse WASM component: {e}"),
+            other => anyhow!("Failed to reencode WASM component: {other}"),
+        })?;
+
+    if !rewriter.marker_found {
+        return Err(anyhow!(
+            "No JS injection marker found in the WASM component. \
+             Was it compiled with EmbeddingMode::BinarySlot?"
+        ));
+    }
+
+    let mut output = component.finish();
+
+    // Final binary patch: set JS_OFFSET in the marker to point to the JS data.
+    // We do this as a post-pass because during Reencode we don't know the final
+    // memory offset until after the data section has been fully processed.
+    patch_js_offset_in_output(&mut output, rewriter.js_mem_offset)?;
+
+    Ok(output)
+}
+
+/// Returns true if `data[offset..]` starts with a valid 36-byte marker pattern:
+/// SLOT_MAGIC + any 4 bytes + SLOT_END_MAGIC
+fn is_marker_at(data: &[u8], offset: usize) -> bool {
+    offset + MARKER_SIZE <= data.len()
+        && &data[offset..offset + 16] == SLOT_MAGIC
+        && &data[offset + 20..offset + MARKER_SIZE] == SLOT_END_MAGIC
+}
+
+/// Finds the marker's byte offset within a data segment's raw bytes.
+fn find_marker_in_data(data: &[u8]) -> Option<usize> {
+    if data.len() < MARKER_SIZE {
+        return None;
+    }
+    (0..=data.len() - MARKER_SIZE).find(|&i| is_marker_at(data, i))
+}
+
+struct MarkerRewriter {
+    js_payload: Vec<u8>,
+    marker_found: bool,
+    /// Tracks the highest memory address used by existing active data segments.
+    max_data_end: u32,
+    /// The memory offset where the JS payload will be placed.
+    js_mem_offset: u32,
+    /// The original memory minimum pages (before we grow it).
+    original_memory_min: u32,
+}
+
+impl Reencode for MarkerRewriter {
+    type Error = anyhow::Error;
+
+    fn parse_data(
+        &mut self,
+        data: &mut wasm_encoder::DataSection,
+        datum: wasmparser_encoder::Data<'_>,
+    ) -> Result<(), Error<Self::Error>> {
+        // Track the highest memory address used by active data segments on memory 0
+        if let wasmparser_encoder::DataKind::Active {
+            memory_index: 0,
+            offset_expr,
+        } = &datum.kind
+        {
+            if let Some(offset) = eval_const_i32(offset_expr) {
+                let end = offset.saturating_add(datum.data.len() as u32);
+                self.max_data_end = self.max_data_end.max(end);
+            }
+        }
+
+        // Check if this segment contains the marker
+        if find_marker_in_data(datum.data).is_some() {
+            if self.marker_found {
+                return Err(Error::UserError(anyhow!(
+                    "Found multiple JS injection markers — expected exactly 1"
+                )));
+            }
+            self.marker_found = true;
+        }
+
+        // Emit segment unchanged — the marker's JS_OFFSET stays 0 for now.
+        // We'll patch JS_OFFSET in the final output via patch_js_offset_in_output.
+        wasm_encoder::reencode::utils::parse_data(self, data, datum)
+    }
+
+    fn parse_data_section(
+        &mut self,
+        data: &mut wasm_encoder::DataSection,
+        section: wasmparser_encoder::DataSectionReader<'_>,
+    ) -> Result<(), Error<Self::Error>> {
+        // Process all existing segments
+        wasm_encoder::reencode::utils::parse_data_section(self, data, section)?;
+
+        if self.marker_found {
+            // Place JS payload page-aligned after all existing data
+            self.js_mem_offset = page_align(self.max_data_end);
+
+            // Add a new active data segment with JS payload at the computed offset
+            let offset = wasm_encoder::ConstExpr::i32_const(self.js_mem_offset as i32);
+            data.active(0, &offset, self.js_payload.iter().copied());
+        }
+
+        Ok(())
+    }
+
+    fn data_count(&mut self, count: u32) -> Result<u32, Error<Self::Error>> {
+        // Add 1 for the extra JS data segment we'll append.
+        Ok(count + 1)
+    }
+
+    fn parse_memory_section(
+        &mut self,
+        memories: &mut wasm_encoder::MemorySection,
+        section: wasmparser_encoder::MemorySectionReader<'_>,
+    ) -> Result<(), Error<Self::Error>> {
+        for memory in section {
+            let memory = memory.map_err(Error::ParseError)?;
+
+            self.original_memory_min = memory.initial as u32;
+
+            // Grow memory to fit the JS payload placed at the end.
+            // We use original_min_pages * PAGE_SIZE as an upper bound for max_data_end
+            // (actual max_data_end computed later, but it can't exceed the original memory).
+            // The JS payload goes at page_align(max_data_end) which is at most
+            // original_min * PAGE_SIZE (already page-aligned).
+            let js_end_upper =
+                self.original_memory_min * WASM_PAGE_SIZE + self.js_payload.len() as u32;
+            let pages_needed = (js_end_upper + WASM_PAGE_SIZE - 1) / WASM_PAGE_SIZE;
+            let new_min = pages_needed.max(memory.initial as u32);
+            let new_max = memory.maximum.map(|m| (m as u64).max(new_min as u64));
+
+            memories.memory(wasm_encoder::MemoryType {
+                minimum: new_min as u64,
+                maximum: new_max,
+                memory64: memory.memory64,
+                shared: memory.shared,
+                page_size_log2: memory.page_size_log2,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl ReencodeComponent for MarkerRewriter {}
+
+/// Evaluate a const expression to an i32 value (handles i32.const only).
+fn eval_const_i32(expr: &wasmparser_encoder::ConstExpr<'_>) -> Option<u32> {
+    let mut reader = expr.get_operators_reader();
+    if let Ok(op) = reader.read() {
+        if let wasmparser_encoder::Operator::I32Const { value } = op {
+            return Some(value as u32);
+        }
+    }
+    None
+}
+
+fn page_align(addr: u32) -> u32 {
+    (addr + WASM_PAGE_SIZE - 1) & !(WASM_PAGE_SIZE - 1)
+}
+
+/// Post-pass: find the marker in the output bytes and patch JS_OFFSET from 0
+/// to the actual JS memory offset. This is a 4-byte in-place write.
+fn patch_js_offset_in_output(output: &mut [u8], js_mem_offset: u32) -> anyhow::Result<()> {
+    let mut found = None;
+    for i in 0..output.len().saturating_sub(MARKER_SIZE) {
+        if is_marker_at(output, i) {
+            // Only patch markers with JS_OFFSET == 0 (unpatched)
+            let current = u32::from_le_bytes(output[i + 16..i + 20].try_into().unwrap());
+            if current == 0 {
+                if found.is_some() {
+                    return Err(anyhow!("Multiple unpatched markers found in output"));
+                }
+                found = Some(i);
+            }
+        }
+    }
+    let pos = found.ok_or_else(|| anyhow!("Could not find marker in reencoded output"))?;
+    output[pos + 16..pos + 20].copy_from_slice(&js_mem_offset.to_le_bytes());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_marker_file() {
+        let marker = create_marker_file();
+        assert_eq!(marker.len(), MARKER_SIZE);
+        assert_eq!(&marker[..16], SLOT_MAGIC.as_slice());
+        assert_eq!(u32::from_le_bytes(marker[16..20].try_into().unwrap()), 0);
+        assert_eq!(&marker[20..], SLOT_END_MAGIC.as_slice());
+    }
+
+    #[test]
+    fn test_find_marker_in_data() {
+        let marker = create_marker_file();
+        assert_eq!(find_marker_in_data(&marker), Some(0));
+
+        // Marker embedded in larger data
+        let mut data = vec![0xAA; 100];
+        data.extend_from_slice(&marker);
+        data.extend_from_slice(&[0xBB; 50]);
+        assert_eq!(find_marker_in_data(&data), Some(100));
+
+        // No marker
+        assert_eq!(find_marker_in_data(&[0u8; 100]), None);
+        assert_eq!(find_marker_in_data(&[0u8; 10]), None);
+    }
+
+    #[test]
+    fn test_inject_no_marker() {
+        let component = wasm_encoder::Component::new();
+        let bytes = component.finish();
+        let result = inject_js_into_bytes(&bytes, "x");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No JS injection marker found"));
+    }
+
+    #[test]
+    fn test_page_align() {
+        assert_eq!(page_align(0), 0);
+        assert_eq!(page_align(1), WASM_PAGE_SIZE);
+        assert_eq!(page_align(WASM_PAGE_SIZE), WASM_PAGE_SIZE);
+        assert_eq!(page_align(WASM_PAGE_SIZE + 1), 2 * WASM_PAGE_SIZE);
+    }
+}

--- a/crates/wasm-rquickjs/src/lib.rs
+++ b/crates/wasm-rquickjs/src/lib.rs
@@ -19,6 +19,7 @@ use wit_parser::{
 mod conversions;
 mod exports;
 mod imports;
+mod inject;
 mod javascript;
 #[cfg(feature = "optimize")]
 mod optimize;
@@ -30,6 +31,7 @@ mod wit;
 
 #[cfg(feature = "optimize")]
 pub use optimize::optimize_component;
+pub use inject::{inject_js_into_component, SLOT_END_MAGIC, SLOT_MAGIC};
 
 /// Write `contents` to `path` only if the file doesn't exist or its current content differs.
 /// This preserves file timestamps when content hasn't changed, avoiding unnecessary recompilation.
@@ -70,6 +72,11 @@ pub enum EmbeddingMode {
     EmbedFile(Utf8PathBuf),
     /// The JS module is going to be fetched run-time through an imported WIT interface
     Composition,
+    /// Embeds a small marker in the compiled WASM component.
+    /// After compilation, JS source can be injected into the marker via `inject_js_into_component`
+    /// without recompiling the Rust crate. The injected JS can be any size — the WASM component
+    /// is structurally rewritten to accommodate the new data.
+    BinarySlot,
 }
 
 /// Specifies a JS module to be evaluated in the generated component.
@@ -383,14 +390,24 @@ fn copy_dir_if_changed(src: &std::path::Path, dst: &std::path::Path) -> std::io:
     Ok(())
 }
 
-/// Copies the JS module files to `<output>/src/<name>.js`.
+/// Copies the JS module files to `<output>/src/<name>.js` or generates slot files.
 fn copy_js_modules(js_modules: &[JsModuleSpec], output: &Utf8Path) -> anyhow::Result<()> {
     for module in js_modules {
-        if let EmbeddingMode::EmbedFile(source) = &module.mode {
-            let filename = module.file_name();
-            let js_dest = output.join("src").join(filename);
-            copy_if_changed(source, js_dest)
-                .context(format!("Failed to copy JavaScript module {}", module.name))?;
+        match &module.mode {
+            EmbeddingMode::EmbedFile(source) => {
+                let filename = module.file_name();
+                let js_dest = output.join("src").join(filename);
+                copy_if_changed(source, js_dest)
+                    .context(format!("Failed to copy JavaScript module {}", module.name))?;
+            }
+            EmbeddingMode::BinarySlot => {
+                let slot_filename = module.name.replace('/', "_") + ".slot";
+                let slot_dest = output.join("src").join(slot_filename);
+                let slot_data = inject::create_marker_file();
+                write_if_changed(slot_dest, slot_data)
+                    .context(format!("Failed to create marker file for module {}", module.name))?;
+            }
+            EmbeddingMode::Composition => {}
         }
     }
     Ok(())

--- a/crates/wasm-rquickjs/src/lib.rs
+++ b/crates/wasm-rquickjs/src/lib.rs
@@ -29,9 +29,9 @@ mod types;
 mod typescript;
 mod wit;
 
+pub use inject::{SLOT_END_MAGIC, SLOT_MAGIC, create_marker_file, inject_js_into_component};
 #[cfg(feature = "optimize")]
 pub use optimize::optimize_component;
-pub use inject::{inject_js_into_component, SLOT_END_MAGIC, SLOT_MAGIC};
 
 /// Write `contents` to `path` only if the file doesn't exist or its current content differs.
 /// This preserves file timestamps when content hasn't changed, avoiding unnecessary recompilation.
@@ -77,6 +77,12 @@ pub enum EmbeddingMode {
     /// without recompiling the Rust crate. The injected JS can be any size — the WASM component
     /// is structurally rewritten to accommodate the new data.
     BinarySlot,
+}
+
+impl EmbeddingMode {
+    pub fn is_binary_slot(&self) -> bool {
+        matches!(self, EmbeddingMode::BinarySlot)
+    }
 }
 
 /// Specifies a JS module to be evaluated in the generated component.
@@ -392,6 +398,7 @@ fn copy_dir_if_changed(src: &std::path::Path, dst: &std::path::Path) -> std::io:
 
 /// Copies the JS module files to `<output>/src/<name>.js` or generates slot files.
 fn copy_js_modules(js_modules: &[JsModuleSpec], output: &Utf8Path) -> anyhow::Result<()> {
+    let mut slot_index: u32 = 0;
     for module in js_modules {
         match &module.mode {
             EmbeddingMode::EmbedFile(source) => {
@@ -403,9 +410,12 @@ fn copy_js_modules(js_modules: &[JsModuleSpec], output: &Utf8Path) -> anyhow::Re
             EmbeddingMode::BinarySlot => {
                 let slot_filename = module.name.replace('/', "_") + ".slot";
                 let slot_dest = output.join("src").join(slot_filename);
-                let slot_data = inject::create_marker_file();
-                write_if_changed(slot_dest, slot_data)
-                    .context(format!("Failed to create marker file for module {}", module.name))?;
+                let slot_data = inject::create_marker_file(slot_index);
+                write_if_changed(slot_dest, slot_data).context(format!(
+                    "Failed to create marker file for module {}",
+                    module.name
+                ))?;
+                slot_index += 1;
             }
             EmbeddingMode::Composition => {}
         }

--- a/crates/wasm-rquickjs/src/optimize.rs
+++ b/crates/wasm-rquickjs/src/optimize.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use camino::Utf8Path;
 use wasmtime::component::types::ComponentItem;
-use wasmtime::component::{Component, Linker, LinkerInstance};
+use wasmtime::component::{Component, Linker, LinkerInstance, ResourceType};
 use wasmtime::{Config, Engine, Store, StoreContextMut};
 use wasmtime_wasi::p2::bindings;
 use wasmtime_wizer::Wizer;
@@ -175,8 +175,66 @@ pub async fn optimize_component(
 }
 
 /// Prefixes for imports that are handled by real implementations
-/// (WASI, HTTP, logging) and should not be stubbed with traps.
-const KNOWN_IMPORT_PREFIXES: &[&str] = &["wasi:"];
+/// and should not be stubbed with traps. Only list the specific WASI
+/// namespaces that wasmtime-wasi, wasmtime-wasi-http, and the logging
+/// stub actually register — not all `wasi:*` (e.g. `wasi:blobstore`
+/// and `wasi:keyvalue` are NOT provided and must be stubbed).
+const KNOWN_IMPORT_PREFIXES: &[&str] = &[
+    "wasi:io/",
+    "wasi:clocks/",
+    "wasi:filesystem/",
+    "wasi:random/",
+    "wasi:cli/",
+    "wasi:sockets/",
+    "wasi:http/",
+    "wasi:logging/",
+];
+
+/// Collect resource types that appear in WASI imports.
+///
+/// Non-WASI interfaces (like `golem:agent/host`) can re-export WASI resource
+/// types (e.g. `pollable`). When stubbing those interfaces we must skip
+/// resources already registered by wasmtime-wasi, otherwise the linker will
+/// reject the type identity mismatch.
+///
+/// The component type system uses the same `ResourceType` value for the same
+/// underlying WIT resource definition regardless of which interface references
+/// it, so we can compare them with `==`.
+fn collect_wasi_resource_types(component: &Component, engine: &Engine) -> Vec<ResourceType> {
+    let mut known = Vec::new();
+    let component_type = component.component_type();
+
+    for (import_name, item) in component_type.imports(engine) {
+        if KNOWN_IMPORT_PREFIXES
+            .iter()
+            .any(|prefix| import_name.starts_with(prefix))
+        {
+            collect_resource_types_from_item(&item, engine, &mut known);
+        }
+    }
+
+    known
+}
+
+fn collect_resource_types_from_item(
+    item: &ComponentItem,
+    engine: &Engine,
+    known: &mut Vec<ResourceType>,
+) {
+    match item {
+        ComponentItem::ComponentInstance(inst) => {
+            for (_name, export_item) in inst.exports(engine) {
+                collect_resource_types_from_item(&export_item, engine, known);
+            }
+        }
+        ComponentItem::Resource(res_ty) => {
+            if !known.contains(res_ty) {
+                known.push(*res_ty);
+            }
+        }
+        _ => {}
+    }
+}
 
 /// Stub unknown component imports with trapping functions.
 ///
@@ -185,12 +243,18 @@ const KNOWN_IMPORT_PREFIXES: &[&str] = &["wasi:"];
 /// This preserves wasmtime's semver version aliasing for WASI interfaces
 /// while ensuring unknown imports (e.g. `golem:api/host`) don't cause
 /// instantiation failures.
+///
+/// Resource types that were already registered by wasmtime-wasi are skipped
+/// to avoid "mismatched resource types" errors when non-WASI interfaces
+/// re-export WASI resources (e.g. `pollable`).
 fn stub_unknown_imports(
     linker: &mut Linker<WizerHost>,
     component: &Component,
 ) -> wasmtime::Result<()> {
     let engine = linker.engine().clone();
     let component_type = component.component_type();
+
+    let wasi_resources = collect_wasi_resource_types(component, &engine);
 
     for (import_name, item) in component_type.imports(&engine) {
         if KNOWN_IMPORT_PREFIXES
@@ -200,7 +264,13 @@ fn stub_unknown_imports(
             continue;
         }
 
-        stub_component_item(&mut linker.root(), import_name, &item, &engine)?;
+        stub_component_item(
+            &mut linker.root(),
+            import_name,
+            &item,
+            &engine,
+            &wasi_resources,
+        )?;
     }
 
     Ok(())
@@ -211,12 +281,19 @@ fn stub_component_item(
     name: &str,
     item: &ComponentItem,
     engine: &Engine,
+    wasi_resources: &[ResourceType],
 ) -> wasmtime::Result<()> {
     match item {
         ComponentItem::ComponentInstance(inst) => {
             let mut nested = linker_instance.instance(name)?;
             for (export_name, export_item) in inst.exports(engine) {
-                stub_component_item(&mut nested, export_name, &export_item, engine)?;
+                stub_component_item(
+                    &mut nested,
+                    export_name,
+                    &export_item,
+                    engine,
+                    wasi_resources,
+                )?;
             }
         }
         ComponentItem::ComponentFunc(_) => {
@@ -228,9 +305,14 @@ fn stub_component_item(
                 )))
             })?;
         }
-        ComponentItem::Resource(_) => {
-            let ty = wasmtime::component::ResourceType::host::<()>();
-            linker_instance.resource(name, ty, |_, _| Ok(()))?;
+        ComponentItem::Resource(res_ty) => {
+            if wasi_resources.contains(res_ty) {
+                // This resource type is already registered by wasmtime-wasi
+                // (e.g. pollable). Skip it to avoid type identity mismatches.
+            } else {
+                let ty = ResourceType::host::<()>();
+                linker_instance.resource(name, ty, |_, _| Ok(()))?;
+            }
         }
         _ => {}
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,9 +75,11 @@ pub enum Command {
         #[arg(long)]
         output: Utf8PathBuf,
 
-        /// Path to the JavaScript source file to inject
-        #[arg(long)]
-        js: Utf8PathBuf,
+        /// Path(s) to JavaScript source file(s) to inject. Order must match the
+        /// BinarySlot module order used during crate generation (primary module first,
+        /// then additional modules in order).
+        #[arg(long, required = true)]
+        js: Vec<Utf8PathBuf>,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,6 +65,20 @@ pub enum Command {
         #[arg(long, default_value = "wizer-initialize")]
         init_func: String,
     },
+    /// Inject JavaScript source into a compiled WASM component template
+    InjectJs {
+        /// Path to the template WASM component (compiled with --js-modules name=@slot)
+        #[arg(long)]
+        input: Utf8PathBuf,
+
+        /// Path for the output WASM component with injected JS
+        #[arg(long)]
+        output: Utf8PathBuf,
+
+        /// Path to the JavaScript source file to inject
+        #[arg(long)]
+        js: Utf8PathBuf,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -93,6 +107,7 @@ impl FromStr for JsModuleSpecArg {
         let name = parts[0].to_string();
         let mode = match parts[1] {
             "@composition" => EmbeddingMode::Composition,
+            "@slot" => EmbeddingMode::BinarySlot,
             path => EmbeddingMode::EmbedFile(Utf8Path::new(path).to_path_buf()),
         };
         Ok(JsModuleSpecArg { name, mode })

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,12 +50,22 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        Command::InjectJs { input, output, js } => {
-            let js_source = std::fs::read_to_string(js.as_std_path()).unwrap_or_else(|err| {
-                eprintln!("Error reading JS file: {err:#}");
-                std::process::exit(1);
-            });
-            if let Err(err) = wasm_rquickjs::inject_js_into_component(input, output, &js_source) {
+        Command::InjectJs {
+            input,
+            output,
+            js: js_paths,
+        } => {
+            let js_sources: Vec<String> = js_paths
+                .iter()
+                .map(|path| {
+                    std::fs::read_to_string(path.as_std_path()).unwrap_or_else(|err| {
+                        eprintln!("Error reading JS file {path}: {err:#}");
+                        std::process::exit(1);
+                    })
+                })
+                .collect();
+            let js_refs: Vec<&str> = js_sources.iter().map(|s| s.as_str()).collect();
+            if let Err(err) = wasm_rquickjs::inject_js_into_component(input, output, &js_refs) {
                 eprintln!("Error injecting JS: {err:#}");
                 std::process::exit(1);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,5 +50,15 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        Command::InjectJs { input, output, js } => {
+            let js_source = std::fs::read_to_string(js.as_std_path()).unwrap_or_else(|err| {
+                eprintln!("Error reading JS file: {err:#}");
+                std::process::exit(1);
+            });
+            if let Err(err) = wasm_rquickjs::inject_js_into_component(input, output, &js_source) {
+                eprintln!("Error injecting JS: {err:#}");
+                std::process::exit(1);
+            }
+        }
     };
 }

--- a/tests/binary_inject.rs
+++ b/tests/binary_inject.rs
@@ -7,7 +7,9 @@ use camino::{Utf8Path, Utf8PathBuf};
 use common::TestInstance;
 use heck::ToSnakeCase;
 use std::process::Command;
-use wasm_rquickjs::{EmbeddingMode, JsModuleSpec, generate_wrapper_crate, inject_js_into_component};
+use wasm_rquickjs::{
+    EmbeddingMode, JsModuleSpec, generate_wrapper_crate, inject_js_into_component,
+};
 use wasmtime::component::Val;
 
 /// Generates a wrapper crate using BinarySlot mode, compiles it, injects JS,
@@ -65,7 +67,7 @@ impl BinarySlotTestBuilder {
             "tmp/{}-binary-inject/{}-injected.wasm",
             self.example_name, self.example_name
         ));
-        inject_js_into_component(&self.wasm_path, &injected_path, js_source)?;
+        inject_js_into_component(&self.wasm_path, &injected_path, &[js_source])?;
         Ok(injected_path)
     }
 
@@ -98,8 +100,7 @@ async fn main() {
 async fn test_inject_and_run() {
     eprintln!("\n--- test_inject_and_run ---");
 
-    let builder = BinarySlotTestBuilder::new("example1")
-        .expect("Failed to build template");
+    let builder = BinarySlotTestBuilder::new("example1").expect("Failed to build template");
 
     let js_source = r#"
 function helloImpl(name) {
@@ -141,8 +142,7 @@ export const asyncHello = asyncHelloImpl;
 async fn test_inject_optimize_and_run() {
     eprintln!("\n--- test_inject_optimize_and_run ---");
 
-    let builder = BinarySlotTestBuilder::new("example1")
-        .expect("Failed to build template");
+    let builder = BinarySlotTestBuilder::new("example1").expect("Failed to build template");
 
     let js_source = r#"
 function helloImpl(name) {
@@ -187,8 +187,7 @@ export const asyncHello = asyncHelloImpl;
 async fn test_reinject_different_js() {
     eprintln!("\n--- test_reinject_different_js ---");
 
-    let builder = BinarySlotTestBuilder::new("example1")
-        .expect("Failed to build template");
+    let builder = BinarySlotTestBuilder::new("example1").expect("Failed to build template");
 
     // First injection
     let js1 = r#"
@@ -209,7 +208,7 @@ export const something = 2;
 export function hello(name) { return `Second: ${name}`; }
 export async function asyncHello(name) { return `Second async: ${name}`; }
 "#;
-    inject_js_into_component(&builder.wasm_path, &injected_path2, js2)
+    inject_js_into_component(&builder.wasm_path, &injected_path2, &[js2])
         .expect("Second injection failed");
 
     // Run first

--- a/tests/binary_inject.rs
+++ b/tests/binary_inject.rs
@@ -1,0 +1,244 @@
+/// Integration tests for the BinarySlot injection mode.
+///
+/// Usage: cargo test --test binary_inject -- --nocapture
+mod common;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use common::TestInstance;
+use heck::ToSnakeCase;
+use std::process::Command;
+use wasm_rquickjs::{EmbeddingMode, JsModuleSpec, generate_wrapper_crate, inject_js_into_component};
+use wasmtime::component::Val;
+
+/// Generates a wrapper crate using BinarySlot mode, compiles it, injects JS,
+/// and optionally optimizes with Wizer.
+struct BinarySlotTestBuilder {
+    example_name: String,
+    #[allow(dead_code)]
+    wrapper_crate_root: Utf8PathBuf,
+    wasm_path: Utf8PathBuf,
+}
+
+impl BinarySlotTestBuilder {
+    fn new(example_name: &str) -> anyhow::Result<Self> {
+        let example_path = Utf8Path::new("examples/runtime").join(example_name);
+        let wrapper_crate_root = Utf8Path::new("tmp")
+            .join(format!("{example_name}-binary-inject"))
+            .join("normal");
+        let shared_target = Utf8Path::new("..").join("..").join("inject-target");
+
+        eprintln!("Generating wrapper crate with BinarySlot for '{example_name}'...");
+        generate_wrapper_crate(
+            &example_path.join("wit"),
+            &[JsModuleSpec {
+                name: example_name.to_string(),
+                mode: EmbeddingMode::BinarySlot,
+            }],
+            &wrapper_crate_root,
+            None,
+        )?;
+
+        eprintln!("Compiling wrapper crate...");
+        let status = Command::new("cargo-component")
+            .arg("build")
+            .arg("--target-dir")
+            .arg(&shared_target)
+            .current_dir(&wrapper_crate_root)
+            .status()?;
+        assert!(status.success(), "cargo-component build failed");
+
+        let wasm_path = Utf8Path::new("tmp")
+            .join("inject-target")
+            .join("wasm32-wasip1")
+            .join("debug")
+            .join(format!("{}.wasm", example_name.to_snake_case()));
+
+        Ok(Self {
+            example_name: example_name.to_string(),
+            wrapper_crate_root,
+            wasm_path,
+        })
+    }
+
+    fn inject(&self, js_source: &str) -> anyhow::Result<Utf8PathBuf> {
+        let injected_path = Utf8PathBuf::from(format!(
+            "tmp/{}-binary-inject/{}-injected.wasm",
+            self.example_name, self.example_name
+        ));
+        inject_js_into_component(&self.wasm_path, &injected_path, js_source)?;
+        Ok(injected_path)
+    }
+
+    async fn inject_and_optimize(&self, js_source: &str) -> anyhow::Result<Utf8PathBuf> {
+        let injected_path = self.inject(js_source)?;
+        let optimized_path = Utf8PathBuf::from(format!(
+            "tmp/{}-binary-inject/{}-optimized.wasm",
+            self.example_name, self.example_name
+        ));
+        wasm_rquickjs::optimize_component(&injected_path, &optimized_path, "wizer-initialize")
+            .await?;
+        Ok(optimized_path)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Test 1: inject JS and run without Wizer
+    test_inject_and_run().await;
+
+    // Test 2: inject JS, optimize with Wizer, then run
+    test_inject_optimize_and_run().await;
+
+    // Test 3: re-inject different JS into the same template
+    test_reinject_different_js().await;
+
+    eprintln!("\n=== All binary_inject tests passed ===");
+}
+
+async fn test_inject_and_run() {
+    eprintln!("\n--- test_inject_and_run ---");
+
+    let builder = BinarySlotTestBuilder::new("example1")
+        .expect("Failed to build template");
+
+    let js_source = r#"
+function helloImpl(name) {
+    return `Hello from injected JS, ${name}!`;
+}
+
+async function asyncHelloImpl(name) {
+    return `Async hello from injected JS, ${name}!`;
+}
+
+export const something = 42;
+export const hello = helloImpl;
+export const asyncHello = asyncHelloImpl;
+"#;
+
+    let injected_path = builder.inject(js_source).expect("Failed to inject JS");
+
+    let mut test_instance = TestInstance::new(&injected_path)
+        .await
+        .expect("Failed to create test instance");
+
+    let (result, _stdout) = test_instance
+        .invoke_and_capture_output(None, "hello", &[Val::String("World".into())])
+        .await;
+
+    let result = result.expect("Function call failed");
+    match result {
+        Some(Val::String(s)) => {
+            assert!(
+                s.contains("injected JS"),
+                "Expected injected JS output, got: {s}"
+            );
+            eprintln!("  ✓ hello returned: {s}");
+        }
+        other => panic!("Unexpected result: {other:?}"),
+    }
+}
+
+async fn test_inject_optimize_and_run() {
+    eprintln!("\n--- test_inject_optimize_and_run ---");
+
+    let builder = BinarySlotTestBuilder::new("example1")
+        .expect("Failed to build template");
+
+    let js_source = r#"
+function helloImpl(name) {
+    return `Hello from optimized injected JS, ${name}!`;
+}
+
+async function asyncHelloImpl(name) {
+    return `Async hello from optimized injected JS, ${name}!`;
+}
+
+export const something = 99;
+export const hello = helloImpl;
+export const asyncHello = asyncHelloImpl;
+"#;
+
+    let optimized_path = builder
+        .inject_and_optimize(js_source)
+        .await
+        .expect("Failed to inject + optimize");
+
+    let mut test_instance = TestInstance::new(&optimized_path)
+        .await
+        .expect("Failed to create test instance");
+
+    let (result, _stdout) = test_instance
+        .invoke_and_capture_output(None, "hello", &[Val::String("World".into())])
+        .await;
+
+    let result = result.expect("Function call failed");
+    match result {
+        Some(Val::String(s)) => {
+            assert!(
+                s.contains("optimized injected JS"),
+                "Expected optimized injected output, got: {s}"
+            );
+            eprintln!("  ✓ hello returned: {s}");
+        }
+        other => panic!("Unexpected result: {other:?}"),
+    }
+}
+
+async fn test_reinject_different_js() {
+    eprintln!("\n--- test_reinject_different_js ---");
+
+    let builder = BinarySlotTestBuilder::new("example1")
+        .expect("Failed to build template");
+
+    // First injection
+    let js1 = r#"
+export const something = 1;
+export function hello(name) { return `First: ${name}`; }
+export async function asyncHello(name) { return `First async: ${name}`; }
+"#;
+
+    let path1 = builder.inject(js1).expect("First injection failed");
+
+    // Second injection from the same template
+    let injected_path2 = Utf8PathBuf::from(format!(
+        "tmp/{}-binary-inject/{}-injected2.wasm",
+        builder.example_name, builder.example_name
+    ));
+    let js2 = r#"
+export const something = 2;
+export function hello(name) { return `Second: ${name}`; }
+export async function asyncHello(name) { return `Second async: ${name}`; }
+"#;
+    inject_js_into_component(&builder.wasm_path, &injected_path2, js2)
+        .expect("Second injection failed");
+
+    // Run first
+    let mut inst1 = TestInstance::new(&path1)
+        .await
+        .expect("Failed to create instance 1");
+    let (r1, _) = inst1
+        .invoke_and_capture_output(None, "hello", &[Val::String("X".into())])
+        .await;
+    match r1.expect("Call 1 failed") {
+        Some(Val::String(s)) => {
+            assert!(s.contains("First"), "Expected 'First' in: {s}");
+            eprintln!("  ✓ injection 1: {s}");
+        }
+        other => panic!("Unexpected: {other:?}"),
+    }
+
+    // Run second
+    let mut inst2 = TestInstance::new(&injected_path2)
+        .await
+        .expect("Failed to create instance 2");
+    let (r2, _) = inst2
+        .invoke_and_capture_output(None, "hello", &[Val::String("X".into())])
+        .await;
+    match r2.expect("Call 2 failed") {
+        Some(Val::String(s)) => {
+            assert!(s.contains("Second"), "Expected 'Second' in: {s}");
+            eprintln!("  ✓ injection 2: {s}");
+        }
+        other => panic!("Unexpected: {other:?}"),
+    }
+}


### PR DESCRIPTION

## Overview

BinarySlot is a dynamic JS injection mode for wasm-rquickjs that allows injecting JavaScript source into prebuilt WASM component templates **without recompiling Rust**. There is no capacity limit — the WASM component is structurally rewritten using `wasmparser` + `wasm-encoder` to accommodate any size JS payload. Multiple JS modules are supported: the primary export module and any number of additional modules can each use BinarySlot mode independently.

## Marker Format (40 bytes)

Each BinarySlot module embeds a 40-byte marker file via `include_bytes!`. Layout:

```
[SLOT_MAGIC 16 bytes][MODULE_INDEX u32 LE][JS_OFFSET u32 LE][SLOT_END_MAGIC 16 bytes]
```

| Field | Offset | Size | Description |
|-------|--------|------|-------------|
| `SLOT_MAGIC` | 0 | 16 | `b"WASM_RQJS_SLOT\x01\x00"` — identifies a slot marker |
| `MODULE_INDEX` | 16 | 4 | Sequential u32: 0 = primary export module, 1+ = additional modules |
| `JS_OFFSET` | 20 | 4 | Pointer into linear memory. 0 = no JS injected yet |
| `SLOT_END_MAGIC` | 24 | 16 | `b"WASM_RQJS_SLTND\x00"` — footer for integrity validation |

Constants: `MARKER_SIZE = 40`, `WASM_PAGE_SIZE = 65536`.

`create_marker_file(module_index: u32)` creates these markers with `JS_OFFSET=0`.

## Template Compilation Flow

1. **Crate generation** (`copy_js_modules` in `lib.rs`): For each `BinarySlot` module, a `.slot` file is created with a unique `MODULE_INDEX` (assigned sequentially across all BinarySlot modules). The primary export module gets index 0, additional modules get 1, 2, etc.

2. **Code generation** (`generate_module_defs` in `exports.rs`):
   - If any module uses BinarySlot, a shared `read_js_from_slot_bytes(slot: &[u8]) -> String` function is emitted. This reads JS from the marker using volatile reads to prevent the optimizer from constant-folding the slot contents.
   - The primary BinarySlot module emits `JS_EXPORT_MODULE_SLOT: &[u8] = include_bytes!("name.slot")` and `js_export_module()` calls `read_js_from_slot_bytes`.
   - Each additional BinarySlot module emits its own `include_bytes!` static and a per-module reader function, used in the `JS_ADDITIONAL_MODULES` lazy vec.

3. **Compilation**: `cargo-component build` compiles the crate to a WASM component. The 40-byte markers end up in data segments with `JS_OFFSET=0`.

## Injection Flow

`inject_js_into_component(input, output, js_sources: &[&str])` — the `js_sources` slice maps by position to `MODULE_INDEX` (first entry → MODULE_INDEX=0, second → MODULE_INDEX=1, etc.).

### Reencode Pass (`MarkerRewriter`)

The `MarkerRewriter` struct implements `wasm_encoder::reencode::Reencode` and `ReencodeComponent`:

1. **`parse_data`**: For each data segment:
   - Tracks `max_data_end` (highest memory address used by active segments on memory 0).
   - Scans segment bytes for markers using `is_marker_at()` (checks `SLOT_MAGIC` at offset 0 and `SLOT_END_MAGIC` at offset 24).
   - If a marker is found, reads its `MODULE_INDEX` and records it. Duplicate indices are an error.
   - Emits the segment unchanged (JS_OFFSET stays 0).

2. **`parse_data_section`**: After processing all existing segments:
   - For each found marker (sorted by module index), appends a new active data segment on memory 0 at `page_align(current_offset)` containing `[JS_LEN u32 LE][JS bytes]`.
   - Records `(module_index, mem_offset)` pairs in `js_mem_offsets`.
   - Each payload starts page-aligned after the previous one.

3. **`data_count`**: Returns `count + N` where N is the number of JS payloads (one per BinarySlot module).

4. **`parse_memory_section`**: Grows the core module's memory minimum pages to fit all JS payloads. Upper bound: `original_min_pages * PAGE_SIZE + total_payload_size + N * PAGE_SIZE` (worst-case page alignment padding per payload).

### Post-Pass Binary Patch

`patch_js_offsets_in_output(output, offsets)`:
- Scans the final output bytes for all markers with `JS_OFFSET == 0`.
- For each `(module_index, js_mem_offset)` pair, finds the marker with matching `MODULE_INDEX` and writes `js_mem_offset` into the `JS_OFFSET` field at byte offset 20.

### Validation

After the reencode pass:
- If no markers were found → error ("No JS injection markers found").
- For each expected module index (0..N), verifies a marker was found → error if missing.

## Runtime Reading

The generated `read_js_from_slot_bytes(slot: &[u8]) -> String` function:

1. Validates `SLOT_MAGIC` at offset 0 via volatile reads.
2. Reads `JS_OFFSET` at offset 20 (skipping `MODULE_INDEX` at offset 16) via volatile reads.
3. Asserts `JS_OFFSET > 0` (panics if slot is empty — JS not injected).
4. Validates `SLOT_END_MAGIC` at offset 24.
5. Reads `JS_LEN` (4 bytes) from linear memory at `JS_OFFSET`.
6. Reads `JS_LEN` bytes from linear memory at `JS_OFFSET + 4`.
7. Returns the JS as a UTF-8 `String`.

Volatile reads prevent the compiler from constant-folding the marker contents at compile time, which is essential because the marker is patched post-compilation.

## CLI Usage

```bash
# Single module (backward compatible)
wasm-rquickjs inject-js \
  --input template.wasm \
  --output output.wasm \
  --js main.js

# Multiple modules (order matches BinarySlot module order from crate generation)
wasm-rquickjs inject-js \
  --input template.wasm \
  --output output.wasm \
  --js main.js \
  --js additional1.js \
  --js additional2.js
```

The `--js` flag accepts multiple paths. Order must match the BinarySlot module order used during `generate-wrapper-crate` (primary module first, then additional modules in order).