### PR TITLE
Fix wizer preinit file access issue

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/builtin/fs.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/fs.rs
@@ -484,6 +484,27 @@ fn make_badf_error<'js>(ctx: &rquickjs::Ctx<'js>, syscall: &str) -> rquickjs::Ob
     obj
 }
 
+/// Synthesize an ENOENT std::io::Error without ever touching wasi-libc.
+///
+/// Used to short-circuit path-based fs operations during Wizer pre-init so
+/// that wasi-libc's lazy preopen-cache initialization never runs against the
+/// (empty) wizer environment. See `crate::internal::is_wizer_active` and
+/// issue #91.
+fn wizer_enoent_io() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "ENOENT during wizer pre-initialization",
+    )
+}
+
+fn wizer_enoent_obj<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    syscall: &str,
+    path: Option<&str>,
+) -> rquickjs::Object<'js> {
+    make_fs_error(ctx, &wizer_enoent_io(), syscall, path)
+}
+
 fn is_dev_stdio_path(path: &str) -> bool {
     matches!(path, "/dev/stdin" | "/dev/stdout" | "/dev/stderr")
 }
@@ -766,6 +787,13 @@ pub mod native_module {
         use std::io::{Seek, SeekFrom};
 
         let result = Object::new(ctx.clone()).unwrap();
+
+        if crate::internal::is_wizer_active() {
+            result
+                .set("error", super::wizer_enoent_obj(&ctx, "open", Some(&path)))
+                .unwrap();
+            return result;
+        }
 
         let fs_path = super::resolve_emulated_symlinks(&path);
 
@@ -1051,6 +1079,13 @@ pub mod native_module {
             return result;
         }
 
+        if crate::internal::is_wizer_active() {
+            result
+                .set("error", super::wizer_enoent_obj(&ctx, "stat", Some(&path)))
+                .unwrap();
+            return result;
+        }
+
         let fs_path = super::resolve_emulated_symlinks(&path);
 
         match std::fs::metadata(&fs_path) {
@@ -1080,6 +1115,13 @@ pub mod native_module {
         if super::is_dev_stdio_path(&path) {
             let stat = super::stdio_stat_obj(&ctx);
             result.set("stat", stat).unwrap();
+            return result;
+        }
+
+        if crate::internal::is_wizer_active() {
+            result
+                .set("error", super::wizer_enoent_obj(&ctx, "lstat", Some(&path)))
+                .unwrap();
             return result;
         }
 
@@ -1164,6 +1206,16 @@ pub mod native_module {
             return result;
         }
 
+        if crate::internal::is_wizer_active() {
+            result
+                .set(
+                    "error",
+                    super::wizer_enoent_obj(&ctx, "scandir", Some(&path)),
+                )
+                .unwrap();
+            return result;
+        }
+
         let fs_path = super::resolve_emulated_symlinks(&path);
 
         match std::fs::read_dir(&fs_path) {
@@ -1211,6 +1263,10 @@ pub mod native_module {
 
     #[rquickjs::function]
     pub fn fs_access(ctx: Ctx<'_>, path: String, _mode: i32) -> Option<Object<'_>> {
+        if crate::internal::is_wizer_active() {
+            return Some(super::wizer_enoent_obj(&ctx, "access", Some(&path)));
+        }
+
         let fs_path = super::resolve_emulated_symlinks(&path);
 
         // For WASI, just check if the path exists (and is accessible)
@@ -1226,6 +1282,16 @@ pub mod native_module {
 
         if super::is_dev_stdio_path(&path) {
             result.set("result", path).unwrap();
+            return result;
+        }
+
+        if crate::internal::is_wizer_active() {
+            result
+                .set(
+                    "error",
+                    super::wizer_enoent_obj(&ctx, "realpath", Some(&path)),
+                )
+                .unwrap();
             return result;
         }
 
@@ -1340,6 +1406,16 @@ pub mod native_module {
 
         if let Some(target) = super::get_emulated_symlink_target(&path) {
             result.set("result", target).unwrap();
+            return result;
+        }
+
+        if crate::internal::is_wizer_active() {
+            result
+                .set(
+                    "error",
+                    super::wizer_enoent_obj(&ctx, "readlink", Some(&path)),
+                )
+                .unwrap();
             return result;
         }
 

--- a/crates/wasm-rquickjs/skeleton/src/internal.rs
+++ b/crates/wasm-rquickjs/skeleton/src/internal.rs
@@ -1711,6 +1711,18 @@ async fn drain_and_idle(js_state: &JsState) {
 static mut STATE: Option<JsState> = None;
 static mut INIT_PHASE: InitPhase = InitPhase::Uninitialized;
 
+/// True while `wizer_initialize` is running. Used by built-in modules to avoid
+/// std::fs / std::env operations during Wizer pre-init: those would trigger
+/// wasi-libc's lazy preopen-cache population with the empty wizer environment,
+/// and the broken cache would then be snapshotted into the pre-initialized
+/// component, breaking filesystem access at runtime. See issue #91.
+static WIZER_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[inline]
+pub fn is_wizer_active() -> bool {
+    WIZER_ACTIVE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 #[allow(static_mut_refs)]
 pub fn get_js_state() -> &'static JsState {
     unsafe {
@@ -2330,6 +2342,12 @@ pub fn format_caught_error(caught: CaughtError) -> String {
 /// After Wizer snapshots this state, the runtime is ready to handle exports immediately.
 #[allow(static_mut_refs)]
 pub fn wizer_initialize() {
+    // Mark Wizer pre-init as active so built-in modules avoid touching
+    // std::fs / std::env: those would trigger wasi-libc's lazy preopen-cache
+    // population with the empty wizer environment, and the broken cache would
+    // then be snapshotted into the pre-initialized component (issue #91).
+    WIZER_ACTIVE.store(true, std::sync::atomic::Ordering::Relaxed);
+
     unsafe {
         // Phase 1: Create runtime
         STATE = Some(block_on(JsState::new_base()));
@@ -2366,4 +2384,6 @@ pub fn wizer_initialize() {
 
         INIT_PHASE = InitPhase::WizerPreInitialized;
     }
+
+    WIZER_ACTIVE.store(false, std::sync::atomic::Ordering::Relaxed);
 }


### PR DESCRIPTION
Resolves #91 

**Root cause**: During wizer pre-init, the wasm-rquickjs runtime evaluates the bundled user JS. When that bundle contains code like exa-js's `node-fetch` dep — which has `try { require('encoding') } catch {}` at module-eval time — the JS require shim walks `node_modules` via `fs.readFileSync` → Rust `fs_open` → `std::fs::OpenOptions::open`. The first such call triggers `wasi-libc`'s lazy preopen-cache population against the empty wizer host environment (which provides no preopens), and the broken empty-cache state gets snapshotted by Wizer. After restore, `std::fs::*` operations fail with `ENOENT scandir ‘/'` even though wasmtime has provided real preopens.

**Fix**:

New `WIZER_ACTIVE: AtomicBool` static + `is_wizer_active()` helper, set to true for the duration of `wizer_initialize()`.
Path-based fs ops (`fs_open`, `fs_stat`, `fs_lstat`, `fs_readdir`, `fs_realpath`, `fs_readlink`, `fs_access`) short-circuit with a synthetic `ENOENT wizer_enoent_obj` when the flag is set, never invoking `std::fs::*` and so never poisoning wasi-libc's preopen cache.
