### PR TITLE
Add Amp orb lifecycle setup

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use the same environment that new non-interactive login shells receive.
+# shellcheck disable=SC1091
+source "$HOME/.config/wasm-rquickjs/orb-env.sh"
+
+required_commands=(cargo cargo-component clang cmake node rustc rustup wasmtime)
+for command_name in "${required_commands[@]}"; do
+  command -v "$command_name" >/dev/null || {
+    echo "missing orb prerequisite: $command_name; rerun .agents/setup" >&2
+    exit 1
+  }
+done
+
+[[ "$(node --version)" == "v22.14.0" ]] || {
+  echo "unexpected Node.js version; rerun .agents/setup" >&2
+  exit 1
+}
+wasmtime --version | grep -q '^wasmtime 46\.0\.1 ' || {
+  echo "unexpected Wasmtime version; rerun .agents/setup" >&2
+  exit 1
+}
+[[ "$(head -1 /opt/wasi-sdk/VERSION 2>/dev/null || true)" == "25.0" ]] || {
+  echo "unexpected WASI SDK version; rerun .agents/setup" >&2
+  exit 1
+}
+for target in wasm32-wasip1 wasm32-wasip2; do
+  rustup target list --installed --toolchain stable | grep -qx "$target" || {
+    echo "missing Rust target $target; rerun .agents/setup" >&2
+    exit 1
+  }
+done
+
+git submodule status --recursive | grep -q '^-' && {
+  echo "uninitialized submodule detected; rerun .agents/setup" >&2
+  exit 1
+}
+
+available_kb="$(df -Pk . | awk 'NR == 2 { print $4 }')"
+if ((available_kb < 20 * 1024 * 1024)); then
+  echo "warning: less than 20 GiB is free; clean completed target/tmp caches before heavy CI lanes" >&2
+fi

--- a/.agents/resume
+++ b/.agents/resume
@@ -5,7 +5,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "$HOME/.config/wasm-rquickjs/orb-env.sh"
 
-required_commands=(cargo cargo-component clang cmake node rustc rustup wasmtime)
+required_commands=(cargo cargo-component clang cmake node npm rustc rustfmt rustup wasmtime)
 for command_name in "${required_commands[@]}"; do
   command -v "$command_name" >/dev/null || {
     echo "missing orb prerequisite: $command_name; rerun .agents/setup" >&2
@@ -13,16 +13,29 @@ for command_name in "${required_commands[@]}"; do
   }
 done
 
-[[ "$(node --version)" == "v22.14.0" ]] || {
+expected_node_version="$(tr -d '[:space:]' < .nvmrc)"
+[[ "$(node --version)" == "v${expected_node_version}" ]] || {
   echo "unexpected Node.js version; rerun .agents/setup" >&2
   exit 1
 }
-wasmtime --version | grep -q '^wasmtime 46\.0\.1 ' || {
+[[ "$(cargo component --version 2>/dev/null | awk '{ print $NF }')" == "0.21.1" ]] || {
+  echo "unexpected cargo-component version; rerun .agents/setup" >&2
+  exit 1
+}
+cargo clippy --version >/dev/null || {
+  echo "missing Rust clippy component; rerun .agents/setup" >&2
+  exit 1
+}
+[[ "$(wasmtime --version | awk '{ print $2 }')" == "46.0.1" ]] || {
   echo "unexpected Wasmtime version; rerun .agents/setup" >&2
   exit 1
 }
 [[ "$(head -1 /opt/wasi-sdk/VERSION 2>/dev/null || true)" == "25.0" ]] || {
   echo "unexpected WASI SDK version; rerun .agents/setup" >&2
+  exit 1
+}
+[[ -x "$WASI_SDK_PATH/bin/clang" ]] || {
+  echo "missing WASI SDK clang; rerun .agents/setup" >&2
   exit 1
 }
 for target in wasm32-wasip1 wasm32-wasip2; do

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WASI_SDK_VERSION=25
+NODE_VERSION="$(tr -d '[:space:]' < .nvmrc)"
+WASMTIME_VERSION=46.0.1
+
+missing_packages=()
+for package in build-essential ca-certificates clang cmake curl git pkg-config xz-utils; do
+  dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q 'ok installed' || missing_packages+=("$package")
+done
+if ((${#missing_packages[@]})); then
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "${missing_packages[@]}"
+fi
+
+if ! command -v rustup >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --profile minimal --default-toolchain stable
+fi
+# shellcheck disable=SC1091
+source "$HOME/.cargo/env"
+rustup toolchain install stable --profile minimal
+rustup default stable
+rustup target add --toolchain stable wasm32-wasip1 wasm32-wasip2
+rustup component add --toolchain stable rustfmt clippy
+
+if ! cargo component --version 2>/dev/null | grep -q '0\.21\.1'; then
+  cargo install --locked --version 0.21.1 cargo-component
+fi
+
+if [[ ! -x /opt/wasi-sdk/bin/clang ]] || \
+  [[ "$(head -1 /opt/wasi-sdk/VERSION 2>/dev/null || true)" != "${WASI_SDK_VERSION}.0" ]]; then
+  archive="$(mktemp --suffix=.tar.gz)"
+  curl -sSfL \
+    "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux.tar.gz" \
+    -o "$archive"
+  sudo rm -rf /opt/wasi-sdk "/opt/wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux"
+  sudo tar xzf "$archive" -C /opt
+  sudo mv "/opt/wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux" /opt/wasi-sdk
+  rm "$archive"
+fi
+
+node_dir="/opt/node-v${NODE_VERSION}-linux-x64"
+if [[ ! -x "$node_dir/bin/node" ]] || \
+  [[ "$($node_dir/bin/node --version 2>/dev/null)" != "v${NODE_VERSION}" ]]; then
+  archive="$(mktemp --suffix=.tar.xz)"
+  curl -sSfL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o "$archive"
+  sudo rm -rf "$node_dir"
+  sudo tar xJf "$archive" -C /opt
+  rm "$archive"
+fi
+
+if [[ ! -x "$HOME/.wasmtime/bin/wasmtime" ]] || \
+  ! "$HOME/.wasmtime/bin/wasmtime" --version 2>/dev/null | grep -q "wasmtime ${WASMTIME_VERSION}"; then
+  curl -sSf https://wasmtime.dev/install.sh | bash -s -- --version "v${WASMTIME_VERSION}"
+fi
+
+git submodule update --init --recursive
+
+mkdir -p "$HOME/.config/wasm-rquickjs"
+cat > "$HOME/.config/wasm-rquickjs/orb-env.sh" <<EOF
+export PATH="\$HOME/.wasmtime/bin:${node_dir}/bin:\$HOME/.cargo/bin:\$PATH"
+export WASI_SDK_VERSION="${WASI_SDK_VERSION}"
+export WASI_SDK_PATH="/opt/wasi-sdk"
+EOF
+
+profile_marker='# wasm-rquickjs orb environment'
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile" 2>/dev/null; then
+  cat >> "$HOME/.bash_profile" <<'EOF'
+
+# wasm-rquickjs orb environment
+if [[ -f "$HOME/.config/wasm-rquickjs/orb-env.sh" ]]; then
+  source "$HOME/.config/wasm-rquickjs/orb-env.sh"
+fi
+EOF
+fi
+
+echo "wasm-rquickjs orb prerequisites are ready"

--- a/.agents/setup
+++ b/.agents/setup
@@ -25,7 +25,7 @@ rustup default stable
 rustup target add --toolchain stable wasm32-wasip1 wasm32-wasip2
 rustup component add --toolchain stable rustfmt clippy
 
-if ! cargo component --version 2>/dev/null | grep -q '0\.21\.1'; then
+if [[ "$(cargo component --version 2>/dev/null | awk '{ print $NF }')" != "0.21.1" ]]; then
   cargo install --locked --version 0.21.1 cargo-component
 fi
 
@@ -52,7 +52,7 @@ if [[ ! -x "$node_dir/bin/node" ]] || \
 fi
 
 if [[ ! -x "$HOME/.wasmtime/bin/wasmtime" ]] || \
-  ! "$HOME/.wasmtime/bin/wasmtime" --version 2>/dev/null | grep -q "wasmtime ${WASMTIME_VERSION}"; then
+  [[ "$("$HOME/.wasmtime/bin/wasmtime" --version 2>/dev/null | awk '{ print $2 }')" != "$WASMTIME_VERSION" ]]; then
   curl -sSf https://wasmtime.dev/install.sh | bash -s -- --version "v${WASMTIME_VERSION}"
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,33 @@ The `skeleton` crate (`crates/wasm-rquickjs/skeleton/`) is a **separate project*
 cargo build --release
 ```
 
+## Amp Orb Environment
+
+Fresh Amp orbs are prepared by `.agents/setup`, which installs the CI toolchain,
+initializes submodules, and persists the pinned Node.js, Wasmtime, Cargo, and WASI
+SDK paths for non-interactive login shells. `.agents/resume` performs only fast
+validation when an existing orb wakes. Keep both scripts idempotent and executable.
+
+The orb root disk is limited to 64 GiB, while a complete P2 run can retain roughly
+47 GiB in `target/` and `tmp/`. Do not retain P2 and P3 build artifacts together
+when reproducing the full CI workflow. Use separate worktrees so
+`enable-wasmtime-fork.sh` cannot affect stock-P3 tests, then run the lanes in this
+order:
+
+1. Run fork-enabled P2 build, test-other, runtime, and node-compat lanes.
+2. Preserve test logs/results outside the P2 worktree, then remove that worktree's
+   generated `target/`, `tmp/`, and `tests/node_compat/suite/` directories.
+3. Run stock-P3 runtime and node-compat lanes.
+4. Remove the P3 worktree's generated `tmp/` directory before running the dedicated
+   `p3_generation`, `p3_exported_resource`, and `p3_async_values` tests. Those tests
+   build isolated crates concurrently under `/tmp` and need substantial transient
+   free space.
+
+Use the repository-supported artifact and Wasmtime caches while a lane is active,
+but never reuse stores, component instances, WASI state, wasm memory, QuickJS state,
+or test temp directories. After an interrupted run, remove a generated cache lock
+only after confirming that no process owns it.
+
 ### Run tests
 ```bash
 cargo test


### PR DESCRIPTION
## Summary
- provision CI-compatible Rust, WASI SDK, Node.js, Wasmtime, and system prerequisites in fresh Amp orbs
- restore and validate the pinned toolchain when an orb resumes
- document the disk-safe P2/P3 CI sequence required by the fixed 64 GiB orb disk

## Verification
- ran `.agents/setup` repeatedly (latest warm run: 0.60s)
- ran `.agents/resume` (latest run: 0.84s)
- verified Node, Wasmtime, Cargo, and WASI SDK from a clean non-interactive login shell
- `bash -n .agents/setup .agents/resume`
- `git diff --check ef79be49f8647f85adaed5341965d23a801f7862`
- Oracle review findings addressed in follow-up commit