### PR TITLE
GOL-483: accept foreign resource aliases in Preview 3 exports

### DIFF
--- a/crates/wasm-rquickjs/src/exports.rs
+++ b/crates/wasm-rquickjs/src/exports.rs
@@ -246,11 +246,7 @@ fn generate_guest_impl(
             let Some(resource_type_id) = resolve_resource_type_id(context, *type_id)? else {
                 continue;
             };
-            let resource = context
-                .resolve
-                .types
-                .get(resource_type_id)
-                .ok_or_else(|| anyhow!("Unknown type id {resource_type_id:?}"))?;
+            let resource = context.typ(resource_type_id)?;
 
             if !matches!(
                 &resource.owner,

--- a/crates/wasm-rquickjs/src/exports.rs
+++ b/crates/wasm-rquickjs/src/exports.rs
@@ -13,7 +13,8 @@ use quote::quote;
 use std::collections::BTreeMap;
 use syn::{Lit, LitStr};
 use wit_parser::{
-    Function, FunctionKind, Interface, InterfaceId, TypeDefKind, TypeId, WorldItem, WorldKey,
+    Function, FunctionKind, Interface, InterfaceId, TypeDefKind, TypeId, TypeOwner, WorldItem,
+    WorldKey,
 };
 
 /// Generates the `<output>/src/lib.rs` file for the wrapper crate, implementing the component exports
@@ -179,14 +180,14 @@ fn generate_guest_impls(context: &GeneratorContext<'_>) -> anyhow::Result<Vec<To
     Ok(result)
 }
 
-/// Returns whether `type_id` ultimately denotes a `resource`, following `use` re-exports and
-/// type aliases (`TypeDefKind::Type(Type::Id(..))`) to their target. A direct resource has its
-/// kind set to `Resource`, but an interface that re-exports a resource via `use other.{r};`
-/// stores it as an alias, so a naive `kind == Resource` check would miss it.
-fn type_resolves_to_resource(
+/// Returns the terminal resource type ID when `type_id` denotes a resource, following `use`
+/// re-exports and type aliases (`TypeDefKind::Type(Type::Id(..))`) to their target. A direct
+/// resource has its kind set to `Resource`, but an interface that re-exports a resource via
+/// `use other.{r};` stores it as an alias, so a naive `kind == Resource` check would miss it.
+fn resolve_resource_type_id(
     context: &GeneratorContext<'_>,
     type_id: TypeId,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<Option<TypeId>> {
     let mut current = type_id;
     loop {
         let typ = context
@@ -195,9 +196,9 @@ fn type_resolves_to_resource(
             .get(current)
             .ok_or_else(|| anyhow!("Unknown type id {current:?}"))?;
         match &typ.kind {
-            TypeDefKind::Resource => return Ok(true),
+            TypeDefKind::Resource => return Ok(Some(current)),
             TypeDefKind::Type(wit_parser::Type::Id(next)) => current = *next,
-            _ => return Ok(false),
+            _ => return Ok(None),
         }
     }
 }
@@ -226,7 +227,7 @@ fn generate_guest_impl(
     // `exports` (so no `GuestX` impl would be generated — the same limitation exists on the P2
     // path), which would surface as an obscure compile error. Reject such methodless exported
     // resources at the type level here with an actionable message.
-    if is_p3 && let Some((_, iface, _)) = interface {
+    if is_p3 && let Some((_, iface, interface_id)) = interface {
         let mut resource_ids_with_functions = std::collections::HashSet::new();
         for (_, function) in exports {
             match &function.kind {
@@ -242,15 +243,25 @@ fn generate_guest_impl(
         }
 
         for (_, type_id) in &iface.types {
-            if type_resolves_to_resource(context, *type_id)?
-                && !resource_ids_with_functions.contains(type_id)
+            let Some(resource_type_id) = resolve_resource_type_id(context, *type_id)? else {
+                continue;
+            };
+            let resource = context
+                .resolve
+                .types
+                .get(resource_type_id)
+                .ok_or_else(|| anyhow!("Unknown type id {resource_type_id:?}"))?;
+
+            if !matches!(
+                &resource.owner,
+                TypeOwner::Interface(owner) if *owner == interface_id
+            ) {
+                continue;
+            }
+            if !resource_ids_with_functions.contains(type_id)
+                && !resource_ids_with_functions.contains(&resource_type_id)
             {
-                let typ = context
-                    .resolve
-                    .types
-                    .get(*type_id)
-                    .ok_or_else(|| anyhow!("Unknown type id {type_id:?}"))?;
-                let resource_name = typ.name.as_deref().unwrap_or("<anonymous>");
+                let resource_name = resource.name.as_deref().unwrap_or("<anonymous>");
                 return Err(anyhow!(
                     "Exported resources without any constructor, method, or static function are not supported by the WASI Preview 3 generation path (resource '{resource_name}')"
                 ));

--- a/tests/p3_generation.rs
+++ b/tests/p3_generation.rs
@@ -1663,20 +1663,24 @@ fn p3_rejects_methodless_exported_resource() -> anyhow::Result<()> {
         "export async function run() { return 1; }\n",
     )?;
 
+    let error = generate_p3(temp.path())
+        .expect_err("P3 generation must reject interface-owned methodless exported resources");
     assert!(
-        generate_p3(temp.path()).is_err(),
-        "P3 generation must reject exported resources even when the resource has no functions"
+        format!("{error:#}").contains(
+            "Exported resources without any constructor, method, or static function are not supported by the WASI Preview 3 generation path (resource 'r')"
+        ),
+        "P3 generation must return an actionable error for an interface-owned methodless resource; got: {error:#}"
     );
     Ok(())
 }
 
 #[test]
-fn p3_rejects_methodless_exported_resource_alias() -> anyhow::Result<()> {
+fn p3_accepts_foreign_methodless_resource_alias_in_export() -> anyhow::Result<()> {
     let temp = Utf8TempDir::new()?;
     write_fixture(
         temp.path(),
         indoc! {r#"
-            package bug:methodless-resource-alias;
+            package bug:foreign-resource-alias;
 
             interface resources {
               resource r;
@@ -1684,20 +1688,17 @@ fn p3_rejects_methodless_exported_resource_alias() -> anyhow::Result<()> {
 
             interface api {
               use resources.{r};
+              run: func(value: borrow<r>);
             }
 
-            world methodless-resource-alias {
+            world foreign-resource-alias {
               export api;
-              export run: async func() -> u32;
             }
         "#},
-        "export async function run() { return 1; }\n",
+        "export const api = { run(_value) {} };\n",
     )?;
 
-    assert!(
-        generate_p3(temp.path()).is_err(),
-        "P3 generation must reject exported resources even when the exported interface re-exports the resource through a type alias"
-    );
+    generate_p3(temp.path())?;
     Ok(())
 }
 

--- a/tests/p3_generation.rs
+++ b/tests/p3_generation.rs
@@ -1675,30 +1675,34 @@ fn p3_rejects_methodless_exported_resource() -> anyhow::Result<()> {
 }
 
 #[test]
-fn p3_accepts_foreign_methodless_resource_alias_in_export() -> anyhow::Result<()> {
+fn p3_builds_with_foreign_resource_alias_in_async_export() -> anyhow::Result<()> {
     let temp = Utf8TempDir::new()?;
     write_fixture(
         temp.path(),
         indoc! {r#"
             package bug:foreign-resource-alias;
 
-            interface resources {
-              resource r;
+            interface common {
+              resource context {
+                get-value: async func() -> string;
+              }
             }
 
             interface api {
-              use resources.{r};
-              run: func(value: borrow<r>);
+              use common.{context};
+              run: async func(ctx: own<context>);
             }
 
             world foreign-resource-alias {
+              import common;
               export api;
             }
         "#},
-        "export const api = { run(_value) {} };\n",
+        "export const api = { async run(_ctx) {} };\n",
     )?;
 
     generate_p3(temp.path())?;
+    let _wasm_path = build_p3(temp.path(), "foreign_resource_alias")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- resolve exported-interface type aliases to their terminal resource before Preview 3 methodless-resource validation
- reject a methodless resource only when that terminal resource is owned by the exported interface being generated
- account for both alias and terminal resource IDs when checking method membership, while leaving Preview 2 behavior unchanged
- add a build regression matching GOL-483's async imported-resource shape and retain the actionable interface-owned methodless-resource negative

## Validation

- `cargo fmt -- --check`
- `cargo test -p wasm-rquickjs --lib` (20 passed)
- `cargo test --test p3_generation -- p3_builds_with_foreign_resource_alias_in_async_export --exact` (1 passed; generated wrapper compiled)
- `cargo test --test p3_generation -- p3_rejects_methodless_exported_resource --exact` (1 passed)
- `cargo test --test p3_generation -- p3_generated_crate_builds_with_exported_resource --exact` (1 passed)
- `cargo clippy -- -Dwarnings`

## Issues

Implements [GOL-483](https://linear.app/golem-cloud/issue/GOL-483/wasm-rquickjs-rejects-foreign-resource-aliases-in-preview-3-exports).

Once this fix is released, [GOL-26](https://linear.app/golem-cloud/issue/GOL-26/ts-tool-middleware-definition-monomorphic-and-universal) can remove its temporary local wrapper-generator patch.