### PR TITLE
test(http): trace server socket ownership (GOL-420)

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1814,12 +1814,46 @@ mod tests {
         shutdowns: AtomicUsize,
     }
 
+    struct CountedBody {
+        frames: VecDeque<bytes::Bytes>,
+        polls: Arc<AtomicUsize>,
+        exact_size: Option<u64>,
+        end_when_empty: bool,
+    }
+
+    impl HttpBody for CountedBody {
+        type Data = bytes::Bytes;
+        type Error = std::convert::Infallible;
+
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+            self.polls.fetch_add(1, Ordering::Relaxed);
+            Poll::Ready(self.frames.pop_front().map(|data| Ok(Frame::data(data))))
+        }
+
+        fn is_end_stream(&self) -> bool {
+            self.end_when_empty && self.frames.is_empty()
+        }
+
+        fn size_hint(&self) -> SizeHint {
+            let mut hint = SizeHint::new();
+            if let Some(exact_size) = self.exact_size {
+                hint.set_exact(exact_size);
+            }
+            hint
+        }
+    }
+
     struct ScriptedIo {
         calls: Arc<ScriptedIoCalls>,
         fail_write: bool,
         accepted_writes: VecDeque<usize>,
         flush_pending_once: bool,
         shutdown_pending_once: bool,
+        fail_flush: bool,
+        fail_shutdown: bool,
     }
 
     impl tokio::io::AsyncRead for ScriptedIo {
@@ -1880,6 +1914,9 @@ mod tests {
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
+            if self.fail_flush {
+                return Poll::Ready(Err(std::io::Error::other("scripted flush failure")));
+            }
             Poll::Ready(Ok(()))
         }
 
@@ -1891,6 +1928,9 @@ mod tests {
             if std::mem::take(&mut self.shutdown_pending_once) {
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
+            }
+            if self.fail_shutdown {
+                return Poll::Ready(Err(std::io::Error::other("scripted shutdown failure")));
             }
             Poll::Ready(Ok(()))
         }
@@ -1910,6 +1950,8 @@ mod tests {
                 accepted_writes: VecDeque::new(),
                 flush_pending_once: false,
                 shutdown_pending_once: false,
+                fail_flush: false,
+                fail_shutdown: false,
             },
             state,
         );
@@ -2115,6 +2157,8 @@ mod tests {
                 accepted_writes: VecDeque::new(),
                 flush_pending_once: false,
                 shutdown_pending_once: false,
+                fail_flush: false,
+                fail_shutdown: false,
             },
             state.clone(),
         );
@@ -2245,31 +2289,131 @@ mod tests {
     }
 
     #[test]
-    fn http_lifecycle_server_response_records_unknown_and_overflow_body_sizes() {
+    fn http_lifecycle_server_io_errors_snapshot_active_and_pending_responses() {
         let trace = HttpLifecycleTrace::new();
-        let unknown = http_body_util::StreamBody::new(futures::stream::iter([Ok::<
-            _,
-            std::convert::Infallible,
-        >(
-            Frame::data(bytes::Bytes::from_static(b"unknown")),
-        )]));
-        let mut unknown = Box::pin(TracedHttpBody::new(
-            unknown,
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let (mut flush_io, _) = scripted_connection(trace.clone(), 21, false);
+        flush_io.state.arm_response(55);
+        assert!(matches!(
+            Pin::new(&mut flush_io).poll_write(&mut cx, b"four"),
+            Poll::Ready(Ok(4))
+        ));
+        flush_io.state.arm_response(56);
+        flush_io.inner.fail_flush = true;
+        assert!(matches!(
+            Pin::new(&mut flush_io).poll_flush(&mut cx),
+            Poll::Ready(Err(_))
+        ));
+        drop(flush_io);
+
+        let (mut shutdown_io, _) = scripted_connection(trace.clone(), 22, false);
+        shutdown_io.state.arm_response(57);
+        assert!(matches!(
+            Pin::new(&mut shutdown_io).poll_write(&mut cx, b"five!"),
+            Poll::Ready(Ok(5))
+        ));
+        shutdown_io.state.arm_response(58);
+        shutdown_io.inner.fail_shutdown = true;
+        assert!(matches!(
+            Pin::new(&mut shutdown_io).poll_shutdown(&mut cx),
+            Poll::Ready(Err(_))
+        ));
+        drop(shutdown_io);
+
+        let snapshot = trace.snapshot();
+        for (active, pending, connection, bytes, connection_phase) in [
+            (55, 56, 21, 4, "server-connection-flush-error"),
+            (57, 58, 22, 5, "server-connection-shutdown-error"),
+        ] {
+            assert_eq!(
+                snapshot
+                    .matches(&format!(
+                        "request={active} phase=server-response-write-error detail={connection}"
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                snapshot
+                    .matches(&format!(
+                        "request={active} phase=server-response-terminal-bytes detail={bytes}"
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                snapshot
+                    .matches(&format!(
+                        "request={pending} phase=server-response-write-error detail={connection}"
+                    ))
+                    .count(),
+                1
+            );
+            assert!(snapshot.contains(&format!("request={connection} phase={connection_phase}")));
+        }
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_body_counts_terminate_without_extra_poll() {
+        let trace = HttpLifecycleTrace::new();
+        let exact_polls = Arc::new(AtomicUsize::new(0));
+        let exact = CountedBody {
+            frames: VecDeque::from([
+                bytes::Bytes::from_static(b"abc"),
+                bytes::Bytes::from_static(b"defg"),
+            ]),
+            polls: exact_polls.clone(),
+            exact_size: Some(7),
+            end_when_empty: true,
+        };
+        let mut exact = Box::pin(TracedHttpBody::new(
+            exact,
             trace.clone(),
             47,
             "server-response",
             None,
         ));
+        let unknown_polls = Arc::new(AtomicUsize::new(0));
+        let unknown = CountedBody {
+            frames: VecDeque::from([
+                bytes::Bytes::from_static(b"un"),
+                bytes::Bytes::from_static(b"known"),
+            ]),
+            polls: unknown_polls.clone(),
+            exact_size: None,
+            end_when_empty: true,
+        };
+        let mut unknown = Box::pin(TracedHttpBody::new(
+            unknown,
+            trace.clone(),
+            48,
+            "server-response",
+            None,
+        ));
         let waker = futures::task::noop_waker();
         let mut cx = Context::from_waker(&waker);
-        assert!(unknown.as_mut().poll_frame(&mut cx).is_ready());
+        for body in [&mut exact, &mut unknown] {
+            assert!(matches!(
+                body.as_mut().poll_frame(&mut cx),
+                Poll::Ready(Some(Ok(_)))
+            ));
+            assert!(matches!(
+                body.as_mut().poll_frame(&mut cx),
+                Poll::Ready(Some(Ok(_)))
+            ));
+        }
+        assert_eq!(exact_polls.load(Ordering::Relaxed), 2);
+        assert_eq!(unknown_polls.load(Ordering::Relaxed), 2);
+        drop(exact);
         drop(unknown);
 
         let overflow = http_body_util::Full::new(bytes::Bytes::from(vec![0; 70_000]));
         let mut overflow = Box::pin(TracedHttpBody::new(
             overflow,
             trace.clone(),
-            48,
+            49,
             "server-response",
             None,
         ));
@@ -2277,17 +2421,23 @@ mod tests {
         drop(overflow);
 
         let snapshot = trace.snapshot();
-        assert!(snapshot.contains("request=47 phase=server-response-body-expected-unknown"));
+        assert!(snapshot.contains("request=47 phase=server-response-body-expected-bytes detail=7"));
         assert!(snapshot.contains("request=47 phase=server-response-body-polled-bytes detail=7"));
+        assert!(snapshot.contains("request=47 phase=server-response-eof"));
+        assert!(!snapshot.contains("request=47 phase=server-response-drop-before-terminal"));
+        assert!(snapshot.contains("request=48 phase=server-response-body-expected-unknown"));
+        assert!(snapshot.contains("request=48 phase=server-response-body-polled-bytes detail=7"));
+        assert!(snapshot.contains("request=48 phase=server-response-eof"));
+        assert!(!snapshot.contains("request=48 phase=server-response-drop-before-terminal"));
         assert!(
-            snapshot.contains("request=48 phase=server-response-body-expected-bytes detail=65535")
+            snapshot.contains("request=49 phase=server-response-body-expected-bytes detail=65535")
         );
         assert!(
-            snapshot.contains("request=48 phase=server-response-body-polled-bytes detail=65535")
+            snapshot.contains("request=49 phase=server-response-body-polled-bytes detail=65535")
         );
         assert_eq!(
             snapshot
-                .matches("request=48 phase=server-response-byte-count-overflow")
+                .matches("request=49 phase=server-response-byte-count-overflow")
                 .count(),
             2
         );

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -302,6 +302,7 @@ enum HttpLifecyclePhase {
     ServerResponseWriteAfterFrame = 40,
     ServerResponseWriteError = 41,
     ServerResponsePendingAtDrop = 42,
+    ServerResponseCorrelationOverlap = 43,
 }
 
 impl HttpLifecyclePhase {
@@ -349,6 +350,7 @@ impl HttpLifecyclePhase {
             40 => "server-response-write-after-frame",
             41 => "server-response-write-error",
             42 => "server-response-pending-at-drop",
+            43 => "server-response-correlation-overlap",
             _ => "unknown",
         }
     }
@@ -624,7 +626,18 @@ impl HttpConnectionState {
     }
 
     fn arm_response(&self, request_id: usize) {
-        self.pending_response.store(request_id, Ordering::Release);
+        if let Err(pending_request) = self.pending_response.compare_exchange(
+            0,
+            request_id,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            self.trace.record(
+                request_id,
+                HttpLifecyclePhase::ServerResponseCorrelationOverlap,
+                pending_request.min(usize::from(u16::MAX)) as u16,
+            );
+        }
     }
 
     fn record_response_write(&self, phase: HttpLifecyclePhase) {
@@ -1547,7 +1560,7 @@ impl Drop for TestCacheLock {
 mod tests {
     use super::*;
     use test_r::test;
-    use tokio::io::{AsyncRead as _, AsyncWrite as _};
+    use tokio::io::{AsyncRead as _, AsyncReadExt as _, AsyncWrite as _, AsyncWriteExt as _};
 
     #[derive(Default)]
     struct ScriptedIoCalls {
@@ -1886,7 +1899,7 @@ mod tests {
     }
 
     #[test]
-    fn http_lifecycle_server_connection_maps_multiple_requests_without_conflation() {
+    fn http_lifecycle_server_connection_maps_multiple_requests_to_same_connection() {
         let trace = HttpLifecycleTrace::new();
         let connection = TracedTestServerConnection {
             state: Arc::new(HttpConnectionState::new(trace.clone(), 17)),
@@ -1897,6 +1910,91 @@ mod tests {
         let snapshot = trace.snapshot();
         assert!(snapshot.contains("request=51 phase=server-request-connection detail=17"));
         assert!(snapshot.contains("request=52 phase=server-request-connection detail=17"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_overlap_is_explicit_and_non_overwriting() {
+        let trace = HttpLifecycleTrace::new();
+        let state = HttpConnectionState::new(trace.clone(), 19);
+        state.arm_response(61);
+        state.arm_response(62);
+
+        assert_eq!(state.pending_response.load(Ordering::Acquire), 61);
+        let snapshot = trace.snapshot();
+        assert!(
+            snapshot.contains("request=62 phase=server-response-correlation-overlap detail=61")
+        );
+    }
+
+    #[test]
+    async fn http_lifecycle_axum_pipeline_preserves_response_correlation() {
+        use axum::body::Body;
+        use axum::extract::{ConnectInfo, Request};
+        use axum::routing::any;
+        use bytes::Bytes;
+        use http_body_util::Full;
+
+        let trace = HttpLifecycleTrace::new();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let listener = TracedTestServerListener {
+            listener,
+            trace: trace.clone(),
+        };
+        let router = axum::Router::new().route(
+            "/",
+            any(
+                |ConnectInfo(connection): ConnectInfo<TracedTestServerConnection>,
+                 request: Request| async move {
+                    let request_id = test_server_http_correlation(request.headers());
+                    record_test_server_connection(request_id, Some(&connection));
+                    axum::response::Response::new(Body::new(TracedHttpBody::new(
+                        Full::new(Bytes::from_static(b"ok")),
+                        connection.state.trace.clone(),
+                        request_id,
+                        "server-response",
+                        Some(connection.state),
+                    )))
+                },
+            ),
+        );
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<TracedTestServerConnection>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let mut client = tokio::net::TcpStream::connect(address).await.unwrap();
+        client
+            .write_all(
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nx-wrq-http-trace-id: 71\r\n\r\n\
+                  GET / HTTP/1.1\r\nHost: localhost\r\nx-wrq-http-trace-id: 72\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        server.abort();
+
+        assert_eq!(
+            String::from_utf8_lossy(&response)
+                .matches("HTTP/1.1 200 OK")
+                .count(),
+            2
+        );
+        let snapshot = trace.snapshot();
+        for request_id in [71, 72] {
+            assert!(snapshot.contains(&format!(
+                "request={request_id} phase=server-request-connection"
+            )));
+            assert!(snapshot.contains(&format!(
+                "request={request_id} phase=server-response-write-after-frame"
+            )));
+        }
+        assert!(!snapshot.contains("server-response-correlation-overlap"));
     }
 
     #[cfg(feature = "use-golem-wasmtime")]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,6 +3,7 @@ pub mod test_server;
 
 use crate::common::WasmSource::Precompiled;
 use anyhow::anyhow;
+use bytes::Buf;
 use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::{NamedUtf8TempFile, Utf8TempDir};
 use futures::FutureExt;
@@ -303,6 +304,18 @@ enum HttpLifecyclePhase {
     ServerResponseWriteError = 41,
     ServerResponsePendingAtDrop = 42,
     ServerResponseCorrelationOverlap = 43,
+    ServerResponseBodyExpectedBytes = 44,
+    ServerResponseBodyExpectedUnknown = 45,
+    ServerResponseBodyPolledBytes = 46,
+    ServerResponseWritePartial = 47,
+    ServerResponseWriteBoundaryBytes = 48,
+    ServerResponseFlushBytes = 49,
+    ServerResponseTerminalBytes = 50,
+    ServerResponseByteCountOverflow = 51,
+    ServerConnectionFlushPending = 52,
+    ServerConnectionFlushOk = 53,
+    ServerConnectionShutdownPending = 54,
+    ServerResponseCorrelationBoundary = 55,
 }
 
 impl HttpLifecyclePhase {
@@ -351,9 +364,42 @@ impl HttpLifecyclePhase {
             41 => "server-response-write-error",
             42 => "server-response-pending-at-drop",
             43 => "server-response-correlation-overlap",
+            44 => "server-response-body-expected-bytes",
+            45 => "server-response-body-expected-unknown",
+            46 => "server-response-body-polled-bytes",
+            47 => "server-response-write-partial",
+            48 => "server-response-write-boundary-bytes",
+            49 => "server-response-flush-bytes",
+            50 => "server-response-terminal-bytes",
+            51 => "server-response-byte-count-overflow",
+            52 => "server-connection-flush-pending",
+            53 => "server-connection-flush-ok",
+            54 => "server-connection-shutdown-pending",
+            55 => "server-response-correlation-boundary",
             _ => "unknown",
         }
     }
+}
+
+const HTTP_BYTE_COUNT_EXPECTED: u16 = 1;
+const HTTP_BYTE_COUNT_POLLED: u16 = 2;
+const HTTP_BYTE_COUNT_WRITE: u16 = 3;
+
+fn record_http_byte_count(
+    trace: &HttpLifecycleTrace,
+    request: usize,
+    phase: HttpLifecyclePhase,
+    count: u64,
+    overflow_kind: u16,
+) {
+    if count > u64::from(u16::MAX) {
+        trace.record(
+            request,
+            HttpLifecyclePhase::ServerResponseByteCountOverflow,
+            overflow_kind,
+        );
+    }
+    trace.record(request, phase, count.min(u64::from(u16::MAX)) as u16);
 }
 
 struct HttpLifecycleJournal {
@@ -640,12 +686,17 @@ impl HttpConnectionState {
         }
     }
 
-    fn record_response_write(&self, phase: HttpLifecyclePhase) {
-        let request_id = self.pending_response.swap(0, Ordering::AcqRel);
-        if request_id != 0 {
-            self.trace.record(request_id, phase, self.connection);
+    fn take_pending_response(&self) -> Option<usize> {
+        match self.pending_response.swap(0, Ordering::AcqRel) {
+            0 => None,
+            request_id => Some(request_id),
         }
     }
+}
+
+struct ActiveResponseWrite {
+    request_id: usize,
+    accepted_bytes: u64,
 }
 
 pub(crate) struct TracedTestServerIo<T> {
@@ -655,6 +706,9 @@ pub(crate) struct TracedTestServerIo<T> {
     saw_write: bool,
     read_terminal: bool,
     write_terminal: bool,
+    active_response: Option<ActiveResponseWrite>,
+    flush_pending: bool,
+    shutdown_pending: bool,
 }
 
 impl<T> TracedTestServerIo<T> {
@@ -666,6 +720,9 @@ impl<T> TracedTestServerIo<T> {
             saw_write: false,
             read_terminal: false,
             write_terminal: false,
+            active_response: None,
+            flush_pending: false,
+            shutdown_pending: false,
         }
     }
 
@@ -675,24 +732,106 @@ impl<T> TracedTestServerIo<T> {
             .record(usize::from(self.state.connection), phase, detail);
     }
 
-    fn record_write_success(&mut self, bytes: usize) {
+    fn record_response_bytes(&self, request_id: usize, phase: HttpLifecyclePhase, bytes: u64) {
+        record_http_byte_count(
+            &self.state.trace,
+            request_id,
+            phase,
+            bytes,
+            HTTP_BYTE_COUNT_WRITE,
+        );
+    }
+
+    fn activate_pending_response(&mut self, first_accepted_bytes: Option<usize>) -> Option<usize> {
+        let pending = self.state.take_pending_response();
+        if let Some(request_id) = pending {
+            match self.active_response.take() {
+                Some(active) if active.request_id != request_id => {
+                    self.record_response_bytes(
+                        active.request_id,
+                        HttpLifecyclePhase::ServerResponseWriteBoundaryBytes,
+                        active.accepted_bytes,
+                    );
+                    self.state.trace.record(
+                        active.request_id,
+                        HttpLifecyclePhase::ServerResponseCorrelationBoundary,
+                        request_id.min(usize::from(u16::MAX)) as u16,
+                    );
+                }
+                Some(active) => {
+                    self.active_response = Some(active);
+                    return Some(request_id);
+                }
+                None => {}
+            }
+            if let Some(first_accepted_bytes) = first_accepted_bytes {
+                self.record_response_bytes(
+                    request_id,
+                    HttpLifecyclePhase::ServerResponseWriteAfterFrame,
+                    first_accepted_bytes as u64,
+                );
+            }
+            self.active_response = Some(ActiveResponseWrite {
+                request_id,
+                accepted_bytes: 0,
+            });
+        }
+        self.active_response
+            .as_ref()
+            .map(|active| active.request_id)
+    }
+
+    fn snapshot_active_response(&mut self, phase: HttpLifecyclePhase) {
+        if let Some(active) = self.active_response.take() {
+            self.record_response_bytes(active.request_id, phase, active.accepted_bytes);
+        }
+    }
+
+    fn record_pending_response(&self, phase: HttpLifecyclePhase) {
+        if let Some(request_id) = self.state.take_pending_response() {
+            self.state
+                .trace
+                .record(request_id, phase, self.state.connection);
+        }
+    }
+
+    fn record_write_success(&mut self, offered: usize, accepted: usize) {
         if !self.saw_write {
             self.saw_write = true;
             self.record_connection(
                 HttpLifecyclePhase::ServerConnectionFirstWrite,
-                bytes.min(usize::from(u16::MAX)) as u16,
+                accepted.min(usize::from(u16::MAX)) as u16,
             );
         }
-        if bytes != 0 {
-            self.state
-                .record_response_write(HttpLifecyclePhase::ServerResponseWriteAfterFrame);
+        if let Some(request_id) = self.activate_pending_response(Some(accepted)) {
+            if let Some(active) = &mut self.active_response {
+                active.accepted_bytes = active.accepted_bytes.saturating_add(accepted as u64);
+            }
+            if accepted < offered {
+                self.record_response_bytes(
+                    request_id,
+                    HttpLifecyclePhase::ServerResponseWritePartial,
+                    offered.saturating_sub(accepted) as u64,
+                );
+            }
         }
     }
 
     fn record_write_error(&mut self, error: &std::io::Error) {
         self.write_terminal = true;
-        self.state
-            .record_response_write(HttpLifecyclePhase::ServerResponseWriteError);
+        self.activate_pending_response(None);
+        if let Some(request_id) = self
+            .active_response
+            .as_ref()
+            .map(|active| active.request_id)
+        {
+            self.state.trace.record(
+                request_id,
+                HttpLifecyclePhase::ServerResponseWriteError,
+                self.state.connection,
+            );
+        }
+        self.snapshot_active_response(HttpLifecyclePhase::ServerResponseTerminalBytes);
         self.record_connection(
             HttpLifecyclePhase::ServerConnectionWriteError,
             error.raw_os_error().unwrap_or_default() as u16,
@@ -743,7 +882,7 @@ impl<T: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for TracedTestServe
     ) -> Poll<std::io::Result<usize>> {
         match Pin::new(&mut self.inner).poll_write(cx, buffer) {
             Poll::Ready(Ok(bytes)) => {
-                self.record_write_success(bytes);
+                self.record_write_success(buffer.len(), bytes);
                 Poll::Ready(Ok(bytes))
             }
             Poll::Ready(Err(error)) => {
@@ -761,7 +900,10 @@ impl<T: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for TracedTestServe
     ) -> Poll<std::io::Result<usize>> {
         match Pin::new(&mut self.inner).poll_write_vectored(cx, buffers) {
             Poll::Ready(Ok(bytes)) => {
-                self.record_write_success(bytes);
+                let offered = buffers
+                    .iter()
+                    .fold(0usize, |total, buffer| total.saturating_add(buffer.len()));
+                self.record_write_success(offered, bytes);
                 Poll::Ready(Ok(bytes))
             }
             Poll::Ready(Err(error)) => {
@@ -778,48 +920,93 @@ impl<T: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for TracedTestServe
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         match Pin::new(&mut self.inner).poll_flush(cx) {
+            Poll::Ready(Ok(())) => {
+                self.flush_pending = false;
+                self.snapshot_active_response(HttpLifecyclePhase::ServerResponseFlushBytes);
+                self.record_connection(HttpLifecyclePhase::ServerConnectionFlushOk, 0);
+                Poll::Ready(Ok(()))
+            }
             Poll::Ready(Err(error)) => {
+                self.flush_pending = false;
                 self.write_terminal = true;
-                self.state
-                    .record_response_write(HttpLifecyclePhase::ServerResponseWriteError);
+                if let Some(request_id) = self
+                    .active_response
+                    .as_ref()
+                    .map(|active| active.request_id)
+                {
+                    self.state.trace.record(
+                        request_id,
+                        HttpLifecyclePhase::ServerResponseWriteError,
+                        self.state.connection,
+                    );
+                }
+                self.snapshot_active_response(HttpLifecyclePhase::ServerResponseTerminalBytes);
+                self.record_pending_response(HttpLifecyclePhase::ServerResponseWriteError);
                 self.record_connection(
                     HttpLifecyclePhase::ServerConnectionFlushError,
                     error.raw_os_error().unwrap_or_default() as u16,
                 );
                 Poll::Ready(Err(error))
             }
-            result => result,
+            Poll::Pending => {
+                if !self.flush_pending {
+                    self.flush_pending = true;
+                    self.record_connection(HttpLifecyclePhase::ServerConnectionFlushPending, 0);
+                }
+                Poll::Pending
+            }
         }
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         match Pin::new(&mut self.inner).poll_shutdown(cx) {
             Poll::Ready(Ok(())) => {
+                self.shutdown_pending = false;
                 if !self.write_terminal {
                     self.write_terminal = true;
+                    self.snapshot_active_response(HttpLifecyclePhase::ServerResponseTerminalBytes);
+                    self.record_pending_response(HttpLifecyclePhase::ServerResponsePendingAtDrop);
                     self.record_connection(HttpLifecyclePhase::ServerConnectionShutdown, 0);
                 }
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(Err(error)) => {
+                self.shutdown_pending = false;
                 self.write_terminal = true;
-                self.state
-                    .record_response_write(HttpLifecyclePhase::ServerResponseWriteError);
+                if let Some(request_id) = self
+                    .active_response
+                    .as_ref()
+                    .map(|active| active.request_id)
+                {
+                    self.state.trace.record(
+                        request_id,
+                        HttpLifecyclePhase::ServerResponseWriteError,
+                        self.state.connection,
+                    );
+                }
+                self.snapshot_active_response(HttpLifecyclePhase::ServerResponseTerminalBytes);
+                self.record_pending_response(HttpLifecyclePhase::ServerResponseWriteError);
                 self.record_connection(
                     HttpLifecyclePhase::ServerConnectionShutdownError,
                     error.raw_os_error().unwrap_or_default() as u16,
                 );
                 Poll::Ready(Err(error))
             }
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                if !self.shutdown_pending {
+                    self.shutdown_pending = true;
+                    self.record_connection(HttpLifecyclePhase::ServerConnectionShutdownPending, 0);
+                }
+                Poll::Pending
+            }
         }
     }
 }
 
 impl<T> Drop for TracedTestServerIo<T> {
     fn drop(&mut self) {
-        self.state
-            .record_response_write(HttpLifecyclePhase::ServerResponsePendingAtDrop);
+        self.snapshot_active_response(HttpLifecyclePhase::ServerResponseTerminalBytes);
+        self.record_pending_response(HttpLifecyclePhase::ServerResponsePendingAtDrop);
         let detail = u16::from(self.saw_read)
             | (u16::from(self.saw_write) << 1)
             | (u16::from(self.read_terminal) << 2)
@@ -857,7 +1044,7 @@ fn traced_test_server_response_body<B: HttpBody>(
 }
 
 /// A transparent body observer. It never polls ahead or adds an await: every host poll is
-/// delegated exactly once, with only the first frame and the terminal outcome recorded.
+/// delegated exactly once while frame byte totals and the terminal outcome are recorded.
 struct TracedHttpBody<B: HttpBody> {
     inner: Pin<Box<B>>,
     trace: HttpLifecycleTrace,
@@ -866,6 +1053,9 @@ struct TracedHttpBody<B: HttpBody> {
     server_connection: Option<Arc<HttpConnectionState>>,
     saw_frame: bool,
     terminal: bool,
+    expected_body_bytes: Option<u64>,
+    polled_body_bytes: u64,
+    body_bytes_recorded: bool,
 }
 
 impl<B: HttpBody> TracedHttpBody<B> {
@@ -876,7 +1066,10 @@ impl<B: HttpBody> TracedHttpBody<B> {
         side: &'static str,
         server_connection: Option<Arc<HttpConnectionState>>,
     ) -> Self {
-        Self {
+        let expected_body_bytes = (side == "server-response")
+            .then(|| inner.size_hint().exact())
+            .flatten();
+        let body = Self {
             inner: Box::pin(inner),
             trace,
             request,
@@ -884,7 +1077,28 @@ impl<B: HttpBody> TracedHttpBody<B> {
             server_connection,
             saw_frame: false,
             terminal: false,
+            expected_body_bytes,
+            polled_body_bytes: 0,
+            body_bytes_recorded: false,
+        };
+        if side == "server-response" {
+            if let Some(expected) = body.expected_body_bytes {
+                record_http_byte_count(
+                    &body.trace,
+                    request,
+                    HttpLifecyclePhase::ServerResponseBodyExpectedBytes,
+                    expected,
+                    HTTP_BYTE_COUNT_EXPECTED,
+                );
+            } else {
+                body.trace.record(
+                    request,
+                    HttpLifecyclePhase::ServerResponseBodyExpectedUnknown,
+                    0,
+                );
+            }
         }
+        body
     }
 
     fn event(&self, outcome: &'static str) {
@@ -911,6 +1125,27 @@ impl<B: HttpBody> TracedHttpBody<B> {
         };
         self.trace.record(self.request, phase, 0);
     }
+
+    fn record_body_bytes(&mut self) {
+        if self.side == "server-response" && !self.body_bytes_recorded {
+            self.body_bytes_recorded = true;
+            record_http_byte_count(
+                &self.trace,
+                self.request,
+                HttpLifecyclePhase::ServerResponseBodyPolledBytes,
+                self.polled_body_bytes,
+                HTTP_BYTE_COUNT_POLLED,
+            );
+        }
+    }
+
+    fn record_terminal(&mut self, outcome: &'static str) {
+        if !self.terminal {
+            self.terminal = true;
+            self.event(outcome);
+        }
+        self.record_body_bytes();
+    }
 }
 
 impl<B: HttpBody> HttpBody for TracedHttpBody<B> {
@@ -924,6 +1159,11 @@ impl<B: HttpBody> HttpBody for TracedHttpBody<B> {
         let this = self.get_mut();
         match this.inner.as_mut().poll_frame(cx) {
             Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    this.polled_body_bytes = this
+                        .polled_body_bytes
+                        .saturating_add(data.remaining() as u64);
+                }
                 if !this.saw_frame {
                     this.saw_frame = true;
                     let outcome = if frame.is_data() {
@@ -938,16 +1178,17 @@ impl<B: HttpBody> HttpBody for TracedHttpBody<B> {
                         connection.arm_response(this.request);
                     }
                 }
+                if this.inner.as_ref().is_end_stream() {
+                    this.record_terminal("eof");
+                }
                 Poll::Ready(Some(Ok(frame)))
             }
             Poll::Ready(Some(Err(error))) => {
-                this.terminal = true;
-                this.event("error");
+                this.record_terminal("error");
                 Poll::Ready(Some(Err(error)))
             }
             Poll::Ready(None) => {
-                this.terminal = true;
-                this.event("eof");
+                this.record_terminal("eof");
                 Poll::Ready(None)
             }
             Poll::Pending => Poll::Pending,
@@ -968,6 +1209,7 @@ impl<B: HttpBody> Drop for TracedHttpBody<B> {
         if !self.terminal && !self.inner.as_ref().is_end_stream() {
             self.event("drop-before-terminal");
         }
+        self.record_body_bytes();
     }
 }
 
@@ -1559,6 +1801,7 @@ impl Drop for TestCacheLock {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
     use test_r::test;
     use tokio::io::{AsyncRead as _, AsyncReadExt as _, AsyncWrite as _, AsyncWriteExt as _};
 
@@ -1574,6 +1817,9 @@ mod tests {
     struct ScriptedIo {
         calls: Arc<ScriptedIoCalls>,
         fail_write: bool,
+        accepted_writes: VecDeque<usize>,
+        flush_pending_once: bool,
+        shutdown_pending_once: bool,
     }
 
     impl tokio::io::AsyncRead for ScriptedIo {
@@ -1590,7 +1836,7 @@ mod tests {
 
     impl tokio::io::AsyncWrite for ScriptedIo {
         fn poll_write(
-            self: Pin<&mut Self>,
+            mut self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
             buffer: &[u8],
         ) -> Poll<std::io::Result<usize>> {
@@ -1598,12 +1844,16 @@ mod tests {
             if self.fail_write {
                 Poll::Ready(Err(std::io::Error::other("scripted write failure")))
             } else {
-                Poll::Ready(Ok(buffer.len()))
+                Poll::Ready(Ok(self
+                    .accepted_writes
+                    .pop_front()
+                    .unwrap_or(buffer.len())
+                    .min(buffer.len())))
             }
         }
 
         fn poll_write_vectored(
-            self: Pin<&mut Self>,
+            mut self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
             buffers: &[std::io::IoSlice<'_>],
         ) -> Poll<std::io::Result<usize>> {
@@ -1611,7 +1861,12 @@ mod tests {
             if self.fail_write {
                 Poll::Ready(Err(std::io::Error::other("scripted write failure")))
             } else {
-                Poll::Ready(Ok(buffers.iter().map(|buffer| buffer.len()).sum()))
+                let offered = buffers.iter().map(|buffer| buffer.len()).sum();
+                Poll::Ready(Ok(self
+                    .accepted_writes
+                    .pop_front()
+                    .unwrap_or(offered)
+                    .min(offered)))
             }
         }
 
@@ -1619,13 +1874,24 @@ mod tests {
             true
         }
 
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
             self.calls.flushes.fetch_add(1, Ordering::Relaxed);
+            if std::mem::take(&mut self.flush_pending_once) {
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
             Poll::Ready(Ok(()))
         }
 
-        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
             self.calls.shutdowns.fetch_add(1, Ordering::Relaxed);
+            if std::mem::take(&mut self.shutdown_pending_once) {
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
             Poll::Ready(Ok(()))
         }
     }
@@ -1641,6 +1907,9 @@ mod tests {
             ScriptedIo {
                 calls: calls.clone(),
                 fail_write,
+                accepted_writes: VecDeque::new(),
+                flush_pending_once: false,
+                shutdown_pending_once: false,
             },
             state,
         );
@@ -1843,6 +2112,9 @@ mod tests {
             ScriptedIo {
                 calls,
                 fail_write: false,
+                accepted_writes: VecDeque::new(),
+                flush_pending_once: false,
+                shutdown_pending_once: false,
             },
             state.clone(),
         );
@@ -1863,9 +2135,161 @@ mod tests {
         let snapshot = trace.snapshot();
         assert_eq!(
             snapshot
-                .matches("request=41 phase=server-response-write-after-frame detail=9")
+                .matches("request=41 phase=server-response-write-after-frame detail=8")
                 .count(),
             1
+        );
+        assert!(snapshot.contains("request=41 phase=server-response-body-expected-bytes detail=4"));
+        assert!(snapshot.contains("request=41 phase=server-response-body-polled-bytes detail=4"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_counts_partial_and_cumulative_writes() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, calls) = scripted_connection(trace.clone(), 10, false);
+        io.inner.accepted_writes = VecDeque::from([4, 6]);
+        io.state.arm_response(44);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, b"0123456789"),
+            Poll::Ready(Ok(4))
+        ));
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, b"456789"),
+            Poll::Ready(Ok(6))
+        ));
+        assert!(matches!(
+            Pin::new(&mut io).poll_flush(&mut cx),
+            Poll::Ready(Ok(()))
+        ));
+        assert_eq!(calls.writes.load(Ordering::Relaxed), 2);
+        assert_eq!(calls.flushes.load(Ordering::Relaxed), 1);
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=44 phase=server-response-write-after-frame detail=4"));
+        assert!(snapshot.contains("request=44 phase=server-response-write-partial detail=6"));
+        assert!(snapshot.contains("request=44 phase=server-response-flush-bytes detail=10"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_records_full_accepted_write_at_terminal() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, _) = scripted_connection(trace.clone(), 11, false);
+        io.state.arm_response(54);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let response = [0; 151];
+
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, &response),
+            Poll::Ready(Ok(151))
+        ));
+        drop(io);
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=54 phase=server-response-write-after-frame detail=151"));
+        assert!(snapshot.contains("request=54 phase=server-response-terminal-bytes detail=151"));
+        assert!(!snapshot.contains("request=54 phase=server-response-write-partial"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_counters_are_independent_after_flush() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, _) = scripted_connection(trace.clone(), 12, false);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        for (request, bytes) in [(45, b"first".as_slice()), (46, b"second".as_slice())] {
+            io.state.arm_response(request);
+            assert!(Pin::new(&mut io).poll_write(&mut cx, bytes).is_ready());
+            assert!(Pin::new(&mut io).poll_flush(&mut cx).is_ready());
+        }
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=45 phase=server-response-flush-bytes detail=5"));
+        assert!(snapshot.contains("request=46 phase=server-response-flush-bytes detail=6"));
+        assert!(!snapshot.contains("server-response-correlation-boundary"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_io_records_pending_flush_and_shutdown_once() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, calls) = scripted_connection(trace.clone(), 14, false);
+        io.inner.flush_pending_once = true;
+        io.inner.shutdown_pending_once = true;
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(Pin::new(&mut io).poll_flush(&mut cx).is_pending());
+        assert!(Pin::new(&mut io).poll_flush(&mut cx).is_ready());
+        assert!(Pin::new(&mut io).poll_shutdown(&mut cx).is_pending());
+        assert!(Pin::new(&mut io).poll_shutdown(&mut cx).is_ready());
+        assert_eq!(calls.flushes.load(Ordering::Relaxed), 2);
+        assert_eq!(calls.shutdowns.load(Ordering::Relaxed), 2);
+
+        let snapshot = trace.snapshot();
+        assert_eq!(
+            snapshot.matches("server-connection-flush-pending").count(),
+            1
+        );
+        assert_eq!(snapshot.matches("server-connection-flush-ok").count(), 1);
+        assert_eq!(
+            snapshot
+                .matches("server-connection-shutdown-pending")
+                .count(),
+            1
+        );
+        assert_eq!(snapshot.matches("server-connection-shutdown").count(), 2);
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_records_unknown_and_overflow_body_sizes() {
+        let trace = HttpLifecycleTrace::new();
+        let unknown = http_body_util::StreamBody::new(futures::stream::iter([Ok::<
+            _,
+            std::convert::Infallible,
+        >(
+            Frame::data(bytes::Bytes::from_static(b"unknown")),
+        )]));
+        let mut unknown = Box::pin(TracedHttpBody::new(
+            unknown,
+            trace.clone(),
+            47,
+            "server-response",
+            None,
+        ));
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(unknown.as_mut().poll_frame(&mut cx).is_ready());
+        drop(unknown);
+
+        let overflow = http_body_util::Full::new(bytes::Bytes::from(vec![0; 70_000]));
+        let mut overflow = Box::pin(TracedHttpBody::new(
+            overflow,
+            trace.clone(),
+            48,
+            "server-response",
+            None,
+        ));
+        assert!(overflow.as_mut().poll_frame(&mut cx).is_ready());
+        drop(overflow);
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=47 phase=server-response-body-expected-unknown"));
+        assert!(snapshot.contains("request=47 phase=server-response-body-polled-bytes detail=7"));
+        assert!(
+            snapshot.contains("request=48 phase=server-response-body-expected-bytes detail=65535")
+        );
+        assert!(
+            snapshot.contains("request=48 phase=server-response-body-polled-bytes detail=65535")
+        );
+        assert_eq!(
+            snapshot
+                .matches("request=48 phase=server-response-byte-count-overflow")
+                .count(),
+            2
         );
     }
 
@@ -1884,6 +2308,38 @@ mod tests {
         let snapshot = trace.snapshot();
         assert!(snapshot.contains("request=42 phase=server-response-write-error detail=11"));
         assert!(snapshot.contains("request=11 phase=server-connection-write-error"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_error_and_drop_snapshot_accepted_bytes() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, _) = scripted_connection(trace.clone(), 15, false);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        io.state.arm_response(49);
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, b"abc"),
+            Poll::Ready(Ok(3))
+        ));
+        io.inner.fail_write = true;
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, b"failure"),
+            Poll::Ready(Err(_))
+        ));
+
+        let (mut dropped, _) = scripted_connection(trace.clone(), 16, false);
+        dropped.state.arm_response(50);
+        assert!(matches!(
+            Pin::new(&mut dropped).poll_write(&mut cx, b"drop"),
+            Poll::Ready(Ok(4))
+        ));
+        drop(dropped);
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=49 phase=server-response-terminal-bytes detail=3"));
+        assert!(snapshot.contains("request=49 phase=server-response-write-error detail=15"));
+        assert!(snapshot.contains("request=50 phase=server-response-terminal-bytes detail=4"));
     }
 
     #[test]
@@ -1924,6 +2380,28 @@ mod tests {
         assert!(
             snapshot.contains("request=62 phase=server-response-correlation-overlap detail=61")
         );
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_boundary_without_flush_is_explicit() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, _) = scripted_connection(trace.clone(), 20, false);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        io.state.arm_response(63);
+        assert!(Pin::new(&mut io).poll_write(&mut cx, b"one").is_ready());
+        io.state.arm_response(64);
+        assert!(Pin::new(&mut io).poll_write(&mut cx, b"two").is_ready());
+
+        let snapshot = trace.snapshot();
+        assert!(
+            snapshot.contains("request=63 phase=server-response-write-boundary-bytes detail=3")
+        );
+        assert!(
+            snapshot.contains("request=63 phase=server-response-correlation-boundary detail=64")
+        );
+        assert!(snapshot.contains("request=64 phase=server-response-write-after-frame detail=3"));
     }
 
     #[test]
@@ -1993,8 +2471,15 @@ mod tests {
             assert!(snapshot.contains(&format!(
                 "request={request_id} phase=server-response-write-after-frame"
             )));
+            assert!(snapshot.contains(&format!(
+                "request={request_id} phase=server-response-body-expected-bytes detail=2"
+            )));
+            assert!(snapshot.contains(&format!(
+                "request={request_id} phase=server-response-body-polled-bytes detail=2"
+            )));
         }
         assert!(!snapshot.contains("server-response-correlation-overlap"));
+        assert!(!snapshot.contains("server-response-correlation-boundary"));
     }
 
     #[cfg(feature = "use-golem-wasmtime")]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -251,6 +251,7 @@ static HOST_TRACE: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 const HOST_TRACE_CAP: usize = 256 * 1024;
 static NEXT_HTTP_TRACE_INVOCATION: AtomicUsize = AtomicUsize::new(1);
 static NEXT_HTTP_TRACE_REQUEST: AtomicUsize = AtomicUsize::new(1);
+static NEXT_HTTP_TRACE_CONNECTION: AtomicUsize = AtomicUsize::new(1);
 static TEST_SERVER_HTTP_TRACE: OnceLock<HttpLifecycleTrace> = OnceLock::new();
 const HTTP_LIFECYCLE_CAP: usize = 256;
 const HTTP_LIFECYCLE_SEQUENCE_MASK: u64 = 0x00ff_ffff;
@@ -287,6 +288,20 @@ enum HttpLifecyclePhase {
     ServerResponseDrop = 26,
     TargetPath = 27,
     ServerPort = 28,
+    ServerConnectionAccept = 29,
+    ServerRequestConnection = 30,
+    ServerConnectionFirstRead = 31,
+    ServerConnectionReadEof = 32,
+    ServerConnectionReadError = 33,
+    ServerConnectionFirstWrite = 34,
+    ServerConnectionWriteError = 35,
+    ServerConnectionFlushError = 36,
+    ServerConnectionShutdown = 37,
+    ServerConnectionShutdownError = 38,
+    ServerConnectionDrop = 39,
+    ServerResponseWriteAfterFrame = 40,
+    ServerResponseWriteError = 41,
+    ServerResponsePendingAtDrop = 42,
 }
 
 impl HttpLifecyclePhase {
@@ -320,6 +335,20 @@ impl HttpLifecyclePhase {
             26 => "server-response-drop-before-terminal",
             27 => "target-path-hash",
             28 => "server-port",
+            29 => "server-connection-accept",
+            30 => "server-request-connection",
+            31 => "server-connection-first-read",
+            32 => "server-connection-read-eof",
+            33 => "server-connection-read-error",
+            34 => "server-connection-first-write",
+            35 => "server-connection-write-error",
+            36 => "server-connection-flush-error",
+            37 => "server-connection-shutdown",
+            38 => "server-connection-shutdown-error",
+            39 => "server-connection-drop",
+            40 => "server-response-write-after-frame",
+            41 => "server-response-write-error",
+            42 => "server-response-pending-at-drop",
             _ => "unknown",
         }
     }
@@ -508,12 +537,310 @@ fn record_test_server_response_head(request_id: usize, status: http::StatusCode)
     );
 }
 
+fn record_test_server_connection(
+    request_id: usize,
+    connection: Option<&TracedTestServerConnection>,
+) {
+    if let Some(connection) = connection {
+        connection.state.trace.record(
+            request_id,
+            HttpLifecyclePhase::ServerRequestConnection,
+            connection.state.connection,
+        );
+    }
+}
+
+pub(crate) fn traced_test_server_listener(
+    listener: tokio::net::TcpListener,
+) -> TracedTestServerListener {
+    TracedTestServerListener {
+        listener,
+        trace: test_server_http_trace().clone(),
+    }
+}
+
+pub(crate) struct TracedTestServerListener {
+    listener: tokio::net::TcpListener,
+    trace: HttpLifecycleTrace,
+}
+
+impl axum::serve::Listener for TracedTestServerListener {
+    type Io = TracedTestServerIo<tokio::net::TcpStream>;
+    type Addr = std::net::SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        let (stream, peer) =
+            <tokio::net::TcpListener as axum::serve::Listener>::accept(&mut self.listener).await;
+        let connection = (NEXT_HTTP_TRACE_CONNECTION.fetch_add(1, Ordering::Relaxed)
+            % usize::from(u16::MAX))
+            + 1;
+        let state = Arc::new(HttpConnectionState::new(
+            self.trace.clone(),
+            connection as u16,
+        ));
+        self.trace.record(
+            connection,
+            HttpLifecyclePhase::ServerConnectionAccept,
+            peer.port(),
+        );
+        (TracedTestServerIo::new(stream, state), peer)
+    }
+
+    fn local_addr(&self) -> std::io::Result<Self::Addr> {
+        self.listener.local_addr()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TracedTestServerConnection {
+    state: Arc<HttpConnectionState>,
+}
+
+impl
+    axum::extract::connect_info::Connected<
+        axum::serve::IncomingStream<'_, TracedTestServerListener>,
+    > for TracedTestServerConnection
+{
+    fn connect_info(target: axum::serve::IncomingStream<'_, TracedTestServerListener>) -> Self {
+        Self {
+            state: target.io().state.clone(),
+        }
+    }
+}
+
+struct HttpConnectionState {
+    trace: HttpLifecycleTrace,
+    connection: u16,
+    pending_response: AtomicUsize,
+}
+
+impl HttpConnectionState {
+    fn new(trace: HttpLifecycleTrace, connection: u16) -> Self {
+        Self {
+            trace,
+            connection,
+            pending_response: AtomicUsize::new(0),
+        }
+    }
+
+    fn arm_response(&self, request_id: usize) {
+        self.pending_response.store(request_id, Ordering::Release);
+    }
+
+    fn record_response_write(&self, phase: HttpLifecyclePhase) {
+        let request_id = self.pending_response.swap(0, Ordering::AcqRel);
+        if request_id != 0 {
+            self.trace.record(request_id, phase, self.connection);
+        }
+    }
+}
+
+pub(crate) struct TracedTestServerIo<T> {
+    inner: T,
+    state: Arc<HttpConnectionState>,
+    saw_read: bool,
+    saw_write: bool,
+    read_terminal: bool,
+    write_terminal: bool,
+}
+
+impl<T> TracedTestServerIo<T> {
+    fn new(inner: T, state: Arc<HttpConnectionState>) -> Self {
+        Self {
+            inner,
+            state,
+            saw_read: false,
+            saw_write: false,
+            read_terminal: false,
+            write_terminal: false,
+        }
+    }
+
+    fn record_connection(&self, phase: HttpLifecyclePhase, detail: u16) {
+        self.state
+            .trace
+            .record(usize::from(self.state.connection), phase, detail);
+    }
+
+    fn record_write_success(&mut self, bytes: usize) {
+        if !self.saw_write {
+            self.saw_write = true;
+            self.record_connection(
+                HttpLifecyclePhase::ServerConnectionFirstWrite,
+                bytes.min(usize::from(u16::MAX)) as u16,
+            );
+        }
+        if bytes != 0 {
+            self.state
+                .record_response_write(HttpLifecyclePhase::ServerResponseWriteAfterFrame);
+        }
+    }
+
+    fn record_write_error(&mut self, error: &std::io::Error) {
+        self.write_terminal = true;
+        self.state
+            .record_response_write(HttpLifecyclePhase::ServerResponseWriteError);
+        self.record_connection(
+            HttpLifecyclePhase::ServerConnectionWriteError,
+            error.raw_os_error().unwrap_or_default() as u16,
+        );
+    }
+}
+
+impl<T: tokio::io::AsyncRead + Unpin> tokio::io::AsyncRead for TracedTestServerIo<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let filled_before = buffer.filled().len();
+        match Pin::new(&mut self.inner).poll_read(cx, buffer) {
+            Poll::Ready(Ok(())) => {
+                let bytes = buffer.filled().len().saturating_sub(filled_before);
+                if bytes != 0 && !self.saw_read {
+                    self.saw_read = true;
+                    self.record_connection(
+                        HttpLifecyclePhase::ServerConnectionFirstRead,
+                        bytes.min(usize::from(u16::MAX)) as u16,
+                    );
+                } else if bytes == 0 && !self.read_terminal {
+                    self.read_terminal = true;
+                    self.record_connection(HttpLifecyclePhase::ServerConnectionReadEof, 0);
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(error)) => {
+                self.read_terminal = true;
+                self.record_connection(
+                    HttpLifecyclePhase::ServerConnectionReadError,
+                    error.raw_os_error().unwrap_or_default() as u16,
+                );
+                Poll::Ready(Err(error))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for TracedTestServerIo<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        match Pin::new(&mut self.inner).poll_write(cx, buffer) {
+            Poll::Ready(Ok(bytes)) => {
+                self.record_write_success(bytes);
+                Poll::Ready(Ok(bytes))
+            }
+            Poll::Ready(Err(error)) => {
+                self.record_write_error(&error);
+                Poll::Ready(Err(error))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffers: &[std::io::IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        match Pin::new(&mut self.inner).poll_write_vectored(cx, buffers) {
+            Poll::Ready(Ok(bytes)) => {
+                self.record_write_success(bytes);
+                Poll::Ready(Ok(bytes))
+            }
+            Poll::Ready(Err(error)) => {
+                self.record_write_error(&error);
+                Poll::Ready(Err(error))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match Pin::new(&mut self.inner).poll_flush(cx) {
+            Poll::Ready(Err(error)) => {
+                self.write_terminal = true;
+                self.state
+                    .record_response_write(HttpLifecyclePhase::ServerResponseWriteError);
+                self.record_connection(
+                    HttpLifecyclePhase::ServerConnectionFlushError,
+                    error.raw_os_error().unwrap_or_default() as u16,
+                );
+                Poll::Ready(Err(error))
+            }
+            result => result,
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        match Pin::new(&mut self.inner).poll_shutdown(cx) {
+            Poll::Ready(Ok(())) => {
+                if !self.write_terminal {
+                    self.write_terminal = true;
+                    self.record_connection(HttpLifecyclePhase::ServerConnectionShutdown, 0);
+                }
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(error)) => {
+                self.write_terminal = true;
+                self.state
+                    .record_response_write(HttpLifecyclePhase::ServerResponseWriteError);
+                self.record_connection(
+                    HttpLifecyclePhase::ServerConnectionShutdownError,
+                    error.raw_os_error().unwrap_or_default() as u16,
+                );
+                Poll::Ready(Err(error))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<T> Drop for TracedTestServerIo<T> {
+    fn drop(&mut self) {
+        self.state
+            .record_response_write(HttpLifecyclePhase::ServerResponsePendingAtDrop);
+        let detail = u16::from(self.saw_read)
+            | (u16::from(self.saw_write) << 1)
+            | (u16::from(self.read_terminal) << 2)
+            | (u16::from(self.write_terminal) << 3);
+        self.record_connection(HttpLifecyclePhase::ServerConnectionDrop, detail);
+    }
+}
+
 fn traced_test_server_body<B: HttpBody>(
     body: B,
     request_id: usize,
     side: &'static str,
 ) -> TracedHttpBody<B> {
-    TracedHttpBody::new(body, test_server_http_trace().clone(), request_id, side)
+    TracedHttpBody::new(
+        body,
+        test_server_http_trace().clone(),
+        request_id,
+        side,
+        None,
+    )
+}
+
+fn traced_test_server_response_body<B: HttpBody>(
+    body: B,
+    request_id: usize,
+    connection: Option<TracedTestServerConnection>,
+) -> TracedHttpBody<B> {
+    TracedHttpBody::new(
+        body,
+        test_server_http_trace().clone(),
+        request_id,
+        "server-response",
+        connection.map(|connection| connection.state),
+    )
 }
 
 /// A transparent body observer. It never polls ahead or adds an await: every host poll is
@@ -523,17 +850,25 @@ struct TracedHttpBody<B: HttpBody> {
     trace: HttpLifecycleTrace,
     request: usize,
     side: &'static str,
+    server_connection: Option<Arc<HttpConnectionState>>,
     saw_frame: bool,
     terminal: bool,
 }
 
 impl<B: HttpBody> TracedHttpBody<B> {
-    fn new(inner: B, trace: HttpLifecycleTrace, request: usize, side: &'static str) -> Self {
+    fn new(
+        inner: B,
+        trace: HttpLifecycleTrace,
+        request: usize,
+        side: &'static str,
+        server_connection: Option<Arc<HttpConnectionState>>,
+    ) -> Self {
         Self {
             inner: Box::pin(inner),
             trace,
             request,
             side,
+            server_connection,
             saw_frame: false,
             terminal: false,
         }
@@ -578,11 +913,17 @@ impl<B: HttpBody> HttpBody for TracedHttpBody<B> {
             Poll::Ready(Some(Ok(frame))) => {
                 if !this.saw_frame {
                     this.saw_frame = true;
-                    this.event(if frame.is_data() {
+                    let outcome = if frame.is_data() {
                         "first-data"
                     } else {
                         "first-trailers"
-                    });
+                    };
+                    this.event(outcome);
+                    if outcome == "first-data"
+                        && let Some(connection) = &this.server_connection
+                    {
+                        connection.arm_response(this.request);
+                    }
                 }
                 Poll::Ready(Some(Ok(frame)))
             }
@@ -641,7 +982,8 @@ fn trace_p2_result(
             let (parts, body) = incoming.resp.into_parts();
             incoming.resp = http::Response::from_parts(
                 parts,
-                TracedHttpBody::new(body, trace.clone(), request_id, "response").boxed_unsync(),
+                TracedHttpBody::new(body, trace.clone(), request_id, "response", None)
+                    .boxed_unsync(),
             );
             Ok(incoming)
         }
@@ -686,7 +1028,7 @@ impl wasmtime_wasi_http::p2::WasiHttpHooks for P2HttpTraceHooks {
         let (parts, body) = request.into_parts();
         let request = http::Request::from_parts(
             parts,
-            TracedHttpBody::new(body, trace.clone(), request_id, "request").boxed_unsync(),
+            TracedHttpBody::new(body, trace.clone(), request_id, "request", None).boxed_unsync(),
         );
         let handle = wasmtime_wasi::runtime::spawn(async move {
             let result =
@@ -713,7 +1055,7 @@ impl wasmtime_wasi_http::p2::WasiHttpHooks for P2HttpTraceHooks {
         let (parts, body) = request.into_parts();
         let request = http::Request::from_parts(
             parts,
-            TracedHttpBody::new(body, trace.clone(), request_id, "request").boxed_unsync(),
+            TracedHttpBody::new(body, trace.clone(), request_id, "request", None).boxed_unsync(),
         );
         let handle = wasmtime_wasi::runtime::spawn(async move {
             let request = if collect_before_send {
@@ -804,7 +1146,7 @@ impl wasmtime_wasi_http::p3::WasiHttpHooks for P3HttpTraceHooks {
         let (parts, body) = request.into_parts();
         let request = http::Request::from_parts(
             parts,
-            TracedHttpBody::new(body, trace.clone(), request_id, "request").boxed_unsync(),
+            TracedHttpBody::new(body, trace.clone(), request_id, "request", None).boxed_unsync(),
         );
 
         Box::new(async move {
@@ -824,7 +1166,8 @@ impl wasmtime_wasi_http::p3::WasiHttpHooks for P3HttpTraceHooks {
             let (parts, body) = response.into_parts();
             let response = http::Response::from_parts(
                 parts,
-                TracedHttpBody::new(body, trace.clone(), request_id, "response").boxed_unsync(),
+                TracedHttpBody::new(body, trace.clone(), request_id, "response", None)
+                    .boxed_unsync(),
             );
             let io_trace = trace.clone();
             let io = Box::new(async move {
@@ -1204,6 +1547,92 @@ impl Drop for TestCacheLock {
 mod tests {
     use super::*;
     use test_r::test;
+    use tokio::io::{AsyncRead as _, AsyncWrite as _};
+
+    #[derive(Default)]
+    struct ScriptedIoCalls {
+        reads: AtomicUsize,
+        writes: AtomicUsize,
+        vectored_writes: AtomicUsize,
+        flushes: AtomicUsize,
+        shutdowns: AtomicUsize,
+    }
+
+    struct ScriptedIo {
+        calls: Arc<ScriptedIoCalls>,
+        fail_write: bool,
+    }
+
+    impl tokio::io::AsyncRead for ScriptedIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buffer: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            self.calls.reads.fetch_add(1, Ordering::Relaxed);
+            buffer.put_slice(b"r");
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl tokio::io::AsyncWrite for ScriptedIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buffer: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.calls.writes.fetch_add(1, Ordering::Relaxed);
+            if self.fail_write {
+                Poll::Ready(Err(std::io::Error::other("scripted write failure")))
+            } else {
+                Poll::Ready(Ok(buffer.len()))
+            }
+        }
+
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buffers: &[std::io::IoSlice<'_>],
+        ) -> Poll<std::io::Result<usize>> {
+            self.calls.vectored_writes.fetch_add(1, Ordering::Relaxed);
+            if self.fail_write {
+                Poll::Ready(Err(std::io::Error::other("scripted write failure")))
+            } else {
+                Poll::Ready(Ok(buffers.iter().map(|buffer| buffer.len()).sum()))
+            }
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            true
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            self.calls.flushes.fetch_add(1, Ordering::Relaxed);
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            self.calls.shutdowns.fetch_add(1, Ordering::Relaxed);
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn scripted_connection(
+        trace: HttpLifecycleTrace,
+        connection: u16,
+        fail_write: bool,
+    ) -> (TracedTestServerIo<ScriptedIo>, Arc<ScriptedIoCalls>) {
+        let calls = Arc::new(ScriptedIoCalls::default());
+        let state = Arc::new(HttpConnectionState::new(trace, connection));
+        let io = TracedTestServerIo::new(
+            ScriptedIo {
+                calls: calls.clone(),
+                fail_write,
+            },
+            state,
+        );
+        (io, calls)
+    }
 
     #[test]
     fn http_lifecycle_ring_rejects_delayed_old_generation() {
@@ -1285,7 +1714,7 @@ mod tests {
     fn http_lifecycle_empty_body_drop_is_terminal() {
         let trace = HttpLifecycleTrace::new();
         let body = http_body_util::Empty::<bytes::Bytes>::new();
-        drop(TracedHttpBody::new(body, trace.clone(), 1, "request"));
+        drop(TracedHttpBody::new(body, trace.clone(), 1, "request", None));
 
         let snapshot = trace.snapshot();
         assert!(!snapshot.contains("drop-before-terminal"));
@@ -1330,6 +1759,144 @@ mod tests {
         let snapshot = test_server_http_trace().snapshot();
         assert!(snapshot.contains("request=41 phase=server-arrival"));
         assert!(snapshot.contains("request=42 phase=server-arrival"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_io_delegates_each_poll_once() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, calls) = scripted_connection(trace.clone(), 7, false);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut storage = [0; 4];
+        let mut read = tokio::io::ReadBuf::new(&mut storage);
+        assert!(Pin::new(&mut io).poll_read(&mut cx, &mut read).is_ready());
+        assert_eq!(read.filled(), b"r");
+        assert_eq!(calls.reads.load(Ordering::Relaxed), 1);
+
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, b"abc"),
+            Poll::Ready(Ok(3))
+        ));
+        assert_eq!(calls.writes.load(Ordering::Relaxed), 1);
+
+        let buffers = [std::io::IoSlice::new(b"d"), std::io::IoSlice::new(b"ef")];
+        assert!(matches!(
+            Pin::new(&mut io).poll_write_vectored(&mut cx, &buffers),
+            Poll::Ready(Ok(3))
+        ));
+        assert_eq!(calls.vectored_writes.load(Ordering::Relaxed), 1);
+        assert!(io.is_write_vectored());
+
+        assert!(matches!(
+            Pin::new(&mut io).poll_flush(&mut cx),
+            Poll::Ready(Ok(()))
+        ));
+        assert_eq!(calls.flushes.load(Ordering::Relaxed), 1);
+        assert!(matches!(
+            Pin::new(&mut io).poll_shutdown(&mut cx),
+            Poll::Ready(Ok(()))
+        ));
+        assert_eq!(calls.shutdowns.load(Ordering::Relaxed), 1);
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=7 phase=server-connection-first-read detail=1"));
+        assert!(snapshot.contains("request=7 phase=server-connection-first-write detail=3"));
+        assert!(snapshot.contains("request=7 phase=server-connection-shutdown"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_frame_arms_exactly_one_correlated_write() {
+        let trace = HttpLifecycleTrace::new();
+        let state = Arc::new(HttpConnectionState::new(trace.clone(), 9));
+        let body = http_body_util::Full::new(bytes::Bytes::from_static(b"body"));
+        let mut body = Box::pin(TracedHttpBody::new(
+            body,
+            trace.clone(),
+            41,
+            "server-response",
+            Some(state.clone()),
+        ));
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(
+            body.as_mut().poll_frame(&mut cx),
+            Poll::Ready(Some(Ok(_)))
+        ));
+        assert_eq!(state.pending_response.load(Ordering::Acquire), 41);
+
+        let calls = Arc::new(ScriptedIoCalls::default());
+        let mut io = TracedTestServerIo::new(
+            ScriptedIo {
+                calls,
+                fail_write: false,
+            },
+            state.clone(),
+        );
+        let buffers = [
+            std::io::IoSlice::new(b"head"),
+            std::io::IoSlice::new(b"body"),
+        ];
+        assert!(matches!(
+            Pin::new(&mut io).poll_write_vectored(&mut cx, &buffers),
+            Poll::Ready(Ok(8))
+        ));
+        assert_eq!(state.pending_response.load(Ordering::Acquire), 0);
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, b"later"),
+            Poll::Ready(Ok(5))
+        ));
+
+        let snapshot = trace.snapshot();
+        assert_eq!(
+            snapshot
+                .matches("request=41 phase=server-response-write-after-frame detail=9")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn http_lifecycle_server_response_write_error_preserves_correlation() {
+        let trace = HttpLifecycleTrace::new();
+        let (mut io, _) = scripted_connection(trace.clone(), 11, true);
+        io.state.arm_response(42);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(
+            Pin::new(&mut io).poll_write(&mut cx, b"response"),
+            Poll::Ready(Err(_))
+        ));
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=42 phase=server-response-write-error detail=11"));
+        assert!(snapshot.contains("request=11 phase=server-connection-write-error"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_connection_drop_reports_armed_response() {
+        let trace = HttpLifecycleTrace::new();
+        let (io, _) = scripted_connection(trace.clone(), 13, false);
+        io.state.arm_response(43);
+        drop(io);
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=43 phase=server-response-pending-at-drop detail=13"));
+        assert!(snapshot.contains("request=13 phase=server-connection-drop"));
+    }
+
+    #[test]
+    fn http_lifecycle_server_connection_maps_multiple_requests_without_conflation() {
+        let trace = HttpLifecycleTrace::new();
+        let connection = TracedTestServerConnection {
+            state: Arc::new(HttpConnectionState::new(trace.clone(), 17)),
+        };
+        record_test_server_connection(51, Some(&connection));
+        record_test_server_connection(52, Some(&connection));
+
+        let snapshot = trace.snapshot();
+        assert!(snapshot.contains("request=51 phase=server-request-connection detail=17"));
+        assert!(snapshot.contains("request=52 phase=server-request-connection detail=17"));
     }
 
     #[cfg(feature = "use-golem-wasmtime")]

--- a/tests/common/test_server.rs
+++ b/tests/common/test_server.rs
@@ -1,6 +1,6 @@
 use axum::body::Body;
 use axum::extract::Request;
-use axum::extract::{Multipart, Path};
+use axum::extract::{ConnectInfo, Multipart, Path};
 use axum::http::HeaderMap;
 use axum::middleware::Next;
 use axum::response::{AppendHeaders, IntoResponse};
@@ -34,7 +34,13 @@ fn trace_http_lifecycle(router: Router, port: u16) -> Router {
     router.layer(axum::middleware::from_fn(
         move |request: Request, next: Next| async move {
             let request_id = super::test_server_http_correlation(request.headers());
+            let connection = request
+                .extensions()
+                .get::<ConnectInfo<super::TracedTestServerConnection>>()
+                .map(|connection| connection.0.clone());
+            let trace_response_write = request.version() == http::Version::HTTP_11;
             super::record_test_server_arrival(request_id, port, request.uri());
+            super::record_test_server_connection(request_id, connection.as_ref());
             let (parts, body) = request.into_parts();
             let request = Request::from_parts(
                 parts,
@@ -49,10 +55,10 @@ fn trace_http_lifecycle(router: Router, port: u16) -> Router {
             let (parts, body) = response.into_parts();
             axum::response::Response::from_parts(
                 parts,
-                Body::new(super::traced_test_server_body(
+                Body::new(super::traced_test_server_response_body(
                     body,
                     request_id,
-                    "server-response",
+                    trace_response_write.then_some(connection).flatten(),
                 )),
             )
         },
@@ -260,7 +266,13 @@ pub async fn start_test_server() -> (u16, TestServerHandle) {
             );
         let router = trace_http_lifecycle(router, host_http_port);
 
-        axum::serve(listener, router).await.unwrap();
+        let listener = super::traced_test_server_listener(listener);
+        axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<super::TracedTestServerConnection>(),
+        )
+        .await
+        .unwrap();
     });
 
     (host_http_port, TestServerHandle::new(handle))
@@ -296,7 +308,13 @@ pub async fn start_abort_test_server() -> (u16, TestServerHandle, mpsc::Unbounde
             )
             .route("/abort-ready", ready);
         let router = trace_http_lifecycle(router, port);
-        axum::serve(listener, router).await.unwrap();
+        let listener = super::traced_test_server_listener(listener);
+        axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<super::TracedTestServerConnection>(),
+        )
+        .await
+        .unwrap();
     });
 
     (port, TestServerHandle::new(handle), arrived_rx)


### PR DESCRIPTION
- extends GOL-420 transport diagnostics from guest/server body polling to the passive Axum socket boundary
- correlates each request with its accepted server connection and records socket read, write, error, shutdown, and drop outcomes without extra polls or awaits
- preserves pending response ownership with explicit overlap evidence instead of silently conflating pipelined requests
- validates real HTTP/1.1 pipelining through Axum ConnectInfo, Hyper body polling, and the wrapped AsyncWrite path
- keeps GOL-405 separate; this branch adds evidence only and does not retry, serialize, inflate timeouts, or change production transport behavior