### PR TITLE
Stream and cancel P3 fetch response bodies

### DIFF
--- a/crates/wasm-rquickjs/skeleton/Cargo.toml_
+++ b/crates/wasm-rquickjs/skeleton/Cargo.toml_
@@ -29,6 +29,7 @@ p2 = ["dep:wit-bindgen", "dep:wit-bindgen-rt", "dep:wasip2", "dep:wstd", "golem-
 # `rt.drive()` scheduler driver). P3 components import the residual P2 WASI surface for `std`
 # anyway, so this adds no new host requirements.
 p3 = ["dep:wit-bindgen-p3", "dep:wasip3", "dep:wasip2", "dep:http", "golem-websocket?/p3"]
+internal-test-execution = []
 
 # Tier meta-features (cumulative). All Preview 2 tiers, since the Node.js builtin set they
 # enable is only compiled in the `p2` path.

--- a/crates/wasm-rquickjs/skeleton/src/builtin/abort_signal.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/abort_signal.rs
@@ -2,20 +2,6 @@ use futures::future::{AbortHandle, Abortable};
 use rquickjs::function::This;
 use rquickjs::{Ctx, Persistent, Value};
 
-pub(crate) fn ensure_not_aborted<'js>(
-    ctx: &Ctx<'js>,
-    signal: Option<&Value<'js>>,
-) -> rquickjs::Result<()> {
-    let Some(signal) = signal.filter(|signal| !signal.is_undefined() && !signal.is_null()) else {
-        return Ok(());
-    };
-    let signal = rquickjs::Object::from_value(signal.clone())?;
-    if signal.get::<_, bool>("aborted")? {
-        return Err(ctx.throw(signal.get::<_, Value<'js>>("reason")?));
-    }
-    Ok(())
-}
-
 pub(crate) async fn with_abort_signal<'js, F, T>(
     ctx: &Ctx<'js>,
     signal: Option<Value<'js>>,

--- a/crates/wasm-rquickjs/skeleton/src/builtin/abort_signal.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/abort_signal.rs
@@ -2,6 +2,20 @@ use futures::future::{AbortHandle, Abortable};
 use rquickjs::function::This;
 use rquickjs::{Ctx, Persistent, Value};
 
+pub(crate) fn ensure_not_aborted<'js>(
+    ctx: &Ctx<'js>,
+    signal: Option<&Value<'js>>,
+) -> rquickjs::Result<()> {
+    let Some(signal) = signal.filter(|signal| !signal.is_undefined() && !signal.is_null()) else {
+        return Ok(());
+    };
+    let signal = rquickjs::Object::from_value(signal.clone())?;
+    if signal.get::<_, bool>("aborted")? {
+        return Err(ctx.throw(signal.get::<_, Value<'js>>("reason")?));
+    }
+    Ok(())
+}
+
 pub(crate) async fn with_abort_signal<'js, F, T>(
     ctx: &Ctx<'js>,
     signal: Option<Value<'js>>,

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -454,7 +454,9 @@ async function streamingRequest(
 }
 
 function responseAbortReason(signal) {
-    return signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+    return signal?.aborted
+        ? signal.reason
+        : new DOMException('The operation was aborted.', 'AbortError');
 }
 
 export class Response {
@@ -469,15 +471,23 @@ export class Response {
             this._isNative = true;
             this._signal = signal;
             this._abortBodyListener = undefined;
+            this._bodyStream = undefined;
+            this._nativeBodyState = {source: undefined, controller: undefined};
             if (signal?.aborted) {
                 this.nativeResponse.discardBody();
             } else if (signal) {
                 const responseRef = new WeakRef(this);
                 this._abortBodyListener = () => {
                     const response = responseRef.deref();
-                    // Rust owns cancellation once consumption starts. This hook only releases an
-                    // unread body, which otherwise has no active native future to cancel.
-                    if (response && !response.bodyUsed) response.nativeResponse.discardBody();
+                    if (!response) return;
+                    const bodyState = response._nativeBodyState;
+                    if (bodyState.source) {
+                        bodyState.source.discard();
+                    } else if (!response.bodyUsed) {
+                        response.nativeResponse.discardBody();
+                    }
+                    bodyState.controller?.error(responseAbortReason(signal));
+                    response._detachAbortBodyListener();
                 };
                 signal.addEventListener('abort', this._abortBodyListener, {once: true});
             }
@@ -523,12 +533,12 @@ export class Response {
 
     get body() {
         if (this._isNative) {
-            let nativeStreamSourceSlot = {
-                nativeStreamSource: undefined
-            };
+            if (this._bodyStream !== undefined) return this._bodyStream;
             let response = this;
-            return new ReadableStream({
-                start() {
+            const bodyState = this._nativeBodyState;
+            this._bodyStream = new ReadableStream({
+                start(controller) {
+                    bodyState.controller = controller;
                 },
                 get type() {
                     return "bytes";
@@ -536,16 +546,17 @@ export class Response {
                 async pull(controller) {
                     response.bodyUsed = true;
                     if (response._signal?.aborted) throw responseAbortReason(response._signal);
-                    if (nativeStreamSourceSlot.nativeStreamSource === undefined) {
-                        nativeStreamSourceSlot.nativeStreamSource = response.nativeResponse.stream();
+                    if (bodyState.source === undefined) {
+                        bodyState.source = response.nativeResponse.stream();
                     }
 
                     let next;
                     let err;
                     try {
-                        [next, err] = await nativeStreamSourceSlot.nativeStreamSource.pull(response._signal);
+                        [next, err] = await bodyState.source.pull();
                     } catch (error) {
                         response._detachAbortBodyListener();
+                        if (response._signal?.aborted) throw responseAbortReason(response._signal);
                         throw error;
                     }
                     if (err !== undefined) {
@@ -558,8 +569,18 @@ export class Response {
                     } else {
                         controller.enqueue(next);
                     }
+                },
+                cancel() {
+                    response.bodyUsed = true;
+                    if (bodyState.source) {
+                        bodyState.source.discard();
+                    } else {
+                        response.nativeResponse.discardBody();
+                    }
+                    response._detachAbortBodyListener();
                 }
             });
+            return this._bodyStream;
         }
 
         if (this._body === null) {

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -472,7 +472,7 @@ export class Response {
             this._bodyStream = undefined;
             this._nativeBodyState = {source: undefined, controller: undefined};
             this._nativeBodyGroup = nativeBodyGroup || {active: 1, cancelWaiters: []};
-            this._nativeBodyBranchFinished = false;
+            this._nativeBodyBranchFinished = this._nativeBodyGroup.terminal === true;
             if (signal?.aborted) {
                 this.nativeResponse.discardBody();
                 this._finishNativeBodyBranch();
@@ -523,10 +523,21 @@ export class Response {
         if (!this._isNative || this._nativeBodyBranchFinished) return;
         this._nativeBodyBranchFinished = true;
         const group = this._nativeBodyGroup;
+        if (group.terminal) return;
         group.active--;
         if (group.active === 0) {
             for (const resolve of group.cancelWaiters.splice(0)) resolve();
         }
+    }
+
+    _finishNativeBodyGroup() {
+        if (!this._isNative) return;
+        this._nativeBodyBranchFinished = true;
+        const group = this._nativeBodyGroup;
+        if (group.terminal) return;
+        group.terminal = true;
+        group.active = 0;
+        for (const resolve of group.cancelWaiters.splice(0)) resolve();
     }
 
     _cancelNativeBodyBranch() {
@@ -575,13 +586,13 @@ export class Response {
                         [next, err] = await bodyState.source.pull();
                     } catch (error) {
                         response._detachAbortBodyListener();
-                        response._finishNativeBodyBranch();
+                        response._finishNativeBodyGroup();
                         if (response._signal?.aborted) throw responseAbortReason(response._signal);
                         throw error;
                     }
                     if (err !== undefined) {
                         response._detachAbortBodyListener();
-                        response._finishNativeBodyBranch();
+                        response._finishNativeBodyGroup();
                         console.error("Error reading response body stream:", err);
                         controller.error(err);
                     } else if (next === undefined) {
@@ -730,7 +741,7 @@ export class Response {
 
         if (this._isNative) {
             const nativeClone = this.nativeResponse.clone();
-            this._nativeBodyGroup.active++;
+            if (!this._nativeBodyGroup.terminal) this._nativeBodyGroup.active++;
             return new Response(
                 nativeClone,
                 this.url,
@@ -780,6 +791,7 @@ export class Response {
             try {
                 return await this.nativeResponse.arrayBuffer(this._signal);
             } catch (error) {
+                if (!this._signal?.aborted) this._finishNativeBodyGroup();
                 if (this._signal?.aborted) throw responseAbortReason(this._signal);
                 throw error;
             } finally {
@@ -845,6 +857,7 @@ export class Response {
             try {
                 return await this.nativeResponse.text(this._signal);
             } catch (error) {
+                if (!this._signal?.aborted) this._finishNativeBodyGroup();
                 if (this._signal?.aborted) throw responseAbortReason(this._signal);
                 throw error;
             } finally {

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -454,11 +454,11 @@ async function streamingRequest(
 }
 
 function responseAbortReason(signal) {
-    return signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+    return signal?.reason || new DOMException('The operation was aborted.', 'AbortError');
 }
 
 export class Response {
-    constructor(bodyOrNative, initOrUrl, credentials, isError = false, signal = undefined) {
+    constructor(bodyOrNative, initOrUrl, credentials, isError = false, signal = undefined, nativeBodyGroup = undefined) {
         if (bodyOrNative instanceof httpNative.HttpResponse) {
             // Internal path: constructed from native HttpResponse
             this.nativeResponse = bodyOrNative;
@@ -471,8 +471,11 @@ export class Response {
             this._abortBodyListener = undefined;
             this._bodyStream = undefined;
             this._nativeBodyState = {source: undefined, controller: undefined};
+            this._nativeBodyGroup = nativeBodyGroup || {active: 1, cancelWaiters: []};
+            this._nativeBodyBranchFinished = false;
             if (signal?.aborted) {
                 this.nativeResponse.discardBody();
+                this._finishNativeBodyBranch();
             } else if (signal) {
                 const responseRef = new WeakRef(this);
                 this._abortBodyListener = () => {
@@ -485,6 +488,7 @@ export class Response {
                         response.nativeResponse.discardBody();
                     }
                     bodyState.controller?.error(responseAbortReason(signal));
+                    response._finishNativeBodyBranch();
                     response._detachAbortBodyListener();
                 };
                 signal.addEventListener('abort', this._abortBodyListener, {once: true});
@@ -513,6 +517,23 @@ export class Response {
             this._signal.removeEventListener('abort', this._abortBodyListener);
             this._abortBodyListener = undefined;
         }
+    }
+
+    _finishNativeBodyBranch() {
+        if (!this._isNative || this._nativeBodyBranchFinished) return;
+        this._nativeBodyBranchFinished = true;
+        const group = this._nativeBodyGroup;
+        group.active--;
+        if (group.active === 0) {
+            for (const resolve of group.cancelWaiters.splice(0)) resolve();
+        }
+    }
+
+    _cancelNativeBodyBranch() {
+        this._finishNativeBodyBranch();
+        const group = this._nativeBodyGroup;
+        if (group.active === 0) return Promise.resolve();
+        return new Promise(resolve => group.cancelWaiters.push(resolve));
     }
 
     get status() {
@@ -554,15 +575,18 @@ export class Response {
                         [next, err] = await bodyState.source.pull();
                     } catch (error) {
                         response._detachAbortBodyListener();
+                        response._finishNativeBodyBranch();
                         if (response._signal?.aborted) throw responseAbortReason(response._signal);
                         throw error;
                     }
                     if (err !== undefined) {
                         response._detachAbortBodyListener();
+                        response._finishNativeBodyBranch();
                         console.error("Error reading response body stream:", err);
                         controller.error(err);
                     } else if (next === undefined) {
                         response._detachAbortBodyListener();
+                        response._finishNativeBodyBranch();
                         controller.close();
                     } else {
                         controller.enqueue(next);
@@ -576,6 +600,7 @@ export class Response {
                         response.nativeResponse.discardBody();
                     }
                     response._detachAbortBodyListener();
+                    return response._cancelNativeBodyBranch();
                 }
             });
             return this._bodyStream;
@@ -704,12 +729,15 @@ export class Response {
         }
 
         if (this._isNative) {
+            const nativeClone = this.nativeResponse.clone();
+            this._nativeBodyGroup.active++;
             return new Response(
-                this.nativeResponse.clone(),
+                nativeClone,
                 this.url,
                 this._credentials,
                 this._isError,
                 this._signal,
+                this._nativeBodyGroup,
             );
         }
         let clonedBody = this._body;
@@ -756,6 +784,7 @@ export class Response {
                 throw error;
             } finally {
                 this._detachAbortBodyListener();
+                this._finishNativeBodyBranch();
             }
         }
         this.bodyUsed = true;
@@ -820,6 +849,7 @@ export class Response {
                 throw error;
             } finally {
                 this._detachAbortBodyListener();
+                this._finishNativeBodyBranch();
             }
         }
         this.bodyUsed = true;

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -462,12 +462,6 @@ export class Response {
         if (bodyOrNative instanceof httpNative.HttpResponse) {
             // Internal path: constructed from native HttpResponse
             this.nativeResponse = bodyOrNative;
-            if (typeof httpNative.pauseNextBodyReadAfterReadyForTest === 'function') {
-                this.pauseNextBodyReadAfterReadyForTest = () =>
-                    httpNative.pauseNextBodyReadAfterReadyForTest(this.nativeResponse);
-                this.takeRecoveredBodyReadBytesForTest = () =>
-                    httpNative.takeRecoveredBodyReadBytesForTest(this.nativeResponse);
-            }
             this.url = initOrUrl || '';
             this.bodyUsed = false;
             this._credentials = credentials || 'same-origin';

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -453,8 +453,8 @@ async function streamingRequest(
     }
 }
 
-function responseAbortError() {
-    return new DOMException('The operation was aborted.', 'AbortError');
+function responseAbortReason(signal) {
+    return signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError');
 }
 
 export class Response {
@@ -472,8 +472,12 @@ export class Response {
             if (signal?.aborted) {
                 this.nativeResponse.discardBody();
             } else if (signal) {
+                const responseRef = new WeakRef(this);
                 this._abortBodyListener = () => {
-                    if (!this.bodyUsed) this.nativeResponse.discardBody();
+                    const response = responseRef.deref();
+                    // Rust owns cancellation once consumption starts. This hook only releases an
+                    // unread body, which otherwise has no active native future to cancel.
+                    if (response && !response.bodyUsed) response.nativeResponse.discardBody();
                 };
                 signal.addEventListener('abort', this._abortBodyListener, {once: true});
             }
@@ -530,10 +534,10 @@ export class Response {
                     return "bytes";
                 },
                 async pull(controller) {
-                    if (response._signal?.aborted) throw responseAbortError();
+                    response.bodyUsed = true;
+                    if (response._signal?.aborted) throw responseAbortReason(response._signal);
                     if (nativeStreamSourceSlot.nativeStreamSource === undefined) {
                         nativeStreamSourceSlot.nativeStreamSource = response.nativeResponse.stream();
-                        response.bodyUsed = true;
                     }
 
                     let next;
@@ -541,7 +545,7 @@ export class Response {
                     try {
                         [next, err] = await nativeStreamSourceSlot.nativeStreamSource.pull(response._signal);
                     } catch (error) {
-                        if (response._signal?.aborted) throw responseAbortError();
+                        response._detachAbortBodyListener();
                         throw error;
                     }
                     if (err !== undefined) {
@@ -724,17 +728,13 @@ export class Response {
 
     async arrayBuffer() {
         if (this._isNative) {
-            if (this._signal?.aborted) throw responseAbortError();
-            let result;
-            try {
-                result = await this.nativeResponse.arrayBuffer(this._signal);
-            } catch (error) {
-                if (this._signal?.aborted) throw responseAbortError();
-                throw error;
-            }
             this.bodyUsed = true;
-            this._detachAbortBodyListener();
-            return result;
+            if (this._signal?.aborted) throw responseAbortReason(this._signal);
+            try {
+                return await this.nativeResponse.arrayBuffer(this._signal);
+            } finally {
+                this._detachAbortBodyListener();
+            }
         }
         this.bodyUsed = true;
         if (this._body === null) {
@@ -789,17 +789,13 @@ export class Response {
 
     async text() {
         if (this._isNative) {
-            if (this._signal?.aborted) throw responseAbortError();
-            let result;
-            try {
-                result = await this.nativeResponse.text(this._signal);
-            } catch (error) {
-                if (this._signal?.aborted) throw responseAbortError();
-                throw error;
-            }
             this.bodyUsed = true;
-            this._detachAbortBodyListener();
-            return result;
+            if (this._signal?.aborted) throw responseAbortReason(this._signal);
+            try {
+                return await this.nativeResponse.text(this._signal);
+            } finally {
+                this._detachAbortBodyListener();
+            }
         }
         this.bodyUsed = true;
         if (this._body === null) {

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -470,7 +470,7 @@ export class Response {
             this._signal = signal;
             this._abortBodyListener = undefined;
             this._bodyStream = undefined;
-            this._nativeBodyState = {source: undefined, controller: undefined};
+            this._nativeBodyState = {source: undefined, controller: undefined, discarded: false};
             this._nativeBodyGroup = nativeBodyGroup || {active: 1, cancelWaiters: []};
             this._nativeBodyBranchFinished = this._nativeBodyGroup.terminal === true;
             if (signal?.aborted) {
@@ -482,6 +482,7 @@ export class Response {
                     const response = responseRef.deref();
                     if (!response) return;
                     const bodyState = response._nativeBodyState;
+                    bodyState.discarded = true;
                     if (bodyState.source) {
                         bodyState.source.discard();
                     } else if (!response.bodyUsed) {
@@ -586,7 +587,11 @@ export class Response {
                         [next, err] = await bodyState.source.pull();
                     } catch (error) {
                         response._detachAbortBodyListener();
-                        response._finishNativeBodyGroup();
+                        if (bodyState.discarded) {
+                            response._finishNativeBodyBranch();
+                        } else {
+                            response._finishNativeBodyGroup();
+                        }
                         if (response._signal?.aborted) throw responseAbortReason(response._signal);
                         throw error;
                     }
@@ -605,6 +610,7 @@ export class Response {
                 },
                 cancel() {
                     response.bodyUsed = true;
+                    bodyState.discarded = true;
                     if (bodyState.source) {
                         bodyState.source.discard();
                     } else {

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -462,6 +462,12 @@ export class Response {
         if (bodyOrNative instanceof httpNative.HttpResponse) {
             // Internal path: constructed from native HttpResponse
             this.nativeResponse = bodyOrNative;
+            if (typeof httpNative.pauseNextBodyReadAfterReadyForTest === 'function') {
+                this.pauseNextBodyReadAfterReadyForTest = () =>
+                    httpNative.pauseNextBodyReadAfterReadyForTest(this.nativeResponse);
+                this.takeRecoveredBodyReadBytesForTest = () =>
+                    httpNative.takeRecoveredBodyReadBytesForTest(this.nativeResponse);
+            }
             this.url = initOrUrl || '';
             this.bodyUsed = false;
             this._credentials = credentials || 'same-origin';

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -454,9 +454,7 @@ async function streamingRequest(
 }
 
 function responseAbortReason(signal) {
-    return signal?.aborted
-        ? signal.reason
-        : new DOMException('The operation was aborted.', 'AbortError');
+    return signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError');
 }
 
 export class Response {
@@ -753,6 +751,9 @@ export class Response {
             if (this._signal?.aborted) throw responseAbortReason(this._signal);
             try {
                 return await this.nativeResponse.arrayBuffer(this._signal);
+            } catch (error) {
+                if (this._signal?.aborted) throw responseAbortReason(this._signal);
+                throw error;
             } finally {
                 this._detachAbortBodyListener();
             }
@@ -814,6 +815,9 @@ export class Response {
             if (this._signal?.aborted) throw responseAbortReason(this._signal);
             try {
                 return await this.nativeResponse.text(this._signal);
+            } catch (error) {
+                if (this._signal?.aborted) throw responseAbortReason(this._signal);
+                throw error;
             } finally {
                 this._detachAbortBodyListener();
             }

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.js
@@ -468,6 +468,15 @@ export class Response {
             this._isError = isError;
             this._isNative = true;
             this._signal = signal;
+            this._abortBodyListener = undefined;
+            if (signal?.aborted) {
+                this.nativeResponse.discardBody();
+            } else if (signal) {
+                this._abortBodyListener = () => {
+                    if (!this.bodyUsed) this.nativeResponse.discardBody();
+                };
+                signal.addEventListener('abort', this._abortBodyListener, {once: true});
+            }
         } else {
             // Standard Web API path: new Response(body, init)
             const body = bodyOrNative;
@@ -484,6 +493,13 @@ export class Response {
             this._body = body instanceof ArrayBuffer || ArrayBuffer.isView(body)
                 ? snapshotBufferSource(body)
                 : body !== undefined && body !== null ? body : null;
+        }
+    }
+
+    _detachAbortBodyListener() {
+        if (this._signal && this._abortBodyListener) {
+            this._signal.removeEventListener('abort', this._abortBodyListener);
+            this._abortBodyListener = undefined;
         }
     }
 
@@ -523,15 +539,17 @@ export class Response {
                     let next;
                     let err;
                     try {
-                        [next, err] = await nativeStreamSourceSlot.nativeStreamSource.pull();
+                        [next, err] = await nativeStreamSourceSlot.nativeStreamSource.pull(response._signal);
                     } catch (error) {
                         if (response._signal?.aborted) throw responseAbortError();
                         throw error;
                     }
                     if (err !== undefined) {
+                        response._detachAbortBodyListener();
                         console.error("Error reading response body stream:", err);
                         controller.error(err);
                     } else if (next === undefined) {
+                        response._detachAbortBodyListener();
                         controller.close();
                     } else {
                         controller.enqueue(next);
@@ -709,12 +727,13 @@ export class Response {
             if (this._signal?.aborted) throw responseAbortError();
             let result;
             try {
-                result = await this.nativeResponse.arrayBuffer();
+                result = await this.nativeResponse.arrayBuffer(this._signal);
             } catch (error) {
                 if (this._signal?.aborted) throw responseAbortError();
                 throw error;
             }
             this.bodyUsed = true;
+            this._detachAbortBodyListener();
             return result;
         }
         this.bodyUsed = true;
@@ -773,12 +792,13 @@ export class Response {
             if (this._signal?.aborted) throw responseAbortError();
             let result;
             try {
-                result = await this.nativeResponse.text();
+                result = await this.nativeResponse.text(this._signal);
             } catch (error) {
                 if (this._signal?.aborted) throw responseAbortError();
                 throw error;
             }
             this.bodyUsed = true;
+            this._detachAbortBodyListener();
             return result;
         }
         this.bodyUsed = true;

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
@@ -753,7 +753,16 @@ impl HttpResponse {
     }
 
     pub fn discard_body(&mut self) {
-        self.body_source = ResponseBodySource::Consumed;
+        let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
+        match source {
+            ResponseBodySource::Native(response) => discard_native_response(*response),
+            ResponseBodySource::Shared(shared) => {
+                if let Some(response) = shared.borrow_mut().response.take() {
+                    discard_native_response(response);
+                }
+            }
+            ResponseBodySource::Bytes(_) | ResponseBodySource::Consumed => {}
+        }
     }
 
     #[qjs(get)]
@@ -797,33 +806,57 @@ impl HttpResponse {
             .to_string()
     }
 
-    #[allow(clippy::await_holding_refcell_ref)]
-    pub async fn array_buffer<'js>(&mut self, ctx: Ctx<'js>) -> rquickjs::Result<ArrayBuffer<'js>> {
+    pub async fn array_buffer<'js>(
+        &mut self,
+        ctx: Ctx<'js>,
+        signal: Option<Value<'js>>,
+    ) -> rquickjs::Result<ArrayBuffer<'js>> {
+        with_abort_signal(&ctx, signal.clone(), async { Ok(()) }).await?;
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         let bytes = match source {
             ResponseBodySource::Bytes(body_bytes) => body_bytes,
-            ResponseBodySource::Native(response) => response
-                .bytes()
-                .await
-                .map_err(|_| Exception::throw_message(&ctx, "failed to read response body"))?
-                .to_vec(),
-            ResponseBodySource::Shared(shared) => {
-                let mut shared = shared.borrow_mut();
-                if let Some(response) = shared.response.take() {
-                    // Native response was not read yet, read it now
-                    let bytes = response
+            ResponseBodySource::Native(response) => {
+                let error_ctx = ctx.clone();
+                with_abort_signal(&ctx, signal, async move {
+                    response
                         .bytes()
                         .await
+                        .map(|bytes| bytes.to_vec())
                         .map_err(|_| {
-                            Exception::throw_message(&ctx, "failed to read response body")
-                        })?
-                        .to_vec();
+                            Exception::throw_message(&error_ctx, "failed to read response body")
+                        })
+                })
+                .await?
+            }
+            ResponseBodySource::Shared(shared) => {
+                let response = shared.borrow_mut().response.take();
+                if let Some(response) = response {
+                    // Native response was not read yet, read it now
+                    let error_ctx = ctx.clone();
+                    let result = with_abort_signal(&ctx, signal, async move {
+                        response
+                            .bytes()
+                            .await
+                            .map(|bytes| bytes.to_vec())
+                            .map_err(|_| {
+                                Exception::throw_message(&error_ctx, "failed to read response body")
+                            })
+                    })
+                    .await;
+                    let bytes = match result {
+                        Ok(bytes) => bytes,
+                        Err(error) => {
+                            shared.borrow_mut().finished = true;
+                            return Err(error);
+                        }
+                    };
+                    let mut shared = shared.borrow_mut();
                     shared.buffer = bytes.clone();
                     shared.finished = true;
                     bytes
                 } else {
                     // Response already read and buffered
-                    shared.buffer.clone()
+                    shared.borrow().buffer.clone()
                 }
             }
             ResponseBodySource::Consumed => {
@@ -911,28 +944,49 @@ impl HttpResponse {
         }
     }
 
-    #[allow(clippy::await_holding_refcell_ref)]
-    pub async fn text<'js>(&mut self, ctx: Ctx<'js>) -> rquickjs::Result<String> {
+    pub async fn text<'js>(
+        &mut self,
+        ctx: Ctx<'js>,
+        signal: Option<Value<'js>>,
+    ) -> rquickjs::Result<String> {
+        with_abort_signal(&ctx, signal.clone(), async { Ok(()) }).await?;
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         match source {
             ResponseBodySource::Bytes(body_bytes) => {
                 Ok(String::from_utf8_lossy(&body_bytes).to_string())
             }
-            ResponseBodySource::Native(response) => response
-                .text()
+            ResponseBodySource::Native(response) => {
+                let error_ctx = ctx.clone();
+                with_abort_signal(&ctx, signal, async move {
+                    response.text().await.map_err(|_| {
+                        Exception::throw_message(&error_ctx, "failed to read response body")
+                    })
+                })
                 .await
-                .map_err(|_| Exception::throw_message(&ctx, "failed to read response body")),
+            }
             ResponseBodySource::Shared(shared) => {
-                let mut shared = shared.borrow_mut();
-                if let Some(response) = shared.response.take() {
-                    let text = response.text().await.map_err(|_| {
-                        Exception::throw_message(&ctx, "failed to read response body")
-                    })?;
+                let response = shared.borrow_mut().response.take();
+                if let Some(response) = response {
+                    let error_ctx = ctx.clone();
+                    let result = with_abort_signal(&ctx, signal, async move {
+                        response.text().await.map_err(|_| {
+                            Exception::throw_message(&error_ctx, "failed to read response body")
+                        })
+                    })
+                    .await;
+                    let text = match result {
+                        Ok(text) => text,
+                        Err(error) => {
+                            shared.borrow_mut().finished = true;
+                            return Err(error);
+                        }
+                    };
+                    let mut shared = shared.borrow_mut();
                     shared.buffer = text.clone().into_bytes();
                     shared.finished = true;
                     Ok(text)
                 } else {
-                    Ok(String::from_utf8_lossy(&shared.buffer).to_string())
+                    Ok(String::from_utf8_lossy(&shared.borrow().buffer).to_string())
                 }
             }
             ResponseBodySource::Consumed => Err(Exception::throw_message(
@@ -1033,6 +1087,13 @@ impl HttpResponse {
     }
 }
 
+fn discard_native_response(mut response: golem_wasi_http::Response) {
+    let (stream, body) = response.get_raw_input_stream();
+    drop(stream);
+    drop(wasip2::http::types::IncomingBody::finish(body));
+    drop(response);
+}
+
 pub struct SharedResponse {
     response: Option<golem_wasi_http::Response>,
     stream: Option<Rc<RefCell<SharedStream>>>,
@@ -1105,34 +1166,61 @@ impl ResponseBodyStream {
     pub async fn pull<'js>(
         &mut self,
         ctx: Ctx<'js>,
-    ) -> List<(Option<TypedArray<'js, u8>>, Option<String>)> {
-        let (result, stream) = match self.stream.take() {
-            Some(BodySource::Native {
-                stream,
-                body,
-                response,
-            }) => {
-                const CHUNK_SIZE: u64 = 4096;
-                let pollable = stream.subscribe();
-                AsyncPollable::new(pollable).wait_for().await;
+        signal: Option<Value<'js>>,
+    ) -> rquickjs::Result<List<(Option<TypedArray<'js, u8>>, Option<String>)>> {
+        let source = self.stream.take();
+        let pull_ctx = ctx.clone();
+        let pull = async move {
+            let ctx = pull_ctx;
+            let (result, stream) = match source {
+                Some(BodySource::Native {
+                    stream,
+                    body,
+                    response,
+                }) => {
+                    const CHUNK_SIZE: u64 = 4096;
+                    let pollable = stream.subscribe();
+                    AsyncPollable::new(pollable).wait_for().await;
 
-                match stream.read(CHUNK_SIZE) {
-                    Ok(chunk) => match TypedArray::new_copy(ctx.clone(), chunk) {
-                        Ok(js_array) => (
-                            List((Some(js_array), None)),
-                            Some(BodySource::Native {
-                                stream,
-                                body,
-                                response,
-                            }),
-                        ),
-                        Err(_) => (
+                    match stream.read(CHUNK_SIZE) {
+                        Ok(chunk) => match TypedArray::new_copy(ctx.clone(), chunk) {
+                            Ok(js_array) => (
+                                List((Some(js_array), None)),
+                                Some(BodySource::Native {
+                                    stream,
+                                    body,
+                                    response,
+                                }),
+                            ),
+                            Err(_) => (
+                                List((
+                                    None,
+                                    Some(
+                                        "Failed to create TypedArray from response body chunk"
+                                            .to_string(),
+                                    ),
+                                )),
+                                Some(BodySource::Native {
+                                    stream,
+                                    body,
+                                    response,
+                                }),
+                            ),
+                        },
+                        Err(StreamError::Closed) => {
+                            // No more data to read, close the stream
+                            drop(stream);
+                            drop(body);
+                            drop(response);
+                            (List((None, None)), None)
+                        }
+                        Err(StreamError::LastOperationFailed(err)) => (
                             List((
                                 None,
-                                Some(
-                                    "Failed to create TypedArray from response body chunk"
-                                        .to_string(),
-                                ),
+                                Some(format!(
+                                    "Failed to read response body: {}",
+                                    err.to_debug_string()
+                                )),
                             )),
                             Some(BodySource::Native {
                                 stream,
@@ -1140,67 +1228,45 @@ impl ResponseBodyStream {
                                 response,
                             }),
                         ),
-                    },
-                    Err(StreamError::Closed) => {
-                        // No more data to read, close the stream
-                        drop(stream);
-                        drop(body);
-                        drop(response);
-                        (List((None, None)), None)
                     }
-                    Err(StreamError::LastOperationFailed(err)) => (
-                        List((
-                            None,
-                            Some(format!(
-                                "Failed to read response body: {}",
-                                err.to_debug_string()
-                            )),
-                        )),
-                        Some(BodySource::Native {
-                            stream,
-                            body,
-                            response,
-                        }),
-                    ),
                 }
-            }
-            Some(BodySource::SharedNative {
-                shared_stream: rc_shared_stream,
-                position,
-            }) => {
-                let shared_stream = rc_shared_stream.borrow();
-                let shared = shared_stream
-                    .shared
-                    .upgrade()
-                    .expect("Shared stream has been dropped");
-                let mut shared = shared.borrow_mut();
-                let buffer_len = shared.buffer.len();
+                Some(BodySource::SharedNative {
+                    shared_stream: rc_shared_stream,
+                    position,
+                }) => {
+                    let shared_stream = rc_shared_stream.borrow();
+                    let shared = shared_stream
+                        .shared
+                        .upgrade()
+                        .expect("Shared stream has been dropped");
+                    let mut shared = shared.borrow_mut();
+                    let buffer_len = shared.buffer.len();
 
-                if position < buffer_len {
-                    let chunk = &shared.buffer[position..];
-                    let chunk_len = chunk.len();
-                    let chunk_array = TypedArray::new_copy(ctx.clone(), chunk).unwrap();
-                    (
-                        List((Some(chunk_array), None)),
-                        Some(BodySource::SharedNative {
-                            shared_stream: rc_shared_stream.clone(),
-                            position: position + chunk_len,
-                        }),
-                    )
-                } else {
-                    if shared.finished {
-                        (List((None, None)), None)
+                    if position < buffer_len {
+                        let chunk = &shared.buffer[position..];
+                        let chunk_len = chunk.len();
+                        let chunk_array = TypedArray::new_copy(ctx.clone(), chunk).unwrap();
+                        (
+                            List((Some(chunk_array), None)),
+                            Some(BodySource::SharedNative {
+                                shared_stream: rc_shared_stream.clone(),
+                                position: position + chunk_len,
+                            }),
+                        )
                     } else {
-                        const CHUNK_SIZE: u64 = 4096;
-                        let pollable = shared_stream.stream.subscribe();
-                        AsyncPollable::new(pollable).wait_for().await;
+                        if shared.finished {
+                            (List((None, None)), None)
+                        } else {
+                            const CHUNK_SIZE: u64 = 4096;
+                            let pollable = shared_stream.stream.subscribe();
+                            AsyncPollable::new(pollable).wait_for().await;
 
-                        match shared_stream.stream.read(CHUNK_SIZE) {
-                            Ok(chunk) => {
-                                let chunk_len = chunk.len();
-                                shared.buffer.extend_from_slice(&chunk);
+                            match shared_stream.stream.read(CHUNK_SIZE) {
+                                Ok(chunk) => {
+                                    let chunk_len = chunk.len();
+                                    shared.buffer.extend_from_slice(&chunk);
 
-                                match TypedArray::new_copy(ctx.clone(), chunk) {
+                                    match TypedArray::new_copy(ctx.clone(), chunk) {
                                     Ok(js_array) => {
                                         (List((Some(js_array), None)), Some(BodySource::SharedNative {
                             shared_stream: rc_shared_stream.clone(),
@@ -1218,68 +1284,80 @@ impl ResponseBodyStream {
                             position: position + chunk_len,
                         })),
                                 }
-                            }
-                            Err(StreamError::Closed) => {
-                                // No more data to read, close the stream
-                                shared.finished = true;
-                                (List((None, None)), None)
-                            }
-                            Err(StreamError::LastOperationFailed(err)) => (
-                                List((
-                                    None,
-                                    Some(format!(
-                                        "Failed to read response body: {}",
-                                        err.to_debug_string()
+                                }
+                                Err(StreamError::Closed) => {
+                                    // No more data to read, close the stream
+                                    shared.finished = true;
+                                    (List((None, None)), None)
+                                }
+                                Err(StreamError::LastOperationFailed(err)) => (
+                                    List((
+                                        None,
+                                        Some(format!(
+                                            "Failed to read response body: {}",
+                                            err.to_debug_string()
+                                        )),
                                     )),
-                                )),
-                                Some(BodySource::SharedNative {
-                                    shared_stream: rc_shared_stream.clone(),
-                                    position,
-                                }),
-                            ),
+                                    Some(BodySource::SharedNative {
+                                        shared_stream: rc_shared_stream.clone(),
+                                        position,
+                                    }),
+                                ),
+                            }
                         }
                     }
                 }
-            }
-            Some(BodySource::Bytes(mut cursor)) => {
-                let mut buf = [0u8; 4096];
-                match std::io::Read::read(&mut cursor, &mut buf) {
-                    Ok(0) => {
-                        // EOF
-                        (List((None, None)), None)
+                Some(BodySource::Bytes(mut cursor)) => {
+                    let mut buf = [0u8; 4096];
+                    match std::io::Read::read(&mut cursor, &mut buf) {
+                        Ok(0) => {
+                            // EOF
+                            (List((None, None)), None)
+                        }
+                        Ok(n) => match TypedArray::new_copy(ctx.clone(), &buf[..n]) {
+                            Ok(js_array) => (
+                                List((Some(js_array), None)),
+                                Some(BodySource::Bytes(cursor)),
+                            ),
+                            Err(_) => (
+                                List((
+                                    None,
+                                    Some(
+                                        "Failed to create TypedArray from response body chunk"
+                                            .to_string(),
+                                    ),
+                                )),
+                                Some(BodySource::Bytes(cursor)),
+                            ),
+                        },
+                        Err(err) => (
+                            List((None, Some(format!("Failed to read response body: {}", err)))),
+                            Some(BodySource::Bytes(cursor)),
+                        ),
                     }
-                    Ok(n) => match TypedArray::new_copy(ctx.clone(), &buf[..n]) {
-                        Ok(js_array) => (
-                            List((Some(js_array), None)),
-                            Some(BodySource::Bytes(cursor)),
-                        ),
-                        Err(_) => (
-                            List((
-                                None,
-                                Some(
-                                    "Failed to create TypedArray from response body chunk"
-                                        .to_string(),
-                                ),
-                            )),
-                            Some(BodySource::Bytes(cursor)),
-                        ),
-                    },
-                    Err(err) => (
-                        List((None, Some(format!("Failed to read response body: {}", err)))),
-                        Some(BodySource::Bytes(cursor)),
-                    ),
                 }
-            }
-            None => (
-                List((
+                None => (
+                    List((
+                        None,
+                        Some("Response body stream has already been consumed".to_string()),
+                    )),
                     None,
-                    Some("Response body stream has already been consumed".to_string()),
-                )),
-                None,
-            ),
+                ),
+            };
+            Ok((result, stream))
         };
-        self.stream = stream;
-        result
+        match with_abort_signal(&ctx, signal, pull).await {
+            Ok((result, stream)) => {
+                self.stream = stream;
+                Ok(result)
+            }
+            Err(error) => {
+                // The cancelled future owned the native stream/body/response state, so dropping it
+                // promptly cancels the transport work and leaves this reader terminal.
+                self.stream = None;
+                Err(error)
+            }
+        }
     }
 }
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
@@ -24,7 +24,7 @@ use std::rc::Rc;
 use wstd::runtime::AsyncPollable;
 
 use super::abort_signal::with_abort_signal;
-use super::shared_response_body::{self, NativeBody, SharedBody};
+use super::shared_response_body::{self, NativeBody, SharedBodyReader};
 
 /// Request mode - defines the cross-origin behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq, rquickjs::class::Trace, rquickjs::JsLifetime)]
@@ -758,7 +758,7 @@ impl HttpResponse {
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         match source {
             ResponseBodySource::Native(response) => discard_native_response(*response),
-            ResponseBodySource::Shared(shared) => SharedResponse::discard(&shared),
+            ResponseBodySource::Shared(shared) => shared.discard(),
             ResponseBodySource::Bytes(_) | ResponseBodySource::Consumed => {}
         }
     }
@@ -965,18 +965,18 @@ impl HttpResponse {
             ),
             ResponseBodySource::Native(mut response) => {
                 let (stream, body) = response.get_raw_input_stream();
-                let shared = Rc::new(RefCell::new(SharedResponse::new(SharedNativeResponse {
+                let (kept, cloned) = SharedResponse::pair(SharedNativeResponse {
                     stream: Some(stream),
                     body: Some(body),
                     response: Some(*response),
-                })));
+                });
                 (
-                    ResponseBodySource::Shared(shared.clone()),
-                    ResponseBodySource::Shared(shared),
+                    ResponseBodySource::Shared(cloned),
+                    ResponseBodySource::Shared(kept),
                 )
             }
             ResponseBodySource::Shared(shared) => (
-                ResponseBodySource::Shared(shared.clone()),
+                ResponseBodySource::Shared(shared.branch()),
                 ResponseBodySource::Shared(shared),
             ),
             ResponseBodySource::Consumed => {
@@ -1004,7 +1004,7 @@ fn discard_native_response(mut response: golem_wasi_http::Response) {
 async fn collect_shared_response_body<'js>(
     ctx: &Ctx<'js>,
     signal: Option<Value<'js>>,
-    shared: Rc<RefCell<SharedResponse>>,
+    shared: SharedResponse,
 ) -> rquickjs::Result<Vec<u8>> {
     with_abort_signal(ctx, signal, async {
         shared_response_body::collect(ctx, shared).await
@@ -1012,7 +1012,7 @@ async fn collect_shared_response_body<'js>(
     .await
 }
 
-pub type SharedResponse = SharedBody<SharedNativeResponse>;
+pub type SharedResponse = SharedBodyReader<SharedNativeResponse>;
 
 pub struct SharedNativeResponse {
     stream: Option<golem_wasi_http::InputStream>,
@@ -1067,7 +1067,7 @@ pub enum ResponseBodySource {
     /// Response has been consumed
     Consumed,
     /// Shared response body with buffering
-    Shared(Rc<RefCell<SharedResponse>>),
+    Shared(SharedResponse),
 }
 
 pub enum BodySource {
@@ -1077,7 +1077,7 @@ pub enum BodySource {
         response: Box<golem_wasi_http::Response>,
     },
     Shared {
-        shared: Rc<RefCell<SharedResponse>>,
+        shared: SharedResponse,
         position: usize,
     },
     Bytes(std::io::Cursor<Vec<u8>>),

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
@@ -7,6 +7,7 @@ pub mod native_module {
 
 use futures::SinkExt;
 use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
+use futures::future::{AbortHandle, Abortable};
 use futures_concurrency::stream::IntoStream;
 use golem_wasi_http::header::{HeaderName, HeaderValue};
 use golem_wasi_http::{
@@ -20,10 +21,10 @@ use rquickjs::{ArrayBuffer, Ctx, Exception, FromJs, IntoJs, JsLifetime, TypedArr
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::task::{Poll, Waker};
 use wstd::runtime::AsyncPollable;
 
-use super::abort_signal::{ensure_not_aborted, with_abort_signal};
+use super::abort_signal::with_abort_signal;
+use super::shared_response_body::{self, NativeBody, SharedBody};
 
 /// Request mode - defines the cross-origin behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq, rquickjs::class::Trace, rquickjs::JsLifetime)]
@@ -757,16 +758,7 @@ impl HttpResponse {
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         match source {
             ResponseBodySource::Native(response) => discard_native_response(*response),
-            ResponseBodySource::Shared(shared) => {
-                let mut shared = shared.borrow_mut();
-                if let Some(native) = shared.native.take() {
-                    discard_shared_native_response(native);
-                }
-                shared.finished = true;
-                for waiter in shared.waiters.drain(..) {
-                    waiter.wake();
-                }
-            }
+            ResponseBodySource::Shared(shared) => SharedResponse::discard(&shared),
             ResponseBodySource::Bytes(_) | ResponseBodySource::Consumed => {}
         }
     }
@@ -817,7 +809,6 @@ impl HttpResponse {
         ctx: Ctx<'js>,
         signal: Option<Value<'js>>,
     ) -> rquickjs::Result<ArrayBuffer<'js>> {
-        ensure_not_aborted(&ctx, signal.as_ref())?;
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         let bytes = match source {
             ResponseBodySource::Bytes(body_bytes) => body_bytes,
@@ -857,26 +848,24 @@ impl HttpResponse {
     pub fn stream<'js>(&mut self, ctx: Ctx<'js>) -> rquickjs::Result<ResponseBodyStream> {
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         match source {
-            ResponseBodySource::Bytes(body_bytes) => Ok(ResponseBodyStream {
-                stream: Some(BodySource::Bytes(std::io::Cursor::new(body_bytes))),
-            }),
+            ResponseBodySource::Bytes(body_bytes) => Ok(ResponseBodyStream::from_source(
+                BodySource::Bytes(std::io::Cursor::new(body_bytes)),
+            )),
             ResponseBodySource::Native(mut response) => {
                 let (stream, body) = response.get_raw_input_stream();
 
-                Ok(ResponseBodyStream {
-                    stream: Some(BodySource::Native {
-                        stream,
-                        body,
-                        response,
-                    }),
-                })
+                Ok(ResponseBodyStream::from_source(BodySource::Native {
+                    stream,
+                    body,
+                    response,
+                }))
             }
-            ResponseBodySource::Shared(shared) => Ok(ResponseBodyStream {
-                stream: Some(BodySource::Shared {
+            ResponseBodySource::Shared(shared) => {
+                Ok(ResponseBodyStream::from_source(BodySource::Shared {
                     shared,
                     position: 0,
-                }),
-            }),
+                }))
+            }
             ResponseBodySource::Consumed => Err(Exception::throw_message(
                 &ctx,
                 "The response has already been consumed",
@@ -889,7 +878,6 @@ impl HttpResponse {
         ctx: Ctx<'js>,
         signal: Option<Value<'js>>,
     ) -> rquickjs::Result<String> {
-        ensure_not_aborted(&ctx, signal.as_ref())?;
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         match source {
             ResponseBodySource::Bytes(body_bytes) => {
@@ -977,17 +965,11 @@ impl HttpResponse {
             ),
             ResponseBodySource::Native(mut response) => {
                 let (stream, body) = response.get_raw_input_stream();
-                let shared = Rc::new(RefCell::new(SharedResponse {
-                    native: Some(SharedNativeResponse {
-                        stream,
-                        body,
-                        response: *response,
-                    }),
-                    buffer: Vec::new(),
-                    finished: false,
-                    error: None,
-                    waiters: Vec::new(),
-                }));
+                let shared = Rc::new(RefCell::new(SharedResponse::new(SharedNativeResponse {
+                    stream: Some(stream),
+                    body: Some(body),
+                    response: Some(*response),
+                })));
                 (
                     ResponseBodySource::Shared(shared.clone()),
                     ResponseBodySource::Shared(shared),
@@ -1019,143 +1001,61 @@ fn discard_native_response(mut response: golem_wasi_http::Response) {
     drop(response);
 }
 
-fn discard_shared_native_response(native: SharedNativeResponse) {
-    drop(native.stream);
-    drop(wasip2::http::types::IncomingBody::finish(native.body));
-    drop(native.response);
-}
-
 async fn collect_shared_response_body<'js>(
     ctx: &Ctx<'js>,
     signal: Option<Value<'js>>,
     shared: Rc<RefCell<SharedResponse>>,
 ) -> rquickjs::Result<Vec<u8>> {
-    let read = async {
-        let mut position = 0;
-        let mut bytes = Vec::new();
-        while let Some(chunk) =
-            read_shared_response_body_chunk(ctx, None, &shared, position).await?
-        {
-            position += chunk.len();
-            bytes.extend_from_slice(&chunk);
-        }
-        Ok(bytes)
-    };
-    with_abort_signal(ctx, signal, read).await
+    with_abort_signal(ctx, signal, async {
+        shared_response_body::collect(ctx, shared).await
+    })
+    .await
 }
 
-async fn read_shared_response_body_chunk<'js>(
-    ctx: &Ctx<'js>,
-    signal: Option<Value<'js>>,
-    shared: &Rc<RefCell<SharedResponse>>,
-    position: usize,
-) -> rquickjs::Result<Option<Vec<u8>>> {
-    loop {
-        {
-            let state = shared.borrow();
-            if position < state.buffer.len() {
-                let end = (position + 16 * 1024).min(state.buffer.len());
-                return Ok(Some(state.buffer[position..end].to_vec()));
-            }
-            if let Some(error) = &state.error {
-                return Err(Exception::throw_message(ctx, error));
-            }
-            if state.finished {
-                return Ok(None);
-            }
-        }
+pub type SharedResponse = SharedBody<SharedNativeResponse>;
 
-        let native = shared.borrow_mut().native.take();
-        let Some(native) = native else {
-            let wait = std::future::poll_fn(|cx| {
-                let mut state = shared.borrow_mut();
-                if position < state.buffer.len()
-                    || state.error.is_some()
-                    || state.finished
-                    || state.native.is_some()
-                {
-                    Poll::Ready(())
-                } else {
-                    if !state
-                        .waiters
-                        .iter()
-                        .any(|waker| waker.will_wake(cx.waker()))
-                    {
-                        state.waiters.push(cx.waker().clone());
-                    }
-                    Poll::Pending
-                }
-            });
-            with_abort_signal(ctx, signal.clone(), async {
-                wait.await;
-                Ok(())
-            })
-            .await?;
-            continue;
-        };
+pub struct SharedNativeResponse {
+    stream: Option<golem_wasi_http::InputStream>,
+    body: Option<golem_wasi_http::IncomingBody>,
+    response: Option<golem_wasi_http::Response>,
+}
 
-        let read = async move {
-            loop {
-                let pollable = native.stream.subscribe();
-                AsyncPollable::new(pollable).wait_for().await;
-                match native.stream.read(16 * 1024) {
-                    Ok(chunk) if chunk.is_empty() => continue,
-                    Ok(chunk) => return Ok((Some(native), Some(chunk.to_vec()))),
-                    Err(StreamError::Closed) => {
-                        discard_shared_native_response(native);
-                        return Ok((None, None));
-                    }
-                    Err(StreamError::LastOperationFailed(error)) => {
-                        let message =
-                            format!("Failed to read response body: {}", error.to_debug_string());
-                        discard_shared_native_response(native);
-                        return Err(message);
-                    }
+impl NativeBody for SharedNativeResponse {
+    async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String> {
+        let stream = self
+            .stream
+            .as_ref()
+            .expect("shared response stream is present");
+        loop {
+            let pollable = stream.subscribe();
+            AsyncPollable::new(pollable).wait_for().await;
+            match stream.read(16 * 1024) {
+                Ok(chunk) if chunk.is_empty() => continue,
+                Ok(chunk) => return Ok(Some(chunk.to_vec())),
+                Err(StreamError::Closed) => return Ok(None),
+                Err(StreamError::LastOperationFailed(error)) => {
+                    return Err(format!(
+                        "Failed to read response body: {}",
+                        error.to_debug_string()
+                    ));
                 }
             }
-        };
-        let outcome = with_abort_signal(ctx, signal, async { Ok(read.await) }).await;
-        let mut state = shared.borrow_mut();
-        let result = match outcome {
-            Err(error) => {
-                state.finished = true;
-                Err(error)
-            }
-            Ok(Ok((native, Some(chunk)))) => {
-                state.buffer.extend_from_slice(&chunk);
-                state.native = native;
-                Ok(Some(chunk))
-            }
-            Ok(Ok((native, None))) => {
-                state.native = native;
-                state.finished = true;
-                Ok(None)
-            }
-            Ok(Err(error)) => {
-                state.error = Some(error.clone());
-                state.finished = true;
-                Err(Exception::throw_message(ctx, &error))
-            }
-        };
-        for waiter in state.waiters.drain(..) {
-            waiter.wake();
         }
-        return result;
+    }
+
+    fn discard(self) {
+        drop(self);
     }
 }
 
-pub struct SharedResponse {
-    native: Option<SharedNativeResponse>,
-    buffer: Vec<u8>,
-    finished: bool,
-    error: Option<String>,
-    waiters: Vec<Waker>,
-}
-
-pub struct SharedNativeResponse {
-    stream: golem_wasi_http::InputStream,
-    body: golem_wasi_http::IncomingBody,
-    response: golem_wasi_http::Response,
+impl Drop for SharedNativeResponse {
+    fn drop(&mut self) {
+        drop(self.stream.take());
+        if let Some(body) = self.body.take() {
+            drop(wasip2::http::types::IncomingBody::finish(body));
+        }
+        drop(self.response.take());
+    }
 }
 
 /// Represents the source of response body data
@@ -1190,7 +1090,13 @@ pub enum BodySource {
 #[rquickjs::class(rename_all = "camelCase")]
 pub struct ResponseBodyStream {
     #[qjs(skip_trace)]
+    state: Rc<RefCell<ResponseBodyStreamState>>,
+}
+
+struct ResponseBodyStreamState {
     stream: Option<BodySource>,
+    active_abort: Option<AbortHandle>,
+    discarded: bool,
 }
 
 impl Default for ResponseBodyStream {
@@ -1203,7 +1109,13 @@ impl Default for ResponseBodyStream {
 impl ResponseBodyStream {
     #[qjs(constructor)]
     pub fn new() -> Self {
-        ResponseBodyStream { stream: None }
+        Self {
+            state: Rc::new(RefCell::new(ResponseBodyStreamState {
+                stream: None,
+                active_abort: None,
+                discarded: false,
+            })),
+        }
     }
 
     #[qjs(get, rename = "type")]
@@ -1212,11 +1124,18 @@ impl ResponseBodyStream {
     }
 
     pub async fn pull<'js>(
-        &mut self,
+        &self,
         ctx: Ctx<'js>,
-        signal: Option<Value<'js>>,
     ) -> rquickjs::Result<List<(Option<TypedArray<'js, u8>>, Option<String>)>> {
-        let source = self.stream.take();
+        let source = {
+            let mut state = self.state.borrow_mut();
+            if state.discarded {
+                return Ok(List((None, None)));
+            }
+            state.stream.take()
+        };
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        self.state.borrow_mut().active_abort = Some(abort_handle);
         let pull_ctx = ctx.clone();
         let pull = async move {
             let ctx = pull_ctx;
@@ -1279,7 +1198,7 @@ impl ResponseBodyStream {
                     }
                 }
                 Some(BodySource::Shared { shared, position }) => {
-                    match read_shared_response_body_chunk(&ctx, None, &shared, position).await? {
+                    match shared_response_body::read_chunk(&ctx, &shared, position).await? {
                         Some(chunk) => {
                             let chunk_len = chunk.len();
                             match TypedArray::new_copy(ctx.clone(), &chunk) {
@@ -1347,18 +1266,45 @@ impl ResponseBodyStream {
             };
             Ok((result, stream))
         };
-        match with_abort_signal(&ctx, signal, pull).await {
-            Ok((result, stream)) => {
-                self.stream = stream;
+        let outcome = Abortable::new(pull, abort_registration).await;
+        let mut state = self.state.borrow_mut();
+        state.active_abort = None;
+        match outcome {
+            Ok(Ok((result, stream))) => {
+                if !state.discarded {
+                    state.stream = stream;
+                }
                 Ok(result)
             }
-            Err(error) => {
-                // The cancelled future owned the native stream/body/response state, so dropping it
-                // promptly cancels the transport work and leaves this reader terminal.
-                self.stream = None;
-                Err(error)
+            Ok(Err(error)) => Err(error),
+            Err(_) => {
+                state.discarded = true;
+                Err(Exception::throw_message(
+                    &ctx,
+                    "Response body stream was discarded",
+                ))
             }
         }
+    }
+
+    pub fn discard(&self) {
+        let (stream, abort) = {
+            let mut state = self.state.borrow_mut();
+            state.discarded = true;
+            (state.stream.take(), state.active_abort.take())
+        };
+        drop(stream);
+        if let Some(abort) = abort {
+            abort.abort();
+        }
+    }
+}
+
+impl ResponseBodyStream {
+    fn from_source(stream: BodySource) -> Self {
+        let response = Self::new();
+        response.state.borrow_mut().stream = Some(stream);
+        response
     }
 }
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http.rs
@@ -19,10 +19,11 @@ use rquickjs::prelude::List;
 use rquickjs::{ArrayBuffer, Ctx, Exception, FromJs, IntoJs, JsLifetime, TypedArray, Value};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
+use std::task::{Poll, Waker};
 use wstd::runtime::AsyncPollable;
 
-use super::abort_signal::with_abort_signal;
+use super::abort_signal::{ensure_not_aborted, with_abort_signal};
 
 /// Request mode - defines the cross-origin behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq, rquickjs::class::Trace, rquickjs::JsLifetime)]
@@ -757,8 +758,13 @@ impl HttpResponse {
         match source {
             ResponseBodySource::Native(response) => discard_native_response(*response),
             ResponseBodySource::Shared(shared) => {
-                if let Some(response) = shared.borrow_mut().response.take() {
-                    discard_native_response(response);
+                let mut shared = shared.borrow_mut();
+                if let Some(native) = shared.native.take() {
+                    discard_shared_native_response(native);
+                }
+                shared.finished = true;
+                for waiter in shared.waiters.drain(..) {
+                    waiter.wake();
                 }
             }
             ResponseBodySource::Bytes(_) | ResponseBodySource::Consumed => {}
@@ -811,7 +817,7 @@ impl HttpResponse {
         ctx: Ctx<'js>,
         signal: Option<Value<'js>>,
     ) -> rquickjs::Result<ArrayBuffer<'js>> {
-        with_abort_signal(&ctx, signal.clone(), async { Ok(()) }).await?;
+        ensure_not_aborted(&ctx, signal.as_ref())?;
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         let bytes = match source {
             ResponseBodySource::Bytes(body_bytes) => body_bytes,
@@ -829,35 +835,7 @@ impl HttpResponse {
                 .await?
             }
             ResponseBodySource::Shared(shared) => {
-                let response = shared.borrow_mut().response.take();
-                if let Some(response) = response {
-                    // Native response was not read yet, read it now
-                    let error_ctx = ctx.clone();
-                    let result = with_abort_signal(&ctx, signal, async move {
-                        response
-                            .bytes()
-                            .await
-                            .map(|bytes| bytes.to_vec())
-                            .map_err(|_| {
-                                Exception::throw_message(&error_ctx, "failed to read response body")
-                            })
-                    })
-                    .await;
-                    let bytes = match result {
-                        Ok(bytes) => bytes,
-                        Err(error) => {
-                            shared.borrow_mut().finished = true;
-                            return Err(error);
-                        }
-                    };
-                    let mut shared = shared.borrow_mut();
-                    shared.buffer = bytes.clone();
-                    shared.finished = true;
-                    bytes
-                } else {
-                    // Response already read and buffered
-                    shared.borrow().buffer.clone()
-                }
+                collect_shared_response_body(&ctx, signal, shared).await?
             }
             ResponseBodySource::Consumed => {
                 return Err(Exception::throw_message(
@@ -893,50 +871,12 @@ impl HttpResponse {
                     }),
                 })
             }
-            ResponseBodySource::Shared(rc_shared) => {
-                let mut shared = rc_shared.borrow_mut();
-                if let Some(mut response) = shared.response.take() {
-                    let (stream, body) = response.get_raw_input_stream();
-
-                    let shared_stream = SharedStream {
-                        stream,
-                        body,
-                        response,
-                        shared: Rc::downgrade(&rc_shared),
-                    };
-
-                    // Read the body into the buffer as it is consumed
-                    Ok(ResponseBodyStream {
-                        stream: Some(BodySource::SharedNative {
-                            shared_stream: Rc::new(RefCell::new(shared_stream)),
-                            position: 0,
-                        }),
-                    })
-                } else if let Some(stream) = &shared.stream {
-                    if shared.finished {
-                        // Response was streaming but now finished
-                        Ok(ResponseBodyStream {
-                            stream: Some(BodySource::Bytes(std::io::Cursor::new(
-                                shared.buffer.clone(),
-                            ))),
-                        })
-                    } else {
-                        // Response is still streaming
-                        Ok(ResponseBodyStream {
-                            stream: Some(BodySource::SharedNative {
-                                shared_stream: stream.clone(),
-                                position: 0,
-                            }),
-                        })
-                    }
-                } else {
-                    Ok(ResponseBodyStream {
-                        stream: Some(BodySource::Bytes(std::io::Cursor::new(
-                            shared.buffer.clone(),
-                        ))),
-                    })
-                }
-            }
+            ResponseBodySource::Shared(shared) => Ok(ResponseBodyStream {
+                stream: Some(BodySource::Shared {
+                    shared,
+                    position: 0,
+                }),
+            }),
             ResponseBodySource::Consumed => Err(Exception::throw_message(
                 &ctx,
                 "The response has already been consumed",
@@ -949,7 +889,7 @@ impl HttpResponse {
         ctx: Ctx<'js>,
         signal: Option<Value<'js>>,
     ) -> rquickjs::Result<String> {
-        with_abort_signal(&ctx, signal.clone(), async { Ok(()) }).await?;
+        ensure_not_aborted(&ctx, signal.as_ref())?;
         let source = std::mem::replace(&mut self.body_source, ResponseBodySource::Consumed);
         match source {
             ResponseBodySource::Bytes(body_bytes) => {
@@ -965,29 +905,8 @@ impl HttpResponse {
                 .await
             }
             ResponseBodySource::Shared(shared) => {
-                let response = shared.borrow_mut().response.take();
-                if let Some(response) = response {
-                    let error_ctx = ctx.clone();
-                    let result = with_abort_signal(&ctx, signal, async move {
-                        response.text().await.map_err(|_| {
-                            Exception::throw_message(&error_ctx, "failed to read response body")
-                        })
-                    })
-                    .await;
-                    let text = match result {
-                        Ok(text) => text,
-                        Err(error) => {
-                            shared.borrow_mut().finished = true;
-                            return Err(error);
-                        }
-                    };
-                    let mut shared = shared.borrow_mut();
-                    shared.buffer = text.clone().into_bytes();
-                    shared.finished = true;
-                    Ok(text)
-                } else {
-                    Ok(String::from_utf8_lossy(&shared.borrow().buffer).to_string())
-                }
+                let bytes = collect_shared_response_body(&ctx, signal, shared).await?;
+                Ok(String::from_utf8_lossy(&bytes).to_string())
             }
             ResponseBodySource::Consumed => Err(Exception::throw_message(
                 &ctx,
@@ -1056,12 +975,18 @@ impl HttpResponse {
                 ResponseBodySource::Bytes(bytes.clone()),
                 ResponseBodySource::Bytes(bytes),
             ),
-            ResponseBodySource::Native(response) => {
+            ResponseBodySource::Native(mut response) => {
+                let (stream, body) = response.get_raw_input_stream();
                 let shared = Rc::new(RefCell::new(SharedResponse {
-                    response: Some(*response),
-                    stream: None,
+                    native: Some(SharedNativeResponse {
+                        stream,
+                        body,
+                        response: *response,
+                    }),
                     buffer: Vec::new(),
                     finished: false,
+                    error: None,
+                    waiters: Vec::new(),
                 }));
                 (
                     ResponseBodySource::Shared(shared.clone()),
@@ -1094,19 +1019,143 @@ fn discard_native_response(mut response: golem_wasi_http::Response) {
     drop(response);
 }
 
-pub struct SharedResponse {
-    response: Option<golem_wasi_http::Response>,
-    stream: Option<Rc<RefCell<SharedStream>>>,
-    buffer: Vec<u8>,
-    finished: bool,
+fn discard_shared_native_response(native: SharedNativeResponse) {
+    drop(native.stream);
+    drop(wasip2::http::types::IncomingBody::finish(native.body));
+    drop(native.response);
 }
 
-#[allow(dead_code)]
-pub struct SharedStream {
+async fn collect_shared_response_body<'js>(
+    ctx: &Ctx<'js>,
+    signal: Option<Value<'js>>,
+    shared: Rc<RefCell<SharedResponse>>,
+) -> rquickjs::Result<Vec<u8>> {
+    let read = async {
+        let mut position = 0;
+        let mut bytes = Vec::new();
+        while let Some(chunk) =
+            read_shared_response_body_chunk(ctx, None, &shared, position).await?
+        {
+            position += chunk.len();
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(bytes)
+    };
+    with_abort_signal(ctx, signal, read).await
+}
+
+async fn read_shared_response_body_chunk<'js>(
+    ctx: &Ctx<'js>,
+    signal: Option<Value<'js>>,
+    shared: &Rc<RefCell<SharedResponse>>,
+    position: usize,
+) -> rquickjs::Result<Option<Vec<u8>>> {
+    loop {
+        {
+            let state = shared.borrow();
+            if position < state.buffer.len() {
+                let end = (position + 16 * 1024).min(state.buffer.len());
+                return Ok(Some(state.buffer[position..end].to_vec()));
+            }
+            if let Some(error) = &state.error {
+                return Err(Exception::throw_message(ctx, error));
+            }
+            if state.finished {
+                return Ok(None);
+            }
+        }
+
+        let native = shared.borrow_mut().native.take();
+        let Some(native) = native else {
+            let wait = std::future::poll_fn(|cx| {
+                let mut state = shared.borrow_mut();
+                if position < state.buffer.len()
+                    || state.error.is_some()
+                    || state.finished
+                    || state.native.is_some()
+                {
+                    Poll::Ready(())
+                } else {
+                    if !state
+                        .waiters
+                        .iter()
+                        .any(|waker| waker.will_wake(cx.waker()))
+                    {
+                        state.waiters.push(cx.waker().clone());
+                    }
+                    Poll::Pending
+                }
+            });
+            with_abort_signal(ctx, signal.clone(), async {
+                wait.await;
+                Ok(())
+            })
+            .await?;
+            continue;
+        };
+
+        let read = async move {
+            loop {
+                let pollable = native.stream.subscribe();
+                AsyncPollable::new(pollable).wait_for().await;
+                match native.stream.read(16 * 1024) {
+                    Ok(chunk) if chunk.is_empty() => continue,
+                    Ok(chunk) => return Ok((Some(native), Some(chunk.to_vec()))),
+                    Err(StreamError::Closed) => {
+                        discard_shared_native_response(native);
+                        return Ok((None, None));
+                    }
+                    Err(StreamError::LastOperationFailed(error)) => {
+                        let message =
+                            format!("Failed to read response body: {}", error.to_debug_string());
+                        discard_shared_native_response(native);
+                        return Err(message);
+                    }
+                }
+            }
+        };
+        let outcome = with_abort_signal(ctx, signal, async { Ok(read.await) }).await;
+        let mut state = shared.borrow_mut();
+        let result = match outcome {
+            Err(error) => {
+                state.finished = true;
+                Err(error)
+            }
+            Ok(Ok((native, Some(chunk)))) => {
+                state.buffer.extend_from_slice(&chunk);
+                state.native = native;
+                Ok(Some(chunk))
+            }
+            Ok(Ok((native, None))) => {
+                state.native = native;
+                state.finished = true;
+                Ok(None)
+            }
+            Ok(Err(error)) => {
+                state.error = Some(error.clone());
+                state.finished = true;
+                Err(Exception::throw_message(ctx, &error))
+            }
+        };
+        for waiter in state.waiters.drain(..) {
+            waiter.wake();
+        }
+        return result;
+    }
+}
+
+pub struct SharedResponse {
+    native: Option<SharedNativeResponse>,
+    buffer: Vec<u8>,
+    finished: bool,
+    error: Option<String>,
+    waiters: Vec<Waker>,
+}
+
+pub struct SharedNativeResponse {
     stream: golem_wasi_http::InputStream,
     body: golem_wasi_http::IncomingBody,
     response: golem_wasi_http::Response,
-    shared: Weak<RefCell<SharedResponse>>,
 }
 
 /// Represents the source of response body data
@@ -1127,8 +1176,8 @@ pub enum BodySource {
         body: golem_wasi_http::IncomingBody,
         response: Box<golem_wasi_http::Response>,
     },
-    SharedNative {
-        shared_stream: Rc<RefCell<SharedStream>>,
+    Shared {
+        shared: Rc<RefCell<SharedResponse>>,
         position: usize,
     },
     Bytes(std::io::Cursor<Vec<u8>>),
@@ -1162,7 +1211,6 @@ impl ResponseBodyStream {
         "bytes".to_string()
     }
 
-    #[allow(clippy::await_holding_refcell_ref)]
     pub async fn pull<'js>(
         &mut self,
         ctx: Ctx<'js>,
@@ -1230,81 +1278,34 @@ impl ResponseBodyStream {
                         ),
                     }
                 }
-                Some(BodySource::SharedNative {
-                    shared_stream: rc_shared_stream,
-                    position,
-                }) => {
-                    let shared_stream = rc_shared_stream.borrow();
-                    let shared = shared_stream
-                        .shared
-                        .upgrade()
-                        .expect("Shared stream has been dropped");
-                    let mut shared = shared.borrow_mut();
-                    let buffer_len = shared.buffer.len();
-
-                    if position < buffer_len {
-                        let chunk = &shared.buffer[position..];
-                        let chunk_len = chunk.len();
-                        let chunk_array = TypedArray::new_copy(ctx.clone(), chunk).unwrap();
-                        (
-                            List((Some(chunk_array), None)),
-                            Some(BodySource::SharedNative {
-                                shared_stream: rc_shared_stream.clone(),
-                                position: position + chunk_len,
-                            }),
-                        )
-                    } else {
-                        if shared.finished {
-                            (List((None, None)), None)
-                        } else {
-                            const CHUNK_SIZE: u64 = 4096;
-                            let pollable = shared_stream.stream.subscribe();
-                            AsyncPollable::new(pollable).wait_for().await;
-
-                            match shared_stream.stream.read(CHUNK_SIZE) {
-                                Ok(chunk) => {
-                                    let chunk_len = chunk.len();
-                                    shared.buffer.extend_from_slice(&chunk);
-
-                                    match TypedArray::new_copy(ctx.clone(), chunk) {
-                                    Ok(js_array) => {
-                                        (List((Some(js_array), None)), Some(BodySource::SharedNative {
-                            shared_stream: rc_shared_stream.clone(),
-                            position: position + chunk_len,
-                        }))
-                                    },
-                                    Err(_) => (List((
+                Some(BodySource::Shared { shared, position }) => {
+                    match read_shared_response_body_chunk(&ctx, None, &shared, position).await? {
+                        Some(chunk) => {
+                            let chunk_len = chunk.len();
+                            match TypedArray::new_copy(ctx.clone(), &chunk) {
+                                Ok(js_array) => (
+                                    List((Some(js_array), None)),
+                                    Some(BodySource::Shared {
+                                        shared,
+                                        position: position + chunk_len,
+                                    }),
+                                ),
+                                Err(_) => (
+                                    List((
                                         None,
                                         Some(
                                             "Failed to create TypedArray from response body chunk"
                                                 .to_string(),
                                         ),
-                                    )), Some(BodySource::SharedNative {
-                            shared_stream: rc_shared_stream.clone(),
-                            position: position + chunk_len,
-                        })),
-                                }
-                                }
-                                Err(StreamError::Closed) => {
-                                    // No more data to read, close the stream
-                                    shared.finished = true;
-                                    (List((None, None)), None)
-                                }
-                                Err(StreamError::LastOperationFailed(err)) => (
-                                    List((
-                                        None,
-                                        Some(format!(
-                                            "Failed to read response body: {}",
-                                            err.to_debug_string()
-                                        )),
                                     )),
-                                    Some(BodySource::SharedNative {
-                                        shared_stream: rc_shared_stream.clone(),
-                                        position,
+                                    Some(BodySource::Shared {
+                                        shared,
+                                        position: position + chunk_len,
                                     }),
                                 ),
                             }
                         }
+                        None => (List((None, None)), None),
                     }
                 }
                 Some(BodySource::Bytes(mut cursor)) => {

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
@@ -1,11 +1,14 @@
 //! Shared Preview 3 response-body ownership for `fetch` and `node:http`.
 
+use std::future::IntoFuture;
+use std::pin::Pin;
 use wasip3::http::types::{ErrorCode, Response, Trailers};
 use wasip3::wit_bindgen::rt::async_support::{
     FutureReader, FutureWriter, StreamReader, StreamResult,
 };
 
 type BodyResultReader = FutureReader<Result<Option<Trailers>, ErrorCode>>;
+type BodyResultFuture = Pin<Box<<BodyResultReader as IntoFuture>::IntoFuture>>;
 type ResponseResultWriter = FutureWriter<Result<(), ErrorCode>>;
 
 enum ResponseBodyState {
@@ -16,17 +19,17 @@ enum ResponseBodyState {
         response_result: ResponseResultWriter,
     },
     Finishing {
-        result: BodyResultReader,
-        response_result: ResponseResultWriter,
+        result: BodyResultFuture,
+        response_result: Option<ResponseResultWriter>,
     },
     Consumed,
 }
 
 /// Owns a native Preview 3 response until its body reaches EOF or is deliberately discarded.
 ///
-/// A cancelled `read_chunk` future drops the state moved into that future, including the stream
-/// reader, body-result future, response-result writer, and response. The owner remains consumed,
-/// which prevents a cancelled transport operation from being resumed with stale resources.
+/// A cancelled `read_chunk` future leaves the current state in this owner. This lets a surviving
+/// clone resume a shared body after another clone cancels its pending read. Deliberate disposal of
+/// the owner still drops the reader, body-result future, response-result writer, and response.
 pub(crate) struct ResponseBody {
     state: ResponseBodyState,
 }
@@ -49,86 +52,86 @@ impl ResponseBody {
     }
 
     pub(crate) async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String> {
-        let state = std::mem::replace(&mut self.state, ResponseBodyState::Consumed);
-        match state {
-            ResponseBodyState::Unconsumed(response) => {
-                let (response_result, response_result_reader) =
-                    wasip3::wit_future::new(|| Ok::<(), ErrorCode>(()));
-                let (reader, result) = Response::consume_body(response, response_result_reader);
-                self.state = ResponseBodyState::Reading {
-                    reader,
-                    result,
-                    response_result,
-                };
-                self.read_from_reader().await
-            }
-            ResponseBodyState::Reading {
+        if matches!(self.state, ResponseBodyState::Unconsumed(_)) {
+            let ResponseBodyState::Unconsumed(response) =
+                std::mem::replace(&mut self.state, ResponseBodyState::Consumed)
+            else {
+                unreachable!();
+            };
+            let (response_result, response_result_reader) =
+                wasip3::wit_future::new(|| Ok::<(), ErrorCode>(()));
+            let (reader, result) = Response::consume_body(response, response_result_reader);
+            self.state = ResponseBodyState::Reading {
                 reader,
                 result,
                 response_result,
-            } => {
-                self.state = ResponseBodyState::Reading {
-                    reader,
-                    result,
-                    response_result,
-                };
-                self.read_from_reader().await
-            }
-            ResponseBodyState::Finishing {
-                result,
-                response_result,
-            } => {
-                drop(response_result);
-                match result.await {
-                    Ok(_) => Ok(None),
-                    Err(error) => Err(format!("HTTP response body error: {error:?}")),
-                }
-            }
+            };
+        }
+
+        match &self.state {
+            ResponseBodyState::Reading { .. } => self.read_from_reader().await,
+            ResponseBodyState::Finishing { .. } => self.finish().await,
             ResponseBodyState::Consumed => Ok(None),
+            ResponseBodyState::Unconsumed(_) => unreachable!(),
         }
     }
 
     async fn read_from_reader(&mut self) -> Result<Option<Vec<u8>>, String> {
-        let state = std::mem::replace(&mut self.state, ResponseBodyState::Consumed);
-        let ResponseBodyState::Reading {
-            mut reader,
-            result,
-            response_result,
-        } = state
-        else {
-            return Ok(None);
-        };
-
         const CHUNK_SIZE: usize = 16 * 1024;
         loop {
-            let (status, bytes) = reader.read(Vec::with_capacity(CHUNK_SIZE)).await;
+            let (status, bytes) = {
+                let ResponseBodyState::Reading { reader, .. } = &mut self.state else {
+                    return Ok(None);
+                };
+                reader.read(Vec::with_capacity(CHUNK_SIZE)).await
+            };
             match status {
-                StreamResult::Complete(_) if !bytes.is_empty() => {
-                    self.state = ResponseBodyState::Reading {
+                StreamResult::Complete(_) if !bytes.is_empty() => return Ok(Some(bytes)),
+                StreamResult::Complete(_) => continue,
+                StreamResult::Dropped => {
+                    let ResponseBodyState::Reading {
                         reader,
                         result,
                         response_result,
+                    } = std::mem::replace(&mut self.state, ResponseBodyState::Consumed)
+                    else {
+                        unreachable!();
                     };
-                    return Ok(Some(bytes));
-                }
-                StreamResult::Complete(_) => continue,
-                StreamResult::Dropped => {
                     drop(reader);
-                    if bytes.is_empty() {
-                        drop(response_result);
-                        return match result.await {
-                            Ok(_) => Ok(None),
-                            Err(error) => Err(format!("HTTP response body error: {error:?}")),
-                        };
-                    }
                     self.state = ResponseBodyState::Finishing {
-                        result,
-                        response_result,
+                        result: Box::pin(result.into_future()),
+                        response_result: Some(response_result),
                     };
-                    return Ok(Some(bytes));
+                    return if bytes.is_empty() {
+                        self.finish().await
+                    } else {
+                        Ok(Some(bytes))
+                    };
                 }
-                StreamResult::Cancelled => return Ok(None),
+                StreamResult::Cancelled => {
+                    self.state = ResponseBodyState::Consumed;
+                    return Ok(None);
+                }
             }
+        }
+    }
+
+    async fn finish(&mut self) -> Result<Option<Vec<u8>>, String> {
+        let outcome = {
+            let ResponseBodyState::Finishing {
+                result,
+                response_result,
+            } = &mut self.state
+            else {
+                return Ok(None);
+            };
+            drop(response_result.take());
+            result.as_mut().await
+        };
+        self.state = ResponseBodyState::Consumed;
+        match outcome {
+            Ok(_) => Ok(None),
+            Err(error) => Err(format!("HTTP response body error: {error:?}")),
         }
     }
 }

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
@@ -16,7 +16,9 @@ type ResponseResultWriter = FutureWriter<Result<(), ErrorCode>>;
 #[derive(Default)]
 struct RecoveredReadState {
     outcome: Option<(StreamResult, Vec<u8>)>,
+    #[cfg(feature = "internal-test-execution")]
     recovered_bytes_for_test: usize,
+    #[cfg(feature = "internal-test-execution")]
     pause_ready_for_test: bool,
 }
 
@@ -25,6 +27,7 @@ type RecoveredRead = Rc<RefCell<RecoveredReadState>>;
 struct CancelSafeRead<'a> {
     read: Pin<Box<StreamRead<'a, u8>>>,
     recovered: RecoveredRead,
+    #[cfg(feature = "internal-test-execution")]
     ready_for_test: Option<(StreamResult, Vec<u8>)>,
     completed: bool,
 }
@@ -34,6 +37,7 @@ impl<'a> CancelSafeRead<'a> {
         Self {
             read: Box::pin(read),
             recovered,
+            #[cfg(feature = "internal-test-execution")]
             ready_for_test: None,
             completed: false,
         }
@@ -44,18 +48,22 @@ impl Future for CancelSafeRead<'_> {
     type Output = (StreamResult, Vec<u8>);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        #[cfg(feature = "internal-test-execution")]
         if self.ready_for_test.is_some() {
             return Poll::Pending;
         }
         match self.read.as_mut().poll(cx) {
             Poll::Ready(result) => {
-                let pause_ready_for_test = {
-                    let mut recovered = self.recovered.borrow_mut();
-                    std::mem::take(&mut recovered.pause_ready_for_test)
-                };
-                if pause_ready_for_test {
-                    self.ready_for_test = Some(result);
-                    return Poll::Pending;
+                #[cfg(feature = "internal-test-execution")]
+                {
+                    let pause_ready_for_test = {
+                        let mut recovered = self.recovered.borrow_mut();
+                        std::mem::take(&mut recovered.pause_ready_for_test)
+                    };
+                    if pause_ready_for_test {
+                        self.ready_for_test = Some(result);
+                        return Poll::Pending;
+                    }
                 }
                 self.completed = true;
                 Poll::Ready(result)
@@ -68,12 +76,18 @@ impl Future for CancelSafeRead<'_> {
 impl Drop for CancelSafeRead<'_> {
     fn drop(&mut self) {
         if !self.completed {
+            #[cfg(feature = "internal-test-execution")]
             let recovered = self
                 .ready_for_test
                 .take()
                 .unwrap_or_else(|| self.read.as_mut().cancel());
+            #[cfg(not(feature = "internal-test-execution"))]
+            let recovered = self.read.as_mut().cancel();
             let mut state = self.recovered.borrow_mut();
-            state.recovered_bytes_for_test += recovered.1.len();
+            #[cfg(feature = "internal-test-execution")]
+            {
+                state.recovered_bytes_for_test += recovered.1.len();
+            }
             state.outcome = Some(recovered);
         }
     }
@@ -122,10 +136,12 @@ impl ResponseBody {
         self.state = ResponseBodyState::Consumed;
     }
 
+    #[cfg(feature = "internal-test-execution")]
     pub(crate) fn take_recovered_read_bytes_for_test(&self) -> usize {
         std::mem::take(&mut self.recovered_read.borrow_mut().recovered_bytes_for_test)
     }
 
+    #[cfg(feature = "internal-test-execution")]
     pub(crate) fn pause_next_ready_read_for_test(&self) -> bool {
         self.recovered_read.borrow_mut().pause_ready_for_test = true;
         true

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
@@ -13,11 +13,19 @@ use wasip3::wit_bindgen::rt::async_support::{
 type BodyResultReader = FutureReader<Result<Option<Trailers>, ErrorCode>>;
 type BodyResultFuture = Pin<Box<<BodyResultReader as IntoFuture>::IntoFuture>>;
 type ResponseResultWriter = FutureWriter<Result<(), ErrorCode>>;
-type RecoveredRead = Rc<RefCell<Option<(StreamResult, Vec<u8>)>>>;
+#[derive(Default)]
+struct RecoveredReadState {
+    outcome: Option<(StreamResult, Vec<u8>)>,
+    recovered_bytes_for_test: usize,
+    pause_ready_for_test: bool,
+}
+
+type RecoveredRead = Rc<RefCell<RecoveredReadState>>;
 
 struct CancelSafeRead<'a> {
     read: Pin<Box<StreamRead<'a, u8>>>,
     recovered: RecoveredRead,
+    ready_for_test: Option<(StreamResult, Vec<u8>)>,
     completed: bool,
 }
 
@@ -26,6 +34,7 @@ impl<'a> CancelSafeRead<'a> {
         Self {
             read: Box::pin(read),
             recovered,
+            ready_for_test: None,
             completed: false,
         }
     }
@@ -35,8 +44,19 @@ impl Future for CancelSafeRead<'_> {
     type Output = (StreamResult, Vec<u8>);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.ready_for_test.is_some() {
+            return Poll::Pending;
+        }
         match self.read.as_mut().poll(cx) {
             Poll::Ready(result) => {
+                let pause_ready_for_test = {
+                    let mut recovered = self.recovered.borrow_mut();
+                    std::mem::take(&mut recovered.pause_ready_for_test)
+                };
+                if pause_ready_for_test {
+                    self.ready_for_test = Some(result);
+                    return Poll::Pending;
+                }
                 self.completed = true;
                 Poll::Ready(result)
             }
@@ -48,7 +68,13 @@ impl Future for CancelSafeRead<'_> {
 impl Drop for CancelSafeRead<'_> {
     fn drop(&mut self) {
         if !self.completed {
-            self.recovered.replace(Some(self.read.as_mut().cancel()));
+            let recovered = self
+                .ready_for_test
+                .take()
+                .unwrap_or_else(|| self.read.as_mut().cancel());
+            let mut state = self.recovered.borrow_mut();
+            state.recovered_bytes_for_test += recovered.1.len();
+            state.outcome = Some(recovered);
         }
     }
 }
@@ -81,19 +107,28 @@ impl ResponseBody {
     pub(crate) fn empty() -> Self {
         Self {
             state: ResponseBodyState::Consumed,
-            recovered_read: Rc::new(RefCell::new(None)),
+            recovered_read: Rc::new(RefCell::new(RecoveredReadState::default())),
         }
     }
 
     pub(crate) fn new(response: Response) -> Self {
         Self {
             state: ResponseBodyState::Unconsumed(response),
-            recovered_read: Rc::new(RefCell::new(None)),
+            recovered_read: Rc::new(RefCell::new(RecoveredReadState::default())),
         }
     }
 
     pub(crate) fn discard(&mut self) {
         self.state = ResponseBodyState::Consumed;
+    }
+
+    pub(crate) fn take_recovered_read_bytes_for_test(&self) -> usize {
+        std::mem::take(&mut self.recovered_read.borrow_mut().recovered_bytes_for_test)
+    }
+
+    pub(crate) fn pause_next_ready_read_for_test(&self) -> bool {
+        self.recovered_read.borrow_mut().pause_ready_for_test = true;
+        true
     }
 
     pub(crate) async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String> {
@@ -124,7 +159,7 @@ impl ResponseBody {
     async fn read_from_reader(&mut self) -> Result<Option<Vec<u8>>, String> {
         const CHUNK_SIZE: usize = 16 * 1024;
         loop {
-            let recovered = self.recovered_read.borrow_mut().take();
+            let recovered = self.recovered_read.borrow_mut().outcome.take();
             let (status, bytes) = if let Some(recovered) = recovered {
                 recovered
             } else {

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
@@ -1,15 +1,57 @@
 //! Shared Preview 3 response-body ownership for `fetch` and `node:http`.
 
-use std::future::IntoFuture;
+use std::cell::RefCell;
+use std::future::{Future, IntoFuture};
 use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll};
 use wasip3::http::types::{ErrorCode, Response, Trailers};
 use wasip3::wit_bindgen::rt::async_support::{
-    FutureReader, FutureWriter, StreamReader, StreamResult,
+    FutureReader, FutureWriter, StreamRead, StreamReader, StreamResult,
 };
 
 type BodyResultReader = FutureReader<Result<Option<Trailers>, ErrorCode>>;
 type BodyResultFuture = Pin<Box<<BodyResultReader as IntoFuture>::IntoFuture>>;
 type ResponseResultWriter = FutureWriter<Result<(), ErrorCode>>;
+type RecoveredRead = Rc<RefCell<Option<(StreamResult, Vec<u8>)>>>;
+
+struct CancelSafeRead<'a> {
+    read: Pin<Box<StreamRead<'a, u8>>>,
+    recovered: RecoveredRead,
+    completed: bool,
+}
+
+impl<'a> CancelSafeRead<'a> {
+    fn new(read: StreamRead<'a, u8>, recovered: RecoveredRead) -> Self {
+        Self {
+            read: Box::pin(read),
+            recovered,
+            completed: false,
+        }
+    }
+}
+
+impl Future for CancelSafeRead<'_> {
+    type Output = (StreamResult, Vec<u8>);
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.read.as_mut().poll(cx) {
+            Poll::Ready(result) => {
+                self.completed = true;
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for CancelSafeRead<'_> {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.recovered.replace(Some(self.read.as_mut().cancel()));
+        }
+    }
+}
 
 enum ResponseBodyState {
     Unconsumed(Response),
@@ -32,18 +74,21 @@ enum ResponseBodyState {
 /// the owner still drops the reader, body-result future, response-result writer, and response.
 pub(crate) struct ResponseBody {
     state: ResponseBodyState,
+    recovered_read: RecoveredRead,
 }
 
 impl ResponseBody {
     pub(crate) fn empty() -> Self {
         Self {
             state: ResponseBodyState::Consumed,
+            recovered_read: Rc::new(RefCell::new(None)),
         }
     }
 
     pub(crate) fn new(response: Response) -> Self {
         Self {
             state: ResponseBodyState::Unconsumed(response),
+            recovered_read: Rc::new(RefCell::new(None)),
         }
     }
 
@@ -79,11 +124,16 @@ impl ResponseBody {
     async fn read_from_reader(&mut self) -> Result<Option<Vec<u8>>, String> {
         const CHUNK_SIZE: usize = 16 * 1024;
         loop {
-            let (status, bytes) = {
+            let recovered = self.recovered_read.borrow_mut().take();
+            let (status, bytes) = if let Some(recovered) = recovered {
+                recovered
+            } else {
+                let recovered_read = self.recovered_read.clone();
                 let ResponseBodyState::Reading { reader, .. } = &mut self.state else {
                     return Ok(None);
                 };
-                reader.read(Vec::with_capacity(CHUNK_SIZE)).await
+                CancelSafeRead::new(reader.read(Vec::with_capacity(CHUNK_SIZE)), recovered_read)
+                    .await
             };
             match status {
                 StreamResult::Complete(_) if !bytes.is_empty() => return Ok(Some(bytes)),
@@ -108,10 +158,7 @@ impl ResponseBody {
                         Ok(Some(bytes))
                     };
                 }
-                StreamResult::Cancelled => {
-                    self.state = ResponseBodyState::Consumed;
-                    return Ok(None);
-                }
+                StreamResult::Cancelled => continue,
             }
         }
     }

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_body_p3.rs
@@ -1,0 +1,134 @@
+//! Shared Preview 3 response-body ownership for `fetch` and `node:http`.
+
+use wasip3::http::types::{ErrorCode, Response, Trailers};
+use wasip3::wit_bindgen::rt::async_support::{
+    FutureReader, FutureWriter, StreamReader, StreamResult,
+};
+
+type BodyResultReader = FutureReader<Result<Option<Trailers>, ErrorCode>>;
+type ResponseResultWriter = FutureWriter<Result<(), ErrorCode>>;
+
+enum ResponseBodyState {
+    Unconsumed(Response),
+    Reading {
+        reader: StreamReader<u8>,
+        result: BodyResultReader,
+        response_result: ResponseResultWriter,
+    },
+    Finishing {
+        result: BodyResultReader,
+        response_result: ResponseResultWriter,
+    },
+    Consumed,
+}
+
+/// Owns a native Preview 3 response until its body reaches EOF or is deliberately discarded.
+///
+/// A cancelled `read_chunk` future drops the state moved into that future, including the stream
+/// reader, body-result future, response-result writer, and response. The owner remains consumed,
+/// which prevents a cancelled transport operation from being resumed with stale resources.
+pub(crate) struct ResponseBody {
+    state: ResponseBodyState,
+}
+
+impl ResponseBody {
+    pub(crate) fn empty() -> Self {
+        Self {
+            state: ResponseBodyState::Consumed,
+        }
+    }
+
+    pub(crate) fn new(response: Response) -> Self {
+        Self {
+            state: ResponseBodyState::Unconsumed(response),
+        }
+    }
+
+    pub(crate) fn discard(&mut self) {
+        self.state = ResponseBodyState::Consumed;
+    }
+
+    pub(crate) async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String> {
+        let state = std::mem::replace(&mut self.state, ResponseBodyState::Consumed);
+        match state {
+            ResponseBodyState::Unconsumed(response) => {
+                let (response_result, response_result_reader) =
+                    wasip3::wit_future::new(|| Ok::<(), ErrorCode>(()));
+                let (reader, result) = Response::consume_body(response, response_result_reader);
+                self.state = ResponseBodyState::Reading {
+                    reader,
+                    result,
+                    response_result,
+                };
+                self.read_from_reader().await
+            }
+            ResponseBodyState::Reading {
+                reader,
+                result,
+                response_result,
+            } => {
+                self.state = ResponseBodyState::Reading {
+                    reader,
+                    result,
+                    response_result,
+                };
+                self.read_from_reader().await
+            }
+            ResponseBodyState::Finishing {
+                result,
+                response_result,
+            } => {
+                drop(response_result);
+                match result.await {
+                    Ok(_) => Ok(None),
+                    Err(error) => Err(format!("HTTP response body error: {error:?}")),
+                }
+            }
+            ResponseBodyState::Consumed => Ok(None),
+        }
+    }
+
+    async fn read_from_reader(&mut self) -> Result<Option<Vec<u8>>, String> {
+        let state = std::mem::replace(&mut self.state, ResponseBodyState::Consumed);
+        let ResponseBodyState::Reading {
+            mut reader,
+            result,
+            response_result,
+        } = state
+        else {
+            return Ok(None);
+        };
+
+        const CHUNK_SIZE: usize = 16 * 1024;
+        loop {
+            let (status, bytes) = reader.read(Vec::with_capacity(CHUNK_SIZE)).await;
+            match status {
+                StreamResult::Complete(_) if !bytes.is_empty() => {
+                    self.state = ResponseBodyState::Reading {
+                        reader,
+                        result,
+                        response_result,
+                    };
+                    return Ok(Some(bytes));
+                }
+                StreamResult::Complete(_) => continue,
+                StreamResult::Dropped => {
+                    drop(reader);
+                    if bytes.is_empty() {
+                        drop(response_result);
+                        return match result.await {
+                            Ok(_) => Ok(None),
+                            Err(error) => Err(format!("HTTP response body error: {error:?}")),
+                        };
+                    }
+                    self.state = ResponseBodyState::Finishing {
+                        result,
+                        response_result,
+                    };
+                    return Ok(Some(bytes));
+                }
+                StreamResult::Cancelled => return Ok(None),
+            }
+        }
+    }
+}

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_internal_test.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_internal_test.js
@@ -1,0 +1,12 @@
+Object.defineProperties(Response.prototype, {
+    pauseNextBodyReadAfterReadyForTest: {
+        value() {
+            return httpNative.pauseNextBodyReadAfterReadyForTest(this.nativeResponse);
+        },
+    },
+    takeRecoveredBodyReadBytesForTest: {
+        value() {
+            return httpNative.takeRecoveredBodyReadBytesForTest(this.nativeResponse);
+        },
+    },
+});

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -32,14 +32,15 @@ use rquickjs::convert::Coerced;
 use rquickjs::prelude::List;
 use rquickjs::{ArrayBuffer, Ctx, Exception, FromJs, IntoJs, JsLifetime, TypedArray, Value};
 
-use super::abort_signal::{ensure_not_aborted, with_abort_signal};
+use super::abort_signal::with_abort_signal;
 use super::http_body::ResponseBody as NativeResponseBody;
+use super::shared_response_body::{self, NativeBody, SharedBody};
+use futures::future::{AbortHandle, Abortable};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::task::{Poll, Waker};
 use url::Url;
 use wasip3::http::types::{ErrorCode, Fields, Method, Request, Response, Scheme, Trailers};
 use wasip3::wit_bindgen::{FutureWriter, StreamWriter};
@@ -876,12 +877,16 @@ enum ResponseBody {
     Consumed,
 }
 
-struct SharedResponseBody {
-    native: Option<NativeResponseBody>,
-    buffer: Vec<u8>,
-    finished: bool,
-    error: Option<String>,
-    waiters: Vec<Waker>,
+type SharedResponseBody = SharedBody<NativeResponseBody>;
+
+impl NativeBody for NativeResponseBody {
+    async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String> {
+        NativeResponseBody::read_chunk(self).await
+    }
+
+    fn discard(mut self) {
+        NativeResponseBody::discard(&mut self);
+    }
 }
 
 #[derive(rquickjs::class::Trace, JsLifetime)]
@@ -955,17 +960,8 @@ impl HttpResponse {
 
     pub fn discard_body(&mut self) {
         match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
-            ResponseBody::Native(mut native) => native.discard(),
-            ResponseBody::Shared(shared) => {
-                let mut shared = shared.borrow_mut();
-                if let Some(mut native) = shared.native.take() {
-                    native.discard();
-                }
-                shared.finished = true;
-                for waiter in shared.waiters.drain(..) {
-                    waiter.wake();
-                }
-            }
+            ResponseBody::Native(native) => native.discard(),
+            ResponseBody::Shared(shared) => SharedResponseBody::discard(&shared),
             ResponseBody::Bytes(_) | ResponseBody::Consumed => {}
         }
     }
@@ -1054,18 +1050,15 @@ impl HttpResponse {
 
     pub fn stream<'js>(&mut self, ctx: Ctx<'js>) -> rquickjs::Result<ResponseBodyStream> {
         match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
-            ResponseBody::Bytes(bytes) => Ok(ResponseBodyStream {
-                source: Some(ResponseBodyStreamSource::Bytes(bytes)),
-                position: 0,
-            }),
-            ResponseBody::Native(native) => Ok(ResponseBodyStream {
-                source: Some(ResponseBodyStreamSource::Native(native)),
-                position: 0,
-            }),
-            ResponseBody::Shared(shared) => Ok(ResponseBodyStream {
-                source: Some(ResponseBodyStreamSource::Shared(shared)),
-                position: 0,
-            }),
+            ResponseBody::Bytes(bytes) => Ok(ResponseBodyStream::from_source(
+                ResponseBodyStreamSource::Bytes(bytes),
+            )),
+            ResponseBody::Native(native) => Ok(ResponseBodyStream::from_source(
+                ResponseBodyStreamSource::Native(native),
+            )),
+            ResponseBody::Shared(shared) => Ok(ResponseBodyStream::from_source(
+                ResponseBodyStreamSource::Shared(shared),
+            )),
             ResponseBody::Consumed => Err(Exception::throw_message(
                 &ctx,
                 "The response has already been consumed",
@@ -1128,13 +1121,7 @@ impl HttpResponse {
                 ResponseBody::Bytes(bytes),
             ),
             ResponseBody::Native(native) => {
-                let shared = Rc::new(RefCell::new(SharedResponseBody {
-                    native: Some(native),
-                    buffer: Vec::new(),
-                    finished: false,
-                    error: None,
-                    waiters: Vec::new(),
-                }));
+                let shared = Rc::new(RefCell::new(SharedResponseBody::new(native)));
                 (
                     ResponseBody::Shared(shared.clone()),
                     ResponseBody::Shared(shared),
@@ -1164,7 +1151,6 @@ impl HttpResponse {
         ctx: &Ctx<'js>,
         signal: Option<Value<'js>>,
     ) -> rquickjs::Result<Vec<u8>> {
-        ensure_not_aborted(ctx, signal.as_ref())?;
         match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
             ResponseBody::Bytes(bytes) => Ok(bytes),
             ResponseBody::Native(mut native) => {
@@ -1195,99 +1181,10 @@ async fn collect_shared_body<'js>(
     signal: Option<Value<'js>>,
     shared: Rc<RefCell<SharedResponseBody>>,
 ) -> rquickjs::Result<Vec<u8>> {
-    let read = async {
-        let mut position = 0;
-        let mut bytes = Vec::new();
-        while let Some(chunk) = read_shared_body_chunk(ctx, None, &shared, position).await? {
-            position += chunk.len();
-            bytes.extend_from_slice(&chunk);
-        }
-        Ok(bytes)
-    };
-    with_abort_signal(ctx, signal, read).await
-}
-
-async fn read_shared_body_chunk<'js>(
-    ctx: &Ctx<'js>,
-    signal: Option<Value<'js>>,
-    shared: &Rc<RefCell<SharedResponseBody>>,
-    position: usize,
-) -> rquickjs::Result<Option<Vec<u8>>> {
-    loop {
-        {
-            let state = shared.borrow();
-            if position < state.buffer.len() {
-                let end = (position + 16 * 1024).min(state.buffer.len());
-                return Ok(Some(state.buffer[position..end].to_vec()));
-            }
-            if let Some(error) = &state.error {
-                return Err(Exception::throw_message(ctx, error));
-            }
-            if state.finished {
-                return Ok(None);
-            }
-        }
-
-        let native = shared.borrow_mut().native.take();
-        let Some(mut native) = native else {
-            let wait = std::future::poll_fn(|cx| {
-                let mut state = shared.borrow_mut();
-                if position < state.buffer.len()
-                    || state.error.is_some()
-                    || state.finished
-                    || state.native.is_some()
-                {
-                    Poll::Ready(())
-                } else {
-                    if !state
-                        .waiters
-                        .iter()
-                        .any(|waker| waker.will_wake(cx.waker()))
-                    {
-                        state.waiters.push(cx.waker().clone());
-                    }
-                    Poll::Pending
-                }
-            });
-            with_abort_signal(ctx, signal.clone(), async {
-                wait.await;
-                Ok(())
-            })
-            .await?;
-            continue;
-        };
-
-        let read = async { Ok(native.read_chunk().await) };
-        let outcome = with_abort_signal(ctx, signal, read).await;
-        let mut state = shared.borrow_mut();
-        let result = match outcome {
-            Err(error) => {
-                state.finished = true;
-                state.native = None;
-                Err(error)
-            }
-            Ok(Err(error)) => {
-                state.error = Some(error.clone());
-                state.finished = true;
-                state.native = None;
-                Err(Exception::throw_message(ctx, &error))
-            }
-            Ok(Ok(Some(chunk))) => {
-                state.buffer.extend_from_slice(&chunk);
-                state.native = Some(native);
-                Ok(Some(chunk))
-            }
-            Ok(Ok(None)) => {
-                state.finished = true;
-                state.native = None;
-                Ok(None)
-            }
-        };
-        for waiter in state.waiters.drain(..) {
-            waiter.wake();
-        }
-        return result;
-    }
+    with_abort_signal(ctx, signal, async {
+        shared_response_body::collect(ctx, shared).await
+    })
+    .await
 }
 
 enum ResponseBodyStreamSource {
@@ -1297,19 +1194,38 @@ enum ResponseBodyStreamSource {
 }
 
 /// Response body reader backing `response.body` / `ReadableStream`.
-#[derive(Default, rquickjs::class::Trace, JsLifetime)]
+#[derive(rquickjs::class::Trace, JsLifetime)]
 #[rquickjs::class(rename_all = "camelCase")]
 pub struct ResponseBodyStream {
     #[qjs(skip_trace)]
+    state: Rc<RefCell<ResponseBodyStreamState>>,
+}
+
+struct ResponseBodyStreamState {
     source: Option<ResponseBodyStreamSource>,
     position: usize,
+    active_abort: Option<AbortHandle>,
+    discarded: bool,
+}
+
+impl Default for ResponseBodyStream {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[rquickjs::methods(rename_all = "camelCase")]
 impl ResponseBodyStream {
     #[qjs(constructor)]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            state: Rc::new(RefCell::new(ResponseBodyStreamState {
+                source: None,
+                position: 0,
+                active_abort: None,
+                discarded: false,
+            })),
+        }
     }
 
     #[qjs(get, rename = "type")]
@@ -1318,50 +1234,100 @@ impl ResponseBodyStream {
     }
 
     pub async fn pull<'js>(
-        &mut self,
+        &self,
         ctx: Ctx<'js>,
-        signal: Option<Value<'js>>,
     ) -> rquickjs::Result<List<(Option<TypedArray<'js, u8>>, Option<String>)>> {
-        let Some(source) = self.source.take() else {
+        let (source, position) = {
+            let mut state = self.state.borrow_mut();
+            if state.discarded {
+                return Ok(List((None, None)));
+            }
+            (state.source.take(), state.position)
+        };
+        let Some(source) = source else {
             return Ok(List((None, None)));
         };
-        let chunk = match source {
-            ResponseBodyStreamSource::Bytes(bytes) => {
-                if self.position >= bytes.len() {
-                    None
-                } else {
-                    let end = (self.position + 16 * 1024).min(bytes.len());
-                    let chunk = bytes[self.position..end].to_vec();
-                    self.source = Some(ResponseBodyStreamSource::Bytes(bytes));
-                    Some(chunk)
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        self.state.borrow_mut().active_abort = Some(abort_handle);
+        let pull_ctx = ctx.clone();
+        let pull = async move {
+            let result = match source {
+                ResponseBodyStreamSource::Bytes(bytes) => {
+                    if position >= bytes.len() {
+                        (None, None)
+                    } else {
+                        let end = (position + 16 * 1024).min(bytes.len());
+                        let chunk = bytes[position..end].to_vec();
+                        (Some(chunk), Some(ResponseBodyStreamSource::Bytes(bytes)))
+                    }
                 }
-            }
-            ResponseBodyStreamSource::Native(mut native) => {
-                let read = async { Ok(native.read_chunk().await) };
-                let chunk = with_abort_signal(&ctx, signal, read)
-                    .await?
-                    .map_err(|error| Exception::throw_message(&ctx, &error))?;
-                if chunk.is_some() {
-                    self.source = Some(ResponseBodyStreamSource::Native(native));
+                ResponseBodyStreamSource::Native(mut native) => {
+                    let chunk = native
+                        .read_chunk()
+                        .await
+                        .map_err(|error| Exception::throw_message(&pull_ctx, &error))?;
+                    let source = chunk
+                        .as_ref()
+                        .map(|_| ResponseBodyStreamSource::Native(native));
+                    (chunk, source)
                 }
-                chunk
-            }
-            ResponseBodyStreamSource::Shared(shared) => {
-                let chunk = read_shared_body_chunk(&ctx, signal, &shared, self.position).await?;
-                if chunk.is_some() {
-                    self.source = Some(ResponseBodyStreamSource::Shared(shared));
+                ResponseBodyStreamSource::Shared(shared) => {
+                    let chunk =
+                        shared_response_body::read_chunk(&pull_ctx, &shared, position).await?;
+                    let source = chunk
+                        .as_ref()
+                        .map(|_| ResponseBodyStreamSource::Shared(shared));
+                    (chunk, source)
                 }
-                chunk
+            };
+            Ok::<_, rquickjs::Error>(result)
+        };
+        let outcome = Abortable::new(pull, abort_registration).await;
+        let (chunk, source) = match outcome {
+            Ok(result) => result?,
+            Err(_) => {
+                let mut state = self.state.borrow_mut();
+                state.active_abort = None;
+                state.discarded = true;
+                return Err(Exception::throw_message(
+                    &ctx,
+                    "Response body stream was discarded",
+                ));
             }
         };
+        let mut state = self.state.borrow_mut();
+        state.active_abort = None;
+        if !state.discarded {
+            state.source = source;
+        }
         let Some(chunk) = chunk else {
             return Ok(List((None, None)));
         };
         let array = TypedArray::new_copy(ctx.clone(), &chunk).map_err(|_| {
             Exception::throw_message(&ctx, "Failed to create TypedArray from response body chunk")
         })?;
-        self.position += chunk.len();
+        state.position += chunk.len();
         Ok(List((Some(array), None)))
+    }
+
+    pub fn discard(&self) {
+        let (source, abort) = {
+            let mut state = self.state.borrow_mut();
+            state.discarded = true;
+            (state.source.take(), state.active_abort.take())
+        };
+        drop(source);
+        if let Some(abort) = abort {
+            abort.abort();
+        }
+    }
+}
+
+impl ResponseBodyStream {
+    fn from_source(source: ResponseBodyStreamSource) -> Self {
+        let response = Self::new();
+        response.state.borrow_mut().source = Some(source);
+        response
     }
 }
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -54,10 +54,38 @@ type SendFuture = Pin<Box<dyn Future<Output = Result<Response, ErrorCode>>>>;
 type TrailersWriter = FutureWriter<Result<Option<Trailers>, ErrorCode>>;
 
 /// Native module exposed to JavaScript as `__wasm_rquickjs_builtin/http_native`.
+#[cfg(not(feature = "internal-test-execution"))]
 #[rquickjs::module]
 pub mod native_module {
     pub use super::HttpRequest;
     pub use super::HttpResponse;
+}
+
+/// Test-instrumented variant of the native HTTP module. Keeping the hooks as module functions
+/// avoids adding test-only methods to the production `HttpResponse` JavaScript prototype.
+#[cfg(feature = "internal-test-execution")]
+#[rquickjs::module]
+pub mod native_module {
+    pub use super::HttpRequest;
+    pub use super::HttpResponse;
+
+    #[qjs(rename = "takeRecoveredBodyReadBytesForTest")]
+    #[rquickjs::function]
+    pub fn take_recovered_body_read_bytes_for_test<'js>(
+        response: rquickjs::Class<'js, super::HttpResponse>,
+    ) -> usize {
+        response.borrow().take_recovered_body_read_bytes_for_test()
+    }
+
+    #[qjs(rename = "pauseNextBodyReadAfterReadyForTest")]
+    #[rquickjs::function]
+    pub fn pause_next_body_read_after_ready_for_test<'js>(
+        response: rquickjs::Class<'js, super::HttpResponse>,
+    ) -> bool {
+        response
+            .borrow()
+            .pause_next_body_read_after_ready_for_test()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -976,24 +1004,6 @@ impl HttpResponse {
         }
     }
 
-    #[cfg(feature = "internal-test-execution")]
-    pub fn take_recovered_body_read_bytes_for_test(&self) -> usize {
-        match &self.body {
-            ResponseBody::Native(native) => native.take_recovered_read_bytes_for_test(),
-            ResponseBody::Shared(shared) => shared.take_recovered_read_bytes_for_test(),
-            ResponseBody::Bytes(_) | ResponseBody::Consumed => 0,
-        }
-    }
-
-    #[cfg(feature = "internal-test-execution")]
-    pub fn pause_next_body_read_after_ready_for_test(&self) -> bool {
-        match &self.body {
-            ResponseBody::Native(native) => native.pause_next_ready_read_for_test(),
-            ResponseBody::Shared(shared) => shared.pause_next_ready_read_for_test(),
-            ResponseBody::Bytes(_) | ResponseBody::Consumed => false,
-        }
-    }
-
     /// Turns this response into a `redirect: "manual"` opaque-redirect filtered response. Like
     /// [`make_opaque`], it hides status/headers/body, but it additionally reports a `type` of
     /// `opaqueredirect` (via [`is_opaque_redirect`]) so the public `Response.type` getter can tell
@@ -1171,6 +1181,24 @@ impl HttpResponse {
 }
 
 impl HttpResponse {
+    #[cfg(feature = "internal-test-execution")]
+    fn take_recovered_body_read_bytes_for_test(&self) -> usize {
+        match &self.body {
+            ResponseBody::Native(native) => native.take_recovered_read_bytes_for_test(),
+            ResponseBody::Shared(shared) => shared.take_recovered_read_bytes_for_test(),
+            ResponseBody::Bytes(_) | ResponseBody::Consumed => 0,
+        }
+    }
+
+    #[cfg(feature = "internal-test-execution")]
+    fn pause_next_body_read_after_ready_for_test(&self) -> bool {
+        match &self.body {
+            ResponseBody::Native(native) => native.pause_next_ready_read_for_test(),
+            ResponseBody::Shared(shared) => shared.pause_next_ready_read_for_test(),
+            ResponseBody::Bytes(_) | ResponseBody::Consumed => false,
+        }
+    }
+
     async fn take_body<'js>(
         &mut self,
         ctx: &Ctx<'js>,

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -1653,7 +1653,14 @@ fn is_https_to_http(from_url: &Url, to_url: &Url) -> bool {
 // JavaScript sources (shared with the Preview 2 path).
 // ---------------------------------------------------------------------------
 
+#[cfg(not(feature = "internal-test-execution"))]
 pub const HTTP_JS: &str = include_str!("http.js");
+#[cfg(feature = "internal-test-execution")]
+pub const HTTP_JS: &str = concat!(
+    include_str!("http.js"),
+    "\n",
+    include_str!("http_internal_test.js")
+);
 pub const FETCH_BLOB_JS: &str = include_str!("fetch-blob-4.0.0.js");
 pub const FORMDATA_JS: &str = include_str!("formdata-polyfill-4.0.10.js");
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -887,6 +887,14 @@ impl NativeBody for NativeResponseBody {
     fn discard(mut self) {
         NativeResponseBody::discard(&mut self);
     }
+
+    fn take_recovered_read_bytes_for_test(&self) -> usize {
+        NativeResponseBody::take_recovered_read_bytes_for_test(self)
+    }
+
+    fn pause_next_ready_read_for_test(&self) -> bool {
+        NativeResponseBody::pause_next_ready_read_for_test(self)
+    }
 }
 
 #[derive(rquickjs::class::Trace, JsLifetime)]
@@ -963,6 +971,22 @@ impl HttpResponse {
             ResponseBody::Native(native) => native.discard(),
             ResponseBody::Shared(shared) => shared.discard(),
             ResponseBody::Bytes(_) | ResponseBody::Consumed => {}
+        }
+    }
+
+    pub fn take_recovered_body_read_bytes_for_test(&self) -> usize {
+        match &self.body {
+            ResponseBody::Native(native) => native.take_recovered_read_bytes_for_test(),
+            ResponseBody::Shared(shared) => shared.take_recovered_read_bytes_for_test(),
+            ResponseBody::Bytes(_) | ResponseBody::Consumed => 0,
+        }
+    }
+
+    pub fn pause_next_body_read_after_ready_for_test(&self) -> bool {
+        match &self.body {
+            ResponseBody::Native(native) => native.pause_next_ready_read_for_test(),
+            ResponseBody::Shared(shared) => shared.pause_next_ready_read_for_test(),
+            ResponseBody::Bytes(_) | ResponseBody::Consumed => false,
         }
     }
 
@@ -1122,10 +1146,7 @@ impl HttpResponse {
             ),
             ResponseBody::Native(native) => {
                 let (kept, cloned) = SharedResponseBody::pair(native);
-                (
-                    ResponseBody::Shared(kept),
-                    ResponseBody::Shared(cloned),
-                )
+                (ResponseBody::Shared(kept), ResponseBody::Shared(cloned))
             }
             ResponseBody::Shared(shared) => (
                 ResponseBody::Shared(shared.branch()),

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -32,13 +32,14 @@ use rquickjs::convert::Coerced;
 use rquickjs::prelude::List;
 use rquickjs::{ArrayBuffer, Ctx, Exception, FromJs, IntoJs, JsLifetime, TypedArray, Value};
 
-use super::abort_signal::with_abort_signal;
+use super::abort_signal::{ensure_not_aborted, with_abort_signal};
 use super::http_body::ResponseBody as NativeResponseBody;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::task::{Poll, Waker};
 use url::Url;
 use wasip3::http::types::{ErrorCode, Fields, Method, Request, Response, Scheme, Trailers};
 use wasip3::wit_bindgen::{FutureWriter, StreamWriter};
@@ -870,6 +871,7 @@ impl WrappedRequestBodyWriter {
 
 enum ResponseBody {
     Bytes(Vec<u8>),
+    Native(NativeResponseBody),
     Shared(Rc<RefCell<SharedResponseBody>>),
     Consumed,
 }
@@ -879,6 +881,7 @@ struct SharedResponseBody {
     buffer: Vec<u8>,
     finished: bool,
     error: Option<String>,
+    waiters: Vec<Waker>,
 }
 
 #[derive(rquickjs::class::Trace, JsLifetime)]
@@ -886,11 +889,6 @@ struct SharedResponseBody {
 pub struct HttpResponse {
     #[qjs(skip_trace)]
     body: ResponseBody,
-    /// A response body that failed mid-transfer (e.g. a truncated response). It is deferred until
-    /// the body is consumed so that a discarded response (e.g. an intermediate redirect body) does
-    /// not surface a spurious error, matching the buffered path's redirect handling.
-    #[qjs(skip_trace)]
-    body_error: Option<String>,
     headers: Vec<Vec<String>>,
     status: u16,
     is_opaque: bool,
@@ -914,7 +912,6 @@ impl HttpResponse {
     pub fn new() -> Self {
         Self {
             body: ResponseBody::Consumed,
-            body_error: None,
             headers: Vec::new(),
             status: 200,
             is_opaque: false,
@@ -925,19 +922,8 @@ impl HttpResponse {
 
     #[qjs(skip)]
     pub fn from_parts(status: u16, headers: Vec<Vec<String>>, body: Vec<u8>) -> Self {
-        Self::from_parts_with_error(status, headers, body, None)
-    }
-
-    #[qjs(skip)]
-    pub fn from_parts_with_error(
-        status: u16,
-        headers: Vec<Vec<String>>,
-        body: Vec<u8>,
-        body_error: Option<String>,
-    ) -> Self {
         Self {
             body: ResponseBody::Bytes(body),
-            body_error,
             headers,
             status,
             is_opaque: false,
@@ -949,13 +935,7 @@ impl HttpResponse {
     #[qjs(skip)]
     fn from_response(status: u16, headers: Vec<Vec<String>>, response: Response) -> Self {
         Self {
-            body: ResponseBody::Shared(Rc::new(RefCell::new(SharedResponseBody {
-                native: Some(NativeResponseBody::new(response)),
-                buffer: Vec::new(),
-                finished: false,
-                error: None,
-            }))),
-            body_error: None,
+            body: ResponseBody::Native(NativeResponseBody::new(response)),
             headers,
             status,
             is_opaque: false,
@@ -971,12 +951,23 @@ impl HttpResponse {
         self.status = 200; // reported as 0 while opaque
         // Opaque responses never surface their body to JS, so a deferred body-transfer error is
         // not observable and must not fail the fetch.
-        self.body_error = None;
     }
 
     pub fn discard_body(&mut self) {
-        self.body = ResponseBody::Consumed;
-        self.body_error = None;
+        match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
+            ResponseBody::Native(mut native) => native.discard(),
+            ResponseBody::Shared(shared) => {
+                let mut shared = shared.borrow_mut();
+                if let Some(mut native) = shared.native.take() {
+                    native.discard();
+                }
+                shared.finished = true;
+                for waiter in shared.waiters.drain(..) {
+                    waiter.wake();
+                }
+            }
+            ResponseBody::Bytes(_) | ResponseBody::Consumed => {}
+        }
     }
 
     /// Turns this response into a `redirect: "manual"` opaque-redirect filtered response. Like
@@ -1067,6 +1058,10 @@ impl HttpResponse {
                 source: Some(ResponseBodyStreamSource::Bytes(bytes)),
                 position: 0,
             }),
+            ResponseBody::Native(native) => Ok(ResponseBodyStream {
+                source: Some(ResponseBodyStreamSource::Native(native)),
+                position: 0,
+            }),
             ResponseBody::Shared(shared) => Ok(ResponseBodyStream {
                 source: Some(ResponseBodyStreamSource::Shared(shared)),
                 position: 0,
@@ -1082,7 +1077,6 @@ impl HttpResponse {
     pub fn error() -> Self {
         Self {
             body: ResponseBody::Consumed,
-            body_error: None,
             headers: Vec::new(),
             status: 500,
             is_opaque: false,
@@ -1100,7 +1094,6 @@ impl HttpResponse {
             .unwrap_or(302);
         Self {
             body: ResponseBody::Consumed,
-            body_error: None,
             headers: vec![vec!["location".to_string(), url.0]],
             status: status_code,
             is_opaque: false,
@@ -1117,7 +1110,6 @@ impl HttpResponse {
             .unwrap_or(200);
         Self {
             body: ResponseBody::Bytes(data.as_bytes().map(|b| b.to_vec()).unwrap_or_default()),
-            body_error: None,
             headers: vec![vec![
                 "content-type".to_string(),
                 "application/json".to_string(),
@@ -1135,6 +1127,19 @@ impl HttpResponse {
                 ResponseBody::Bytes(bytes.clone()),
                 ResponseBody::Bytes(bytes),
             ),
+            ResponseBody::Native(native) => {
+                let shared = Rc::new(RefCell::new(SharedResponseBody {
+                    native: Some(native),
+                    buffer: Vec::new(),
+                    finished: false,
+                    error: None,
+                    waiters: Vec::new(),
+                }));
+                (
+                    ResponseBody::Shared(shared.clone()),
+                    ResponseBody::Shared(shared),
+                )
+            }
             ResponseBody::Shared(shared) => (
                 ResponseBody::Shared(shared.clone()),
                 ResponseBody::Shared(shared),
@@ -1144,7 +1149,6 @@ impl HttpResponse {
         self.body = kept;
         Self {
             body: cloned,
-            body_error: self.body_error.clone(),
             headers: self.headers.clone(),
             status: self.status,
             is_opaque: self.is_opaque,
@@ -1160,14 +1164,22 @@ impl HttpResponse {
         ctx: &Ctx<'js>,
         signal: Option<Value<'js>>,
     ) -> rquickjs::Result<Vec<u8>> {
+        ensure_not_aborted(ctx, signal.as_ref())?;
         match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
-            ResponseBody::Bytes(bytes) => {
-                // A body that failed mid-transfer must reject when the caller actually consumes it
-                // instead of surfacing partial bytes.
-                if let Some(err) = self.body_error.take() {
-                    return Err(Exception::throw_message(ctx, &err));
-                }
-                Ok(bytes)
+            ResponseBody::Bytes(bytes) => Ok(bytes),
+            ResponseBody::Native(mut native) => {
+                let read = async move {
+                    let mut bytes = Vec::new();
+                    while let Some(chunk) = native
+                        .read_chunk()
+                        .await
+                        .map_err(|error| Exception::throw_message(ctx, &error))?
+                    {
+                        bytes.extend_from_slice(&chunk);
+                    }
+                    Ok(bytes)
+                };
+                with_abort_signal(ctx, signal, read).await
             }
             ResponseBody::Shared(shared) => collect_shared_body(ctx, signal, shared).await,
             ResponseBody::Consumed => Err(Exception::throw_message(
@@ -1183,13 +1195,16 @@ async fn collect_shared_body<'js>(
     signal: Option<Value<'js>>,
     shared: Rc<RefCell<SharedResponseBody>>,
 ) -> rquickjs::Result<Vec<u8>> {
-    let mut position = 0;
-    let mut bytes = Vec::new();
-    while let Some(chunk) = read_shared_body_chunk(ctx, signal.clone(), &shared, position).await? {
-        position += chunk.len();
-        bytes.extend_from_slice(&chunk);
-    }
-    Ok(bytes)
+    let read = async {
+        let mut position = 0;
+        let mut bytes = Vec::new();
+        while let Some(chunk) = read_shared_body_chunk(ctx, None, &shared, position).await? {
+            position += chunk.len();
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(bytes)
+    };
+    with_abort_signal(ctx, signal, read).await
 }
 
 async fn read_shared_body_chunk<'js>(
@@ -1198,60 +1213,86 @@ async fn read_shared_body_chunk<'js>(
     shared: &Rc<RefCell<SharedResponseBody>>,
     position: usize,
 ) -> rquickjs::Result<Option<Vec<u8>>> {
-    {
-        let state = shared.borrow();
-        if position < state.buffer.len() {
-            let end = (position + 16 * 1024).min(state.buffer.len());
-            return Ok(Some(state.buffer[position..end].to_vec()));
+    loop {
+        {
+            let state = shared.borrow();
+            if position < state.buffer.len() {
+                let end = (position + 16 * 1024).min(state.buffer.len());
+                return Ok(Some(state.buffer[position..end].to_vec()));
+            }
+            if let Some(error) = &state.error {
+                return Err(Exception::throw_message(ctx, error));
+            }
+            if state.finished {
+                return Ok(None);
+            }
         }
-        if let Some(error) = &state.error {
-            return Err(Exception::throw_message(ctx, error));
-        }
-        if state.finished {
-            return Ok(None);
-        }
-    }
 
-    let Some(mut native) = shared.borrow_mut().native.take() else {
-        return Err(Exception::throw_message(
-            ctx,
-            "A cloned response body read is already in progress",
-        ));
-    };
+        let native = shared.borrow_mut().native.take();
+        let Some(mut native) = native else {
+            let wait = std::future::poll_fn(|cx| {
+                let mut state = shared.borrow_mut();
+                if position < state.buffer.len()
+                    || state.error.is_some()
+                    || state.finished
+                    || state.native.is_some()
+                {
+                    Poll::Ready(())
+                } else {
+                    if !state
+                        .waiters
+                        .iter()
+                        .any(|waker| waker.will_wake(cx.waker()))
+                    {
+                        state.waiters.push(cx.waker().clone());
+                    }
+                    Poll::Pending
+                }
+            });
+            with_abort_signal(ctx, signal.clone(), async {
+                wait.await;
+                Ok(())
+            })
+            .await?;
+            continue;
+        };
 
-    let read = async { Ok(native.read_chunk().await) };
-    let outcome = with_abort_signal(ctx, signal, read).await;
-    match outcome {
-        Err(error) => {
-            let mut state = shared.borrow_mut();
-            state.finished = true;
-            state.native = None;
-            Err(error)
+        let read = async { Ok(native.read_chunk().await) };
+        let outcome = with_abort_signal(ctx, signal, read).await;
+        let mut state = shared.borrow_mut();
+        let result = match outcome {
+            Err(error) => {
+                state.finished = true;
+                state.native = None;
+                Err(error)
+            }
+            Ok(Err(error)) => {
+                state.error = Some(error.clone());
+                state.finished = true;
+                state.native = None;
+                Err(Exception::throw_message(ctx, &error))
+            }
+            Ok(Ok(Some(chunk))) => {
+                state.buffer.extend_from_slice(&chunk);
+                state.native = Some(native);
+                Ok(Some(chunk))
+            }
+            Ok(Ok(None)) => {
+                state.finished = true;
+                state.native = None;
+                Ok(None)
+            }
+        };
+        for waiter in state.waiters.drain(..) {
+            waiter.wake();
         }
-        Ok(Err(error)) => {
-            let mut state = shared.borrow_mut();
-            state.error = Some(error.clone());
-            state.finished = true;
-            state.native = None;
-            Err(Exception::throw_message(ctx, &error))
-        }
-        Ok(Ok(Some(chunk))) => {
-            let mut state = shared.borrow_mut();
-            state.buffer.extend_from_slice(&chunk);
-            state.native = Some(native);
-            Ok(Some(chunk))
-        }
-        Ok(Ok(None)) => {
-            let mut state = shared.borrow_mut();
-            state.finished = true;
-            state.native = None;
-            Ok(None)
-        }
+        return result;
     }
 }
 
 enum ResponseBodyStreamSource {
     Bytes(Vec<u8>),
+    Native(NativeResponseBody),
     Shared(Rc<RefCell<SharedResponseBody>>),
 }
 
@@ -1281,7 +1322,7 @@ impl ResponseBodyStream {
         ctx: Ctx<'js>,
         signal: Option<Value<'js>>,
     ) -> rquickjs::Result<List<(Option<TypedArray<'js, u8>>, Option<String>)>> {
-        let Some(source) = self.source.as_ref() else {
+        let Some(source) = self.source.take() else {
             return Ok(List((None, None)));
         };
         let chunk = match source {
@@ -1290,15 +1331,30 @@ impl ResponseBodyStream {
                     None
                 } else {
                     let end = (self.position + 16 * 1024).min(bytes.len());
-                    Some(bytes[self.position..end].to_vec())
+                    let chunk = bytes[self.position..end].to_vec();
+                    self.source = Some(ResponseBodyStreamSource::Bytes(bytes));
+                    Some(chunk)
                 }
             }
+            ResponseBodyStreamSource::Native(mut native) => {
+                let read = async { Ok(native.read_chunk().await) };
+                let chunk = with_abort_signal(&ctx, signal, read)
+                    .await?
+                    .map_err(|error| Exception::throw_message(&ctx, &error))?;
+                if chunk.is_some() {
+                    self.source = Some(ResponseBodyStreamSource::Native(native));
+                }
+                chunk
+            }
             ResponseBodyStreamSource::Shared(shared) => {
-                read_shared_body_chunk(&ctx, signal, shared, self.position).await?
+                let chunk = read_shared_body_chunk(&ctx, signal, &shared, self.position).await?;
+                if chunk.is_some() {
+                    self.source = Some(ResponseBodyStreamSource::Shared(shared));
+                }
+                chunk
             }
         };
         let Some(chunk) = chunk else {
-            self.source = None;
             return Ok(List((None, None)));
         };
         let array = TypedArray::new_copy(ctx.clone(), &chunk).map_err(|_| {

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -14,9 +14,9 @@
 //! bodies (string / `ArrayBuffer` / `Uint8Array` / `URLSearchParams` / `Blob` / `FormData`,
 //! the latter two are converted to `ArrayBuffer` by `http.js` before reaching native code),
 //! redirect following/error/manual policies, credentials filtering, referrer policy, and
-//! response consumption via `text()`, `arrayBuffer()`, and `body`/`stream()`. Response bodies
-//! are read to completion eagerly after the response head arrives, so streaming is served from
-//! the buffered bytes.
+//! response consumption via `text()`, `arrayBuffer()`, and `body`/`stream()`. Response heads are
+//! returned immediately and native response bodies are consumed lazily, with buffering only when
+//! clones need independent views of the same underlying stream.
 //!
 //! Streaming *request* bodies (a `ReadableStream` passed as the fetch body) are also supported.
 //! `http.js` drives them through the split native contract (`initSend` / `initRequestBody` /
@@ -33,9 +33,12 @@ use rquickjs::prelude::List;
 use rquickjs::{ArrayBuffer, Ctx, Exception, FromJs, IntoJs, JsLifetime, TypedArray, Value};
 
 use super::abort_signal::with_abort_signal;
+use super::http_body::ResponseBody as NativeResponseBody;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::rc::Rc;
 use url::Url;
 use wasip3::http::types::{ErrorCode, Fields, Method, Request, Response, Scheme, Trailers};
 use wasip3::wit_bindgen::{FutureWriter, StreamWriter};
@@ -544,16 +547,9 @@ impl HttpRequest {
             return Ok(opaque);
         }
 
-        // Final visible response: read the body fully. A body that failed mid-transfer must reject
-        // the fetch immediately (matching the buffered `simple_send` path) instead of surfacing
-        // partial bytes or deferring the error to `text()`/`arrayBuffer()`. Because discarded
-        // redirect / opaque bodies were already dropped above, reaching here means the body is
-        // genuinely visible to JS, so it is safe to fail `fetch()` eagerly.
-        let (body, body_error) = consume_response_body(response).await;
-        if let Some(err) = body_error {
-            return Err(Exception::throw_message(&ctx, &err));
-        }
-        Ok(HttpResponse::from_parts(status, resp_headers, body))
+        // Preserve the native body owner so fetch resolves after the response head. Transfer
+        // errors are surfaced when JS consumes the body, matching the Preview 2 lifecycle.
+        Ok(HttpResponse::from_response(status, resp_headers, response))
     }
 
     /// Buffered send with redirect handling. Only the final visible response body is read; the
@@ -682,13 +678,9 @@ impl HttpRequest {
                 return Ok(opaque);
             }
 
-            // Non-opaque final response: read the body fully. A body that failed mid-transfer must
-            // reject the fetch instead of surfacing partial bytes.
-            let (body, body_error) = consume_response_body(response).await;
-            if let Some(err) = body_error {
-                return Err(Exception::throw_message(&ctx, &err));
-            }
-            let mut response = HttpResponse::from_parts(status, resp_headers, body);
+            // Keep the final response body native and lazy so fetch resolves as soon as the head
+            // arrives. Body transfer failures remain observable at consumption time.
+            let mut response = HttpResponse::from_response(status, resp_headers, response);
             response.redirected = current_redirects > 0;
             return Ok(response);
         }
@@ -724,9 +716,9 @@ impl HttpRequest {
 }
 
 /// Performs a single (non-redirecting) request through `wasi:http/client` and returns the response
-/// head. The response body is **not** consumed here: the caller reads it with
-/// [`consume_response_body`] for a final visible response, or drops the response to discard the
-/// body of a followed redirect / opaque response without paying for a large or never-ending body.
+/// head. The response body is **not** consumed here: the caller retains it for a final visible
+/// response, or drops it to discard a followed redirect / opaque response without paying for a
+/// large or never-ending body.
 async fn send_once(
     ctx: &Ctx<'_>,
     url: &Url,
@@ -789,38 +781,6 @@ async fn send_once(
         .map_err(|e| Exception::throw_message(ctx, &format!("HTTP request failed: {e:?}")))?;
 
     Ok(response)
-}
-
-/// Reads a `wasi:http` response body fully into memory.
-///
-/// Returns `(body, body_error)`. `body_error` is `Some(message)` when the response body failed
-/// mid-transfer (e.g. a truncated response); the caller decides whether to surface it. Only call
-/// this for responses whose body is actually visible to JS — a discarded redirect / opaque body
-/// should be dropped without reading instead, so a large or never-ending body cannot stall fetch.
-async fn consume_response_body(response: Response) -> (Vec<u8>, Option<String>) {
-    // Consume the response body stream fully. The `res` future communicates a handling error to
-    // the transport; we always signal success by letting its writer resolve to `Ok(())`.
-    let (res_tx, res_rx) = wasip3::wit_future::new(|| Ok::<(), ErrorCode>(()));
-    let (body_reader, body_result) = Response::consume_body(response, res_rx);
-    let body = body_reader.collect().await;
-    // Do not report successful response processing to the host until the body
-    // stream is fully consumed. Resolving this future early can let the HTTP
-    // transport recycle or tear down the connection while the guest still
-    // reads it, making a subsequent request intermittently observe an
-    // incomplete response under concurrent load.
-    drop(res_tx);
-
-    // The returned future only resolves after the body stream is closed (which the `collect`
-    // above guarantees). Await it to detect a body that failed mid-transfer — e.g. a truncated
-    // response. It resolves to `Ok(Option<Trailers>)` on success (trailers are not surfaced to
-    // the JS `fetch` API) or `Err(ErrorCode)` when the transport reports the body was not
-    // received successfully.
-    let body_error = match body_result.await {
-        Ok(_) => None,
-        Err(e) => Some(format!("HTTP response body error: {e:?}")),
-    };
-
-    (body, body_error)
 }
 
 // ---------------------------------------------------------------------------
@@ -910,7 +870,15 @@ impl WrappedRequestBodyWriter {
 
 enum ResponseBody {
     Bytes(Vec<u8>),
+    Shared(Rc<RefCell<SharedResponseBody>>),
     Consumed,
+}
+
+struct SharedResponseBody {
+    native: Option<NativeResponseBody>,
+    buffer: Vec<u8>,
+    finished: bool,
+    error: Option<String>,
 }
 
 #[derive(rquickjs::class::Trace, JsLifetime)]
@@ -970,6 +938,24 @@ impl HttpResponse {
         Self {
             body: ResponseBody::Bytes(body),
             body_error,
+            headers,
+            status,
+            is_opaque: false,
+            is_opaque_redirect: false,
+            redirected: false,
+        }
+    }
+
+    #[qjs(skip)]
+    fn from_response(status: u16, headers: Vec<Vec<String>>, response: Response) -> Self {
+        Self {
+            body: ResponseBody::Shared(Rc::new(RefCell::new(SharedResponseBody {
+                native: Some(NativeResponseBody::new(response)),
+                buffer: Vec::new(),
+                finished: false,
+                error: None,
+            }))),
+            body_error: None,
             headers,
             status,
             is_opaque: false,
@@ -1051,8 +1037,12 @@ impl HttpResponse {
             .to_string()
     }
 
-    pub async fn array_buffer<'js>(&mut self, ctx: Ctx<'js>) -> rquickjs::Result<ArrayBuffer<'js>> {
-        let bytes = self.take_body(&ctx)?;
+    pub async fn array_buffer<'js>(
+        &mut self,
+        ctx: Ctx<'js>,
+        signal: Option<Value<'js>>,
+    ) -> rquickjs::Result<ArrayBuffer<'js>> {
+        let bytes = self.take_body(&ctx, signal).await?;
         let ctx_clone = ctx.clone();
         ArrayBuffer::new(ctx, bytes).map_err(move |_| {
             Exception::throw_message(
@@ -1062,17 +1052,30 @@ impl HttpResponse {
         })
     }
 
-    pub async fn text<'js>(&mut self, ctx: Ctx<'js>) -> rquickjs::Result<String> {
-        let bytes = self.take_body(&ctx)?;
+    pub async fn text<'js>(
+        &mut self,
+        ctx: Ctx<'js>,
+        signal: Option<Value<'js>>,
+    ) -> rquickjs::Result<String> {
+        let bytes = self.take_body(&ctx, signal).await?;
         Ok(String::from_utf8_lossy(&bytes).to_string())
     }
 
     pub fn stream<'js>(&mut self, ctx: Ctx<'js>) -> rquickjs::Result<ResponseBodyStream> {
-        let bytes = self.take_body(&ctx)?;
-        Ok(ResponseBodyStream {
-            bytes: Some(bytes),
-            position: 0,
-        })
+        match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
+            ResponseBody::Bytes(bytes) => Ok(ResponseBodyStream {
+                source: Some(ResponseBodyStreamSource::Bytes(bytes)),
+                position: 0,
+            }),
+            ResponseBody::Shared(shared) => Ok(ResponseBodyStream {
+                source: Some(ResponseBodyStreamSource::Shared(shared)),
+                position: 0,
+            }),
+            ResponseBody::Consumed => Err(Exception::throw_message(
+                &ctx,
+                "The response has already been consumed",
+            )),
+        }
     }
 
     #[qjs(static)]
@@ -1132,6 +1135,10 @@ impl HttpResponse {
                 ResponseBody::Bytes(bytes.clone()),
                 ResponseBody::Bytes(bytes),
             ),
+            ResponseBody::Shared(shared) => (
+                ResponseBody::Shared(shared.clone()),
+                ResponseBody::Shared(shared),
+            ),
             ResponseBody::Consumed => (ResponseBody::Consumed, ResponseBody::Consumed),
         };
         self.body = kept;
@@ -1148,7 +1155,11 @@ impl HttpResponse {
 }
 
 impl HttpResponse {
-    fn take_body(&mut self, ctx: &Ctx<'_>) -> rquickjs::Result<Vec<u8>> {
+    async fn take_body<'js>(
+        &mut self,
+        ctx: &Ctx<'js>,
+        signal: Option<Value<'js>>,
+    ) -> rquickjs::Result<Vec<u8>> {
         match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
             ResponseBody::Bytes(bytes) => {
                 // A body that failed mid-transfer must reject when the caller actually consumes it
@@ -1158,6 +1169,7 @@ impl HttpResponse {
                 }
                 Ok(bytes)
             }
+            ResponseBody::Shared(shared) => collect_shared_body(ctx, signal, shared).await,
             ResponseBody::Consumed => Err(Exception::throw_message(
                 ctx,
                 "The response has already been consumed",
@@ -1166,13 +1178,89 @@ impl HttpResponse {
     }
 }
 
-/// Response body reader backing `response.body` / `ReadableStream`. Because Preview 3 responses
-/// are buffered eagerly, this simply serves the buffered bytes in chunks.
+async fn collect_shared_body<'js>(
+    ctx: &Ctx<'js>,
+    signal: Option<Value<'js>>,
+    shared: Rc<RefCell<SharedResponseBody>>,
+) -> rquickjs::Result<Vec<u8>> {
+    let mut position = 0;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = read_shared_body_chunk(ctx, signal.clone(), &shared, position).await? {
+        position += chunk.len();
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+async fn read_shared_body_chunk<'js>(
+    ctx: &Ctx<'js>,
+    signal: Option<Value<'js>>,
+    shared: &Rc<RefCell<SharedResponseBody>>,
+    position: usize,
+) -> rquickjs::Result<Option<Vec<u8>>> {
+    {
+        let state = shared.borrow();
+        if position < state.buffer.len() {
+            let end = (position + 16 * 1024).min(state.buffer.len());
+            return Ok(Some(state.buffer[position..end].to_vec()));
+        }
+        if let Some(error) = &state.error {
+            return Err(Exception::throw_message(ctx, error));
+        }
+        if state.finished {
+            return Ok(None);
+        }
+    }
+
+    let Some(mut native) = shared.borrow_mut().native.take() else {
+        return Err(Exception::throw_message(
+            ctx,
+            "A cloned response body read is already in progress",
+        ));
+    };
+
+    let read = async { Ok(native.read_chunk().await) };
+    let outcome = with_abort_signal(ctx, signal, read).await;
+    match outcome {
+        Err(error) => {
+            let mut state = shared.borrow_mut();
+            state.finished = true;
+            state.native = None;
+            Err(error)
+        }
+        Ok(Err(error)) => {
+            let mut state = shared.borrow_mut();
+            state.error = Some(error.clone());
+            state.finished = true;
+            state.native = None;
+            Err(Exception::throw_message(ctx, &error))
+        }
+        Ok(Ok(Some(chunk))) => {
+            let mut state = shared.borrow_mut();
+            state.buffer.extend_from_slice(&chunk);
+            state.native = Some(native);
+            Ok(Some(chunk))
+        }
+        Ok(Ok(None)) => {
+            let mut state = shared.borrow_mut();
+            state.finished = true;
+            state.native = None;
+            Ok(None)
+        }
+    }
+}
+
+enum ResponseBodyStreamSource {
+    Bytes(Vec<u8>),
+    Shared(Rc<RefCell<SharedResponseBody>>),
+}
+
+/// Response body reader backing `response.body` / `ReadableStream`.
 #[derive(Default, rquickjs::class::Trace, JsLifetime)]
 #[rquickjs::class(rename_all = "camelCase")]
 pub struct ResponseBodyStream {
     #[qjs(skip_trace)]
-    bytes: Option<Vec<u8>>,
+    source: Option<ResponseBodyStreamSource>,
     position: usize,
 }
 
@@ -1191,20 +1279,32 @@ impl ResponseBodyStream {
     pub async fn pull<'js>(
         &mut self,
         ctx: Ctx<'js>,
+        signal: Option<Value<'js>>,
     ) -> rquickjs::Result<List<(Option<TypedArray<'js, u8>>, Option<String>)>> {
-        const CHUNK_SIZE: usize = 16384;
-        let Some(bytes) = self.bytes.as_ref() else {
+        let Some(source) = self.source.as_ref() else {
             return Ok(List((None, None)));
         };
-        if self.position >= bytes.len() {
+        let chunk = match source {
+            ResponseBodyStreamSource::Bytes(bytes) => {
+                if self.position >= bytes.len() {
+                    None
+                } else {
+                    let end = (self.position + 16 * 1024).min(bytes.len());
+                    Some(bytes[self.position..end].to_vec())
+                }
+            }
+            ResponseBodyStreamSource::Shared(shared) => {
+                read_shared_body_chunk(&ctx, signal, shared, self.position).await?
+            }
+        };
+        let Some(chunk) = chunk else {
+            self.source = None;
             return Ok(List((None, None)));
-        }
-        let end = (self.position + CHUNK_SIZE).min(bytes.len());
-        let chunk = &bytes[self.position..end];
-        let array = TypedArray::new_copy(ctx.clone(), chunk).map_err(|_| {
+        };
+        let array = TypedArray::new_copy(ctx.clone(), &chunk).map_err(|_| {
             Exception::throw_message(&ctx, "Failed to create TypedArray from response body chunk")
         })?;
-        self.position = end;
+        self.position += chunk.len();
         Ok(List((Some(array), None)))
     }
 }

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -888,10 +888,12 @@ impl NativeBody for NativeResponseBody {
         NativeResponseBody::discard(&mut self);
     }
 
+    #[cfg(feature = "internal-test-execution")]
     fn take_recovered_read_bytes_for_test(&self) -> usize {
         NativeResponseBody::take_recovered_read_bytes_for_test(self)
     }
 
+    #[cfg(feature = "internal-test-execution")]
     fn pause_next_ready_read_for_test(&self) -> bool {
         NativeResponseBody::pause_next_ready_read_for_test(self)
     }
@@ -974,6 +976,7 @@ impl HttpResponse {
         }
     }
 
+    #[cfg(feature = "internal-test-execution")]
     pub fn take_recovered_body_read_bytes_for_test(&self) -> usize {
         match &self.body {
             ResponseBody::Native(native) => native.take_recovered_read_bytes_for_test(),
@@ -982,6 +985,7 @@ impl HttpResponse {
         }
     }
 
+    #[cfg(feature = "internal-test-execution")]
     pub fn pause_next_body_read_after_ready_for_test(&self) -> bool {
         match &self.body {
             ResponseBody::Native(native) => native.pause_next_ready_read_for_test(),

--- a/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/http_p3.rs
@@ -34,7 +34,7 @@ use rquickjs::{ArrayBuffer, Ctx, Exception, FromJs, IntoJs, JsLifetime, TypedArr
 
 use super::abort_signal::with_abort_signal;
 use super::http_body::ResponseBody as NativeResponseBody;
-use super::shared_response_body::{self, NativeBody, SharedBody};
+use super::shared_response_body::{self, NativeBody, SharedBodyReader};
 use futures::future::{AbortHandle, Abortable};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -873,11 +873,11 @@ impl WrappedRequestBodyWriter {
 enum ResponseBody {
     Bytes(Vec<u8>),
     Native(NativeResponseBody),
-    Shared(Rc<RefCell<SharedResponseBody>>),
+    Shared(SharedResponseBody),
     Consumed,
 }
 
-type SharedResponseBody = SharedBody<NativeResponseBody>;
+type SharedResponseBody = SharedBodyReader<NativeResponseBody>;
 
 impl NativeBody for NativeResponseBody {
     async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String> {
@@ -961,7 +961,7 @@ impl HttpResponse {
     pub fn discard_body(&mut self) {
         match std::mem::replace(&mut self.body, ResponseBody::Consumed) {
             ResponseBody::Native(native) => native.discard(),
-            ResponseBody::Shared(shared) => SharedResponseBody::discard(&shared),
+            ResponseBody::Shared(shared) => shared.discard(),
             ResponseBody::Bytes(_) | ResponseBody::Consumed => {}
         }
     }
@@ -1121,14 +1121,14 @@ impl HttpResponse {
                 ResponseBody::Bytes(bytes),
             ),
             ResponseBody::Native(native) => {
-                let shared = Rc::new(RefCell::new(SharedResponseBody::new(native)));
+                let (kept, cloned) = SharedResponseBody::pair(native);
                 (
-                    ResponseBody::Shared(shared.clone()),
-                    ResponseBody::Shared(shared),
+                    ResponseBody::Shared(kept),
+                    ResponseBody::Shared(cloned),
                 )
             }
             ResponseBody::Shared(shared) => (
-                ResponseBody::Shared(shared.clone()),
+                ResponseBody::Shared(shared.branch()),
                 ResponseBody::Shared(shared),
             ),
             ResponseBody::Consumed => (ResponseBody::Consumed, ResponseBody::Consumed),
@@ -1179,7 +1179,7 @@ impl HttpResponse {
 async fn collect_shared_body<'js>(
     ctx: &Ctx<'js>,
     signal: Option<Value<'js>>,
-    shared: Rc<RefCell<SharedResponseBody>>,
+    shared: SharedResponseBody,
 ) -> rquickjs::Result<Vec<u8>> {
     with_abort_signal(ctx, signal, async {
         shared_response_body::collect(ctx, shared).await
@@ -1190,7 +1190,7 @@ async fn collect_shared_body<'js>(
 enum ResponseBodyStreamSource {
     Bytes(Vec<u8>),
     Native(NativeResponseBody),
-    Shared(Rc<RefCell<SharedResponseBody>>),
+    Shared(SharedResponseBody),
 }
 
 /// Response body reader backing `response.body` / `ReadableStream`.

--- a/crates/wasm-rquickjs/skeleton/src/builtin/mod.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod execution;
 mod formdata_node;
 mod fs;
 mod gc;
+mod shared_response_body;
 
 #[cfg(feature = "fetch")]
 mod http;

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_p3.rs
@@ -27,6 +27,7 @@
 //! sits unpolled would deadlock the shared async executor. The response body is still streamed
 //! chunk-by-chunk (not read to completion eagerly).
 
+use super::http_body::ResponseBody;
 use rquickjs::class::Trace;
 use rquickjs::prelude::List;
 use rquickjs::{Ctx, Exception, JsLifetime, TypedArray};
@@ -34,18 +35,10 @@ use std::future::Future;
 use std::pin::Pin;
 use url::Url;
 use wasip3::http::types::{ErrorCode, Fields, Method, Request, Response, Scheme, Trailers};
-use wasip3::wit_bindgen::rt::async_support::{
-    FutureReader, FutureWriter, StreamReader, StreamResult,
-};
 
 /// Boxed, pinned future that drives a `wasi:http/client.send` and the request-body upload
 /// concurrently, resolving once the response head is available.
 type SendFuture = Pin<Box<dyn Future<Output = Result<Response, ErrorCode>>>>;
-
-/// Reader half of the response body result future. Resolves once the response body stream is
-/// closed, reporting whether the body was received successfully.
-type BodyResultReader = FutureReader<Result<Option<Trailers>, ErrorCode>>;
-type ResponseResultWriter = FutureWriter<Result<(), ErrorCode>>;
 
 #[rquickjs::module]
 pub mod native_module {
@@ -375,29 +368,11 @@ impl NodeHttpClientRequest {
     }
 }
 
-enum ResponseBodyState {
-    /// Response head received; the body stream has not been consumed yet.
-    Unconsumed(Response),
-    /// The body stream is being read incrementally.
-    Reading {
-        reader: StreamReader<u8>,
-        result: BodyResultReader,
-        response_result: ResponseResultWriter,
-    },
-    /// The body stream reported end-of-stream after a final data chunk; the body result future
-    /// still needs to be awaited to surface a mid-transfer error.
-    Finishing {
-        result: BodyResultReader,
-        response_result: ResponseResultWriter,
-    },
-    Consumed,
-}
-
 #[derive(Trace, JsLifetime)]
 #[rquickjs::class(rename_all = "camelCase")]
 pub struct NodeHttpIncomingResponse {
     #[qjs(skip_trace)]
-    body_state: ResponseBodyState,
+    body: ResponseBody,
     headers: Vec<Vec<String>>,
     status: u16,
 }
@@ -413,7 +388,7 @@ impl NodeHttpIncomingResponse {
     #[qjs(constructor)]
     pub fn new() -> Self {
         NodeHttpIncomingResponse {
-            body_state: ResponseBodyState::Consumed,
+            body: ResponseBody::empty(),
             headers: Vec::new(),
             status: 0,
         }
@@ -422,7 +397,7 @@ impl NodeHttpIncomingResponse {
     #[qjs(skip)]
     pub(crate) fn from_raw_response(raw: RawResponse) -> Self {
         NodeHttpIncomingResponse {
-            body_state: ResponseBodyState::Unconsumed(raw.response),
+            body: ResponseBody::new(raw.response),
             headers: raw.headers,
             status: raw.status,
         }
@@ -440,128 +415,26 @@ impl NodeHttpIncomingResponse {
 
     pub fn discard_body(&mut self) {
         // Dropping the response / stream reader / result future discards the body without reading.
-        self.body_state = ResponseBodyState::Consumed;
+        self.body.discard();
     }
 
     pub async fn read_body_chunk<'js>(
         &mut self,
         ctx: Ctx<'js>,
     ) -> rquickjs::Result<List<(Option<TypedArray<'js, u8>>, bool)>> {
-        let state = std::mem::replace(&mut self.body_state, ResponseBodyState::Consumed);
-
-        match state {
-            ResponseBodyState::Unconsumed(response) => {
-                // Consume the response body stream. The `res` future signals a handling result to
-                // the transport; we always signal success by letting its writer resolve to `Ok(())`.
-                let (res_tx, res_rx) = wasip3::wit_future::new(|| Ok::<(), ErrorCode>(()));
-                let (reader, result) = Response::consume_body(response, res_rx);
-                self.body_state = ResponseBodyState::Reading {
-                    reader,
-                    result,
-                    response_result: res_tx,
-                };
-                self.read_from_reader(ctx).await
+        match self.body.read_chunk().await {
+            Ok(Some(bytes)) => {
+                let chunk = TypedArray::new_copy(ctx.clone(), bytes).map_err(|_| {
+                    Exception::throw_message(
+                        &ctx,
+                        "Failed to create TypedArray from response body chunk",
+                    )
+                })?;
+                Ok(List((Some(chunk), false)))
             }
-            ResponseBodyState::Reading {
-                reader,
-                result,
-                response_result,
-            } => {
-                self.body_state = ResponseBodyState::Reading {
-                    reader,
-                    result,
-                    response_result,
-                };
-                self.read_from_reader(ctx).await
-            }
-            ResponseBodyState::Finishing {
-                result,
-                response_result,
-            } => {
-                drop(response_result);
-                let body_error = body_result_error(result).await;
-                if let Some(err) = body_error {
-                    return Err(Exception::throw_message(&ctx, &err));
-                }
-                Ok(List((None, true)))
-            }
-            ResponseBodyState::Consumed => Ok(List((None, true))),
+            Ok(None) => Ok(List((None, true))),
+            Err(error) => Err(Exception::throw_message(&ctx, &error)),
         }
-    }
-}
-
-impl NodeHttpIncomingResponse {
-    async fn read_from_reader<'js>(
-        &mut self,
-        ctx: Ctx<'js>,
-    ) -> rquickjs::Result<List<(Option<TypedArray<'js, u8>>, bool)>> {
-        let state = std::mem::replace(&mut self.body_state, ResponseBodyState::Consumed);
-
-        let ResponseBodyState::Reading {
-            mut reader,
-            result,
-            response_result,
-        } = state
-        else {
-            return Ok(List((None, true)));
-        };
-
-        const CHUNK_SIZE: usize = 16384;
-        loop {
-            let (status, buf) = reader.read(Vec::with_capacity(CHUNK_SIZE)).await;
-            match status {
-                StreamResult::Complete(_) if !buf.is_empty() => {
-                    let js_array = TypedArray::new_copy(ctx.clone(), buf).map_err(|_| {
-                        Exception::throw_message(
-                            &ctx,
-                            "Failed to create TypedArray from response body chunk",
-                        )
-                    })?;
-                    self.body_state = ResponseBodyState::Reading {
-                        reader,
-                        result,
-                        response_result,
-                    };
-                    return Ok(List((Some(js_array), false)));
-                }
-                // A zero-length completion carries no data and no EOF signal; retry.
-                StreamResult::Complete(_) => continue,
-                StreamResult::Dropped => {
-                    // Body stream closed. Drop the reader; a final data chunk (if any) is returned
-                    // now and the body result future is checked on the next call.
-                    drop(reader);
-                    if buf.is_empty() {
-                        drop(response_result);
-                        let body_error = body_result_error(result).await;
-                        if let Some(err) = body_error {
-                            return Err(Exception::throw_message(&ctx, &err));
-                        }
-                        return Ok(List((None, true)));
-                    }
-                    let js_array = TypedArray::new_copy(ctx.clone(), buf).map_err(|_| {
-                        Exception::throw_message(
-                            &ctx,
-                            "Failed to create TypedArray from response body chunk",
-                        )
-                    })?;
-                    self.body_state = ResponseBodyState::Finishing {
-                        result,
-                        response_result,
-                    };
-                    return Ok(List((Some(js_array), false)));
-                }
-                StreamResult::Cancelled => return Ok(List((None, true))),
-            }
-        }
-    }
-}
-
-/// Awaits the response body result future, returning an error message if the body failed
-/// mid-transfer (e.g. a truncated response).
-async fn body_result_error(result: BodyResultReader) -> Option<String> {
-    match result.await {
-        Ok(_) => None,
-        Err(e) => Some(format!("HTTP response body error: {e:?}")),
     }
 }
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
@@ -8,11 +8,11 @@ use std::task::{Poll, Waker};
 pub(crate) trait NativeBody {
     async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String>;
     fn discard(self);
-    #[cfg(feature = "p3")]
+    #[cfg(all(feature = "p3", feature = "internal-test-execution"))]
     fn take_recovered_read_bytes_for_test(&self) -> usize {
         0
     }
-    #[cfg(feature = "p3")]
+    #[cfg(all(feature = "p3", feature = "internal-test-execution"))]
     fn pause_next_ready_read_for_test(&self) -> bool {
         false
     }
@@ -72,7 +72,7 @@ impl<S: NativeBody> SharedBodyReader<S> {
         drop(self);
     }
 
-    #[cfg(feature = "p3")]
+    #[cfg(all(feature = "p3", feature = "internal-test-execution"))]
     pub(crate) fn take_recovered_read_bytes_for_test(&self) -> usize {
         self.shared
             .borrow()
@@ -81,7 +81,7 @@ impl<S: NativeBody> SharedBodyReader<S> {
             .map_or(0, NativeBody::take_recovered_read_bytes_for_test)
     }
 
-    #[cfg(feature = "p3")]
+    #[cfg(all(feature = "p3", feature = "internal-test-execution"))]
     pub(crate) fn pause_next_ready_read_for_test(&self) -> bool {
         self.shared
             .borrow()

--- a/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
@@ -8,6 +8,14 @@ use std::task::{Poll, Waker};
 pub(crate) trait NativeBody {
     async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String>;
     fn discard(self);
+    #[cfg(feature = "p3")]
+    fn take_recovered_read_bytes_for_test(&self) -> usize {
+        0
+    }
+    #[cfg(feature = "p3")]
+    fn pause_next_ready_read_for_test(&self) -> bool {
+        false
+    }
 }
 
 pub(crate) struct SharedBody<S> {
@@ -19,7 +27,7 @@ pub(crate) struct SharedBody<S> {
     readers: usize,
 }
 
-impl<S> SharedBody<S> {
+impl<S: NativeBody> SharedBody<S> {
     fn new(native: S) -> Self {
         Self {
             native: Some(native),
@@ -62,6 +70,24 @@ impl<S: NativeBody> SharedBodyReader<S> {
 
     pub(crate) fn discard(self) {
         drop(self);
+    }
+
+    #[cfg(feature = "p3")]
+    pub(crate) fn take_recovered_read_bytes_for_test(&self) -> usize {
+        self.shared
+            .borrow()
+            .native
+            .as_ref()
+            .map_or(0, NativeBody::take_recovered_read_bytes_for_test)
+    }
+
+    #[cfg(feature = "p3")]
+    pub(crate) fn pause_next_ready_read_for_test(&self) -> bool {
+        self.shared
+            .borrow()
+            .native
+            .as_ref()
+            .is_some_and(NativeBody::pause_next_ready_read_for_test)
     }
 }
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
@@ -1,0 +1,167 @@
+//! Target-independent buffering and fan-out for cloned fetch response bodies.
+
+use rquickjs::{Ctx, Exception};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::task::{Poll, Waker};
+
+pub(crate) trait NativeBody {
+    async fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, String>;
+    fn discard(self);
+}
+
+pub(crate) struct SharedBody<S> {
+    native: Option<S>,
+    buffer: Vec<u8>,
+    finished: bool,
+    error: Option<String>,
+    waiters: Vec<Waker>,
+}
+
+impl<S> SharedBody<S> {
+    pub(crate) fn new(native: S) -> Self {
+        Self {
+            native: Some(native),
+            buffer: Vec::new(),
+            finished: false,
+            error: None,
+            waiters: Vec::new(),
+        }
+    }
+
+    pub(crate) fn discard(shared: &Rc<RefCell<Self>>)
+    where
+        S: NativeBody,
+    {
+        let (native, waiters) = {
+            let mut state = shared.borrow_mut();
+            state.finished = true;
+            (state.native.take(), std::mem::take(&mut state.waiters))
+        };
+        if let Some(native) = native {
+            native.discard();
+        }
+        wake_all(waiters);
+    }
+}
+
+struct NativeLease<S: NativeBody> {
+    native: Option<S>,
+    shared: Rc<RefCell<SharedBody<S>>>,
+}
+
+impl<S: NativeBody> Drop for NativeLease<S> {
+    fn drop(&mut self) {
+        let Some(native) = self.native.take() else {
+            return;
+        };
+        native.discard();
+        let waiters = {
+            let mut state = self.shared.borrow_mut();
+            state.finished = true;
+            std::mem::take(&mut state.waiters)
+        };
+        wake_all(waiters);
+    }
+}
+
+pub(crate) async fn collect<'js, S: NativeBody>(
+    ctx: &Ctx<'js>,
+    shared: Rc<RefCell<SharedBody<S>>>,
+) -> rquickjs::Result<Vec<u8>> {
+    let mut position = 0;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = read_chunk(ctx, &shared, position).await? {
+        position += chunk.len();
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+pub(crate) async fn read_chunk<'js, S: NativeBody>(
+    ctx: &Ctx<'js>,
+    shared: &Rc<RefCell<SharedBody<S>>>,
+    position: usize,
+) -> rquickjs::Result<Option<Vec<u8>>> {
+    loop {
+        {
+            let state = shared.borrow();
+            if position < state.buffer.len() {
+                let end = (position + 16 * 1024).min(state.buffer.len());
+                return Ok(Some(state.buffer[position..end].to_vec()));
+            }
+            if let Some(error) = &state.error {
+                return Err(Exception::throw_message(ctx, error));
+            }
+            if state.finished {
+                return Ok(None);
+            }
+        }
+
+        let native = shared.borrow_mut().native.take();
+        let Some(native) = native else {
+            std::future::poll_fn(|cx| {
+                let mut state = shared.borrow_mut();
+                if position < state.buffer.len()
+                    || state.error.is_some()
+                    || state.finished
+                    || state.native.is_some()
+                {
+                    Poll::Ready(())
+                } else {
+                    if !state
+                        .waiters
+                        .iter()
+                        .any(|waker| waker.will_wake(cx.waker()))
+                    {
+                        state.waiters.push(cx.waker().clone());
+                    }
+                    Poll::Pending
+                }
+            })
+            .await;
+            continue;
+        };
+
+        let mut lease = NativeLease {
+            native: Some(native),
+            shared: shared.clone(),
+        };
+        let outcome = lease
+            .native
+            .as_mut()
+            .expect("native response body lease is present")
+            .read_chunk()
+            .await;
+
+        let native = lease.native.take();
+        let (result, waiters) = {
+            let mut state = shared.borrow_mut();
+            let result = match outcome {
+                Ok(Some(chunk)) => {
+                    state.buffer.extend_from_slice(&chunk);
+                    state.native = native;
+                    Ok(Some(chunk))
+                }
+                Ok(None) => {
+                    state.finished = true;
+                    Ok(None)
+                }
+                Err(error) => {
+                    state.error = Some(error.clone());
+                    state.finished = true;
+                    Err(Exception::throw_message(ctx, &error))
+                }
+            };
+            (result, std::mem::take(&mut state.waiters))
+        };
+        wake_all(waiters);
+        return result;
+    }
+}
+
+fn wake_all(waiters: Vec<Waker>) {
+    for waiter in waiters {
+        waiter.wake();
+    }
+}

--- a/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/shared_response_body.rs
@@ -16,27 +16,73 @@ pub(crate) struct SharedBody<S> {
     finished: bool,
     error: Option<String>,
     waiters: Vec<Waker>,
+    readers: usize,
 }
 
 impl<S> SharedBody<S> {
-    pub(crate) fn new(native: S) -> Self {
+    fn new(native: S) -> Self {
         Self {
             native: Some(native),
             buffer: Vec::new(),
             finished: false,
             error: None,
             waiters: Vec::new(),
+            readers: 2,
+        }
+    }
+}
+
+pub(crate) struct SharedBodyReader<S: NativeBody> {
+    shared: Rc<RefCell<SharedBody<S>>>,
+    active: bool,
+}
+
+impl<S: NativeBody> SharedBodyReader<S> {
+    pub(crate) fn pair(native: S) -> (Self, Self) {
+        let shared = Rc::new(RefCell::new(SharedBody::new(native)));
+        (
+            Self {
+                shared: shared.clone(),
+                active: true,
+            },
+            Self {
+                shared,
+                active: true,
+            },
+        )
+    }
+
+    pub(crate) fn branch(&self) -> Self {
+        self.shared.borrow_mut().readers += 1;
+        Self {
+            shared: self.shared.clone(),
+            active: true,
         }
     }
 
-    pub(crate) fn discard(shared: &Rc<RefCell<Self>>)
-    where
-        S: NativeBody,
-    {
+    pub(crate) fn discard(self) {
+        drop(self);
+    }
+}
+
+impl<S: NativeBody> Drop for SharedBodyReader<S> {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.active = false;
         let (native, waiters) = {
-            let mut state = shared.borrow_mut();
-            state.finished = true;
-            (state.native.take(), std::mem::take(&mut state.waiters))
+            let mut state = self.shared.borrow_mut();
+            state.readers = state
+                .readers
+                .checked_sub(1)
+                .expect("shared response reader count underflow");
+            if state.readers == 0 && !state.finished {
+                state.finished = true;
+                (state.native.take(), std::mem::take(&mut state.waiters))
+            } else {
+                (None, Vec::new())
+            }
         };
         if let Some(native) = native {
             native.discard();
@@ -55,23 +101,31 @@ impl<S: NativeBody> Drop for NativeLease<S> {
         let Some(native) = self.native.take() else {
             return;
         };
-        native.discard();
-        let waiters = {
+        let (native, waiters) = {
             let mut state = self.shared.borrow_mut();
-            state.finished = true;
-            std::mem::take(&mut state.waiters)
+            let discard = state.readers == 0 || state.finished;
+            if discard {
+                state.finished = true;
+                (Some(native), std::mem::take(&mut state.waiters))
+            } else {
+                state.native = Some(native);
+                (None, std::mem::take(&mut state.waiters))
+            }
         };
+        if let Some(native) = native {
+            native.discard();
+        }
         wake_all(waiters);
     }
 }
 
 pub(crate) async fn collect<'js, S: NativeBody>(
     ctx: &Ctx<'js>,
-    shared: Rc<RefCell<SharedBody<S>>>,
+    reader: SharedBodyReader<S>,
 ) -> rquickjs::Result<Vec<u8>> {
     let mut position = 0;
     let mut bytes = Vec::new();
-    while let Some(chunk) = read_chunk(ctx, &shared, position).await? {
+    while let Some(chunk) = read_chunk(ctx, &reader, position).await? {
         position += chunk.len();
         bytes.extend_from_slice(&chunk);
     }
@@ -80,9 +134,10 @@ pub(crate) async fn collect<'js, S: NativeBody>(
 
 pub(crate) async fn read_chunk<'js, S: NativeBody>(
     ctx: &Ctx<'js>,
-    shared: &Rc<RefCell<SharedBody<S>>>,
+    reader: &SharedBodyReader<S>,
     position: usize,
 ) -> rquickjs::Result<Option<Vec<u8>>> {
+    let shared = &reader.shared;
     loop {
         {
             let state = shared.borrow();

--- a/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
@@ -109,6 +109,8 @@ mod querystring;
 mod readline;
 #[path = "builtin/repl.rs"]
 mod repl;
+#[path = "builtin/shared_response_body.rs"]
+mod shared_response_body;
 #[path = "builtin/socket_helpers.rs"]
 mod socket_helpers;
 #[cfg(feature = "sqlite")]

--- a/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
@@ -57,10 +57,10 @@ mod dns;
 mod domain;
 #[path = "builtin/encoding.rs"]
 mod encoding;
-#[path = "builtin/execution.rs"]
-pub(crate) mod execution;
 #[path = "builtin/events.rs"]
 mod events;
+#[path = "builtin/execution.rs"]
+pub(crate) mod execution;
 #[path = "builtin/formdata_node.rs"]
 mod formdata_node;
 #[path = "builtin/fs.rs"]
@@ -71,6 +71,8 @@ mod gc;
 mod http;
 #[path = "builtin/http2.rs"]
 mod http2;
+#[path = "builtin/http_body_p3.rs"]
+mod http_body;
 #[path = "builtin/https.rs"]
 mod https;
 #[path = "builtin/ieee754.rs"]

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1388,6 +1388,7 @@ export async function abortPendingResponseBody(port, testCase) {
         await Promise.resolve();
         const pendingUntilSurvivorFinishes = !cancelSettled;
         await pendingRead.catch(() => undefined);
+        await new Promise(resolve => setTimeout(resolve, 0));
         const pendingAfterCanceledReadSettled = !cancelSettled;
         const text = await response.text();
         await cancel;
@@ -1443,8 +1444,8 @@ export async function abortPendingResponseBody(port, testCase) {
             cancelSettled = true;
         });
         await pendingRead.catch(() => undefined);
-        const pendingAfterCanceledReadSettled = !cancelSettled;
         await new Promise(resolve => setTimeout(resolve, 0));
+        const pendingAfterCanceledReadSettled = !cancelSettled;
         const recoveredBytes = hasRecoveryTestHook
             ? response.nativeResponse.takeRecoveredBodyReadBytesForTest()
             : 0;

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1455,13 +1455,24 @@ export async function abortPendingResponseBody(port, testCase) {
             : 0;
         const text = await response.text();
         await cancel;
-        return finishPendingResponseBodyCase(
+        const result =
             (!requiresPendingRace || (hasRecoveryTestHook && pauseArmed))
             && exercisedTargetRace
             && pendingAfterCanceledReadSettled
             && (!requiresPendingRace || recoveredBytes > 0)
-            && text === 'first chunksecond chunk',
-        );
+            && text === 'first chunksecond chunk';
+        if (!result) {
+            console.log('clone race diagnostics', JSON.stringify({
+                requiresPendingRace,
+                hasRecoveryTestHook,
+                pauseArmed,
+                exercisedTargetRace,
+                pendingAfterCanceledReadSettled,
+                recoveredBytes,
+                text,
+            }));
+        }
+        return finishPendingResponseBodyCase(result);
     }
 
     if (testCase === 19) {

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1138,3 +1138,69 @@ export async function abortResponseBody(port) {
     }
     return streamError instanceof DOMException && streamError.name === 'AbortError';
 }
+
+function isAbortError(error) {
+    return error instanceof DOMException && error.name === 'AbortError';
+}
+
+export async function abortPendingResponseBody(port, testCase) {
+    const url = `http://localhost:${port}/pending-response-body`;
+
+    if (testCase === 0) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        controller.abort();
+        try {
+            await response.text();
+            return false;
+        } catch (error) {
+            return isAbortError(error);
+        }
+    }
+
+    if (testCase === 1) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const read = response.text();
+        controller.abort();
+        try {
+            await read;
+            return false;
+        } catch (error) {
+            return isAbortError(error);
+        }
+    }
+
+    if (testCase === 2) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const reader = response.body.getReader();
+        const first = await reader.read();
+        const pendingRead = reader.read();
+        controller.abort();
+        try {
+            await pendingRead;
+            return false;
+        } catch (error) {
+            return first.done === false
+                && new TextDecoder().decode(first.value) === 'first chunk'
+                && isAbortError(error);
+        }
+    }
+
+    if (testCase === 3) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const clone = response.clone();
+        const read = clone.text();
+        controller.abort();
+        try {
+            await read;
+            return false;
+        } catch (error) {
+            return isAbortError(error);
+        }
+    }
+
+    return false;
+}

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -567,22 +567,21 @@ export async function responseCloneStreamingBody(port) {
 
     console.log(`Cloned status: ${cloned.status}`);
 
-    let clonedBytesData = [];
-    for await (const chunk of cloned.body) {
-        for (const byte of chunk) {
-            clonedBytesData.push(byte);
+    const consume = async (body) => {
+        const data = [];
+        for await (const chunk of body) {
+            for (const byte of chunk) {
+                data.push(byte);
+            }
         }
-    }
+        return new Uint8Array(data);
+    };
 
-    let originalBytesData = [];
-    for await (const chunk of response.body) {
-        for (const byte of chunk) {
-            originalBytesData.push(byte);
-        }
-    }
-
-    const clonedBytes = new Uint8Array(clonedBytesData);
-    const originalBytes = new Uint8Array(originalBytesData);
+    // Clones must tee the native stream: both readers are deliberately active together.
+    const [clonedBytes, originalBytes] = await Promise.all([
+        consume(cloned.body),
+        consume(response.body),
+    ]);
 
     console.log(`Cloned body: ${clonedBytes}`);
     console.log(`Original body: ${originalBytes}`);
@@ -614,10 +613,13 @@ export async function responseCloneReuseBodies(port) {
         const clone1 = response.clone();
         const clone2 = response.clone();
 
-        // Read all three bodies
-        const originalBody = await response.json();
-        const clone1Body = await clone1.json();
-        const clone2Body = await clone2.json();
+        // Start all consumers before awaiting any one of them. The shared native reader must
+        // wake the other clone consumers as buffered chunks become available.
+        const [originalBody, clone1Body, clone2Body] = await Promise.all([
+            response.json(),
+            clone1.json(),
+            clone2.json(),
+        ]);
 
         console.log(`Original id: ${originalBody.id}`);
         console.log(`Clone1 id: ${clone1Body.id}`);
@@ -1114,14 +1116,15 @@ export async function abortResponseBody(port) {
     const textResponse = await fetch(`http://localhost:${port}/todos/0`, {
         signal: textController.signal,
     });
-    textController.abort('body reason must not escape');
+    const textReason = new Error('body abort reason');
+    textController.abort(textReason);
     let textError;
     try {
         await textResponse.text();
     } catch (error) {
         textError = error;
     }
-    if (!(textError instanceof DOMException) || textError.name !== 'AbortError') {
+    if (textError !== textReason) {
         return false;
     }
 
@@ -1129,18 +1132,28 @@ export async function abortResponseBody(port) {
     const streamResponse = await fetch(`http://localhost:${port}/todos/0`, {
         signal: streamController.signal,
     });
-    streamController.abort('stream reason must not escape');
+    const streamReason = new Error('stream abort reason');
+    streamController.abort(streamReason);
     let streamError;
     try {
         await streamResponse.body.getReader().read();
     } catch (error) {
         streamError = error;
     }
-    return streamError instanceof DOMException && streamError.name === 'AbortError';
+    return streamError === streamReason;
 }
 
 function isAbortError(error) {
     return error instanceof DOMException && error.name === 'AbortError';
+}
+
+let retainedResponseBodyController;
+
+async function finishPendingResponseBodyCase(result) {
+    // Keep the invocation alive long enough for the host fixture to observe that the body was
+    // released by abort/GC, rather than by component teardown after this export returns.
+    await new Promise(resolve => setTimeout(resolve, 250));
+    return result;
 }
 
 export async function abortPendingResponseBody(port, testCase) {
@@ -1154,20 +1167,26 @@ export async function abortPendingResponseBody(port, testCase) {
             await response.text();
             return false;
         } catch (error) {
-            return isAbortError(error);
+            return finishPendingResponseBodyCase(
+                isAbortError(error) && response.bodyUsed && cloneThrows(response),
+            );
         }
     }
 
     if (testCase === 1) {
         const controller = new AbortController();
         const response = await fetch(url, {signal: controller.signal});
+        const reason = new Error('custom response body abort reason');
         const read = response.text();
-        controller.abort();
+        const disturbedImmediately = response.bodyUsed && cloneThrows(response);
+        controller.abort(reason);
         try {
             await read;
             return false;
         } catch (error) {
-            return isAbortError(error);
+            return finishPendingResponseBodyCase(
+                disturbedImmediately && response.bodyUsed && error === reason,
+            );
         }
     }
 
@@ -1182,9 +1201,10 @@ export async function abortPendingResponseBody(port, testCase) {
             await pendingRead;
             return false;
         } catch (error) {
-            return first.done === false
+            return finishPendingResponseBodyCase(first.done === false
                 && new TextDecoder().decode(first.value) === 'first chunk'
-                && isAbortError(error);
+                && response.bodyUsed
+                && isAbortError(error));
         }
     }
 
@@ -1198,9 +1218,61 @@ export async function abortPendingResponseBody(port, testCase) {
             await read;
             return false;
         } catch (error) {
-            return isAbortError(error);
+            return finishPendingResponseBodyCase(
+                clone.bodyUsed && cloneThrows(clone) && isAbortError(error),
+            );
+        }
+    }
+
+    if (testCase === 4) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const read = response.arrayBuffer();
+        const disturbedImmediately = response.bodyUsed && cloneThrows(response);
+        controller.abort();
+        try {
+            await read;
+            return false;
+        } catch (error) {
+            return finishPendingResponseBodyCase(
+                disturbedImmediately && response.bodyUsed && isAbortError(error),
+            );
+        }
+    }
+
+    if (testCase === 5) {
+        const controller = new AbortController();
+        retainedResponseBodyController = controller;
+        if (retainedResponseBodyController !== controller) return false;
+        let response = await fetch(url, {signal: controller.signal});
+        response = null;
+        gc();
+        await Promise.resolve();
+        gc();
+        return finishPendingResponseBodyCase(true);
+    }
+
+    if (testCase === 6) {
+        const response = await fetch(`http://localhost:${port}/truncated-response-body`);
+        const resolvedAtHead = response.status === 200 && !response.bodyUsed;
+        try {
+            await response.text();
+            return false;
+        } catch (error) {
+            return finishPendingResponseBodyCase(
+                resolvedAtHead && response.bodyUsed && cloneThrows(response) && error instanceof Error,
+            );
         }
     }
 
     return false;
+}
+
+function cloneThrows(response) {
+    try {
+        response.clone();
+        return false;
+    } catch (error) {
+        return error instanceof TypeError;
+    }
 }

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1416,24 +1416,59 @@ export async function abortPendingResponseBody(port, testCase) {
     if (testCase === 18) {
         const response = await fetch(`http://localhost:${port}/clone-race-response-body`);
         const canceled = response.clone();
+        const requiresPendingRace =
+            typeof response.nativeResponse.makeOpaqueRedirect === 'function';
+        const pauseArmed = requiresPendingRace
+            ? canceled.nativeResponse.pauseNextBodyReadAfterReadyForTest()
+            : false;
         const reader = canceled.body.getReader();
         let pendingReadSettled = false;
         const pendingRead = reader.read().finally(() => {
             pendingReadSettled = true;
         });
         await fetch(`http://localhost:${port}/clone-race-release`);
+        await Promise.resolve();
+        if (requiresPendingRace) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+        }
         // Preview 3's cancel-safe native read is the race under test. Preview 2 may deliver the
         // available chunk before this continuation, but must still preserve it for the survivor.
-        const requiresPendingRace =
-            typeof response.nativeResponse.makeOpaqueRedirect === 'function';
         const exercisedTargetRace = !requiresPendingRace || !pendingReadSettled;
         const cancel = reader.cancel('cancel after bytes became available');
         await pendingRead.catch(() => undefined);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const recoveredBytes = requiresPendingRace
+            ? response.nativeResponse.takeRecoveredBodyReadBytesForTest()
+            : 0;
         const text = await response.text();
         await cancel;
         return finishPendingResponseBodyCase(
-            exercisedTargetRace && text === 'first chunksecond chunk',
+            (!requiresPendingRace || pauseArmed)
+            && exercisedTargetRace
+            && (!requiresPendingRace || recoveredBytes > 0)
+            && text === 'first chunksecond chunk',
         );
+    }
+
+    if (testCase === 19) {
+        const response = await fetch(`http://localhost:${port}/truncated-response-body`);
+        const canceled = response.clone();
+        response.clone(); // Keep a third branch idle while the shared source errors.
+        let cancelSettled = false;
+        const cancel = canceled.body.cancel('cancel before shared body error').then(() => {
+            cancelSettled = true;
+        });
+        await Promise.resolve();
+        const pendingBeforeError = !cancelSettled;
+        try {
+            await response.text();
+            return false;
+        } catch (error) {
+            await cancel;
+            return finishPendingResponseBodyCase(
+                pendingBeforeError && cancelSettled && error instanceof Error,
+            );
+        }
     }
 
     return false;

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1422,9 +1422,9 @@ export async function abortPendingResponseBody(port, testCase) {
         const requiresPendingRace =
             typeof response.nativeResponse.makeOpaqueRedirect === 'function';
         const hasRecoveryTestHook =
-            typeof canceled.nativeResponse.pauseNextBodyReadAfterReadyForTest === 'function';
+            typeof canceled.pauseNextBodyReadAfterReadyForTest === 'function';
         const pauseArmed = hasRecoveryTestHook
-            ? canceled.nativeResponse.pauseNextBodyReadAfterReadyForTest()
+            ? canceled.pauseNextBodyReadAfterReadyForTest()
             : false;
         const reader = canceled.body.getReader();
         let pendingReadSettled = false;
@@ -1447,7 +1447,7 @@ export async function abortPendingResponseBody(port, testCase) {
         await new Promise(resolve => setTimeout(resolve, 0));
         const pendingAfterCanceledReadSettled = !cancelSettled;
         const recoveredBytes = hasRecoveryTestHook
-            ? response.nativeResponse.takeRecoveredBodyReadBytesForTest()
+            ? response.takeRecoveredBodyReadBytesForTest()
             : 0;
         const text = await response.text();
         await cancel;

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -564,6 +564,7 @@ export async function responseCloneStreamingBody(port) {
     console.log(`Original status: ${response.status}`);
 
     const cloned = response.clone();
+    const buffered = response.clone();
 
     console.log(`Cloned status: ${cloned.status}`);
 
@@ -578,15 +579,17 @@ export async function responseCloneStreamingBody(port) {
     };
 
     // Clones must tee the native stream: both readers are deliberately active together.
-    const [clonedBytes, originalBytes] = await Promise.all([
+    const [clonedBytes, originalBytes, bufferedBytes] = await Promise.all([
         consume(cloned.body),
         consume(response.body),
+        buffered.arrayBuffer().then(buffer => new Uint8Array(buffer)),
     ]);
 
     console.log(`Cloned body: ${clonedBytes}`);
     console.log(`Original body: ${originalBytes}`);
 
-    if (Buffer.compare(clonedBytes, originalBytes) === 0) {
+    if (Buffer.compare(clonedBytes, originalBytes) === 0
+        && Buffer.compare(originalBytes, bufferedBytes) === 0) {
         console.log("Streaming clone test passed");
     }
 }
@@ -1263,6 +1266,95 @@ export async function abortPendingResponseBody(port, testCase) {
                 resolvedAtHead && response.bodyUsed && cloneThrows(response) && error instanceof Error,
             );
         }
+    }
+
+    if (testCase === 7) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        controller.abort(null);
+        try {
+            await response.text();
+            return false;
+        } catch (error) {
+            return finishPendingResponseBodyCase(
+                error === null && response.bodyUsed && cloneThrows(response),
+            );
+        }
+    }
+
+    if (testCase === 8) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const read = response.arrayBuffer();
+        const disturbedImmediately = response.bodyUsed && cloneThrows(response);
+        controller.abort(null);
+        try {
+            await read;
+            return false;
+        } catch (error) {
+            return finishPendingResponseBodyCase(
+                disturbedImmediately && response.bodyUsed && error === null,
+            );
+        }
+    }
+
+    if (testCase === 9) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const clone = response.clone();
+        const reader = response.body.getReader();
+        const first = await reader.read();
+        const pendingRead = reader.read();
+        const pendingClone = clone.text();
+        controller.abort(null);
+        const [readerResult, cloneResult] = await Promise.allSettled([
+            pendingRead,
+            pendingClone,
+        ]);
+        return finishPendingResponseBodyCase(
+            first.done === false
+            && new TextDecoder().decode(first.value) === 'first chunk'
+            && readerResult.status === 'rejected'
+            && readerResult.reason === null
+            && cloneResult.status === 'rejected'
+            && cloneResult.reason === null,
+        );
+    }
+
+    if (testCase === 10) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const reader = response.body.getReader();
+        const first = await reader.read();
+        const reason = 'idle reader abort';
+        controller.abort(reason);
+        let closedReason;
+        try {
+            await reader.closed;
+            return false;
+        } catch (error) {
+            closedReason = error;
+        }
+        return finishPendingResponseBodyCase(
+            first.done === false && closedReason === reason,
+        );
+    }
+
+    if (testCase === 11) {
+        const response = await fetch(url);
+        const reader = response.body.getReader();
+        const first = await reader.read();
+        await reader.cancel('consumer stopped');
+        return finishPendingResponseBodyCase(first.done === false && response.bodyUsed);
+    }
+
+    if (testCase === 12) {
+        const response = await fetch(`http://localhost:${port}/empty-response-body`);
+        const resolvedAtHead = response.status === 204 && !response.bodyUsed;
+        const text = await response.text();
+        return finishPendingResponseBodyCase(
+            resolvedAtHead && text === '' && response.bodyUsed && cloneThrows(response),
+        );
     }
 
     return false;

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1360,9 +1360,18 @@ export async function abortPendingResponseBody(port, testCase) {
     if (testCase === 13) {
         const response = await fetch(`http://localhost:${port}/clone-response-body`);
         const canceled = response.clone();
-        await canceled.body.cancel('cancel before pull');
+        let cancelSettled = false;
+        const cancel = canceled.body.cancel('cancel before pull').then(() => {
+            cancelSettled = true;
+        });
+        await Promise.resolve();
+        const pendingUntilSurvivorFinishes = !cancelSettled;
+        const text = await response.text();
+        await cancel;
         return finishPendingResponseBodyCase(
-            await response.text() === 'first chunksecond chunk',
+            pendingUntilSurvivorFinishes
+            && cancelSettled
+            && text === 'first chunksecond chunk',
         );
     }
 
@@ -1372,11 +1381,58 @@ export async function abortPendingResponseBody(port, testCase) {
         const reader = canceled.body.getReader();
         const pendingRead = reader.read();
         await Promise.resolve();
-        const survivingRead = response.text();
-        await reader.cancel('cancel in-flight clone read');
+        let cancelSettled = false;
+        const cancel = reader.cancel('cancel in-flight clone read').then(() => {
+            cancelSettled = true;
+        });
+        await Promise.resolve();
+        const pendingUntilSurvivorFinishes = !cancelSettled;
         await pendingRead.catch(() => undefined);
+        const text = await response.text();
+        await cancel;
         return finishPendingResponseBodyCase(
-            await survivingRead === 'first chunksecond chunk',
+            pendingUntilSurvivorFinishes
+            && cancelSettled
+            && text === 'first chunksecond chunk',
+        );
+    }
+
+    if (testCase >= 15 && testCase <= 17) {
+        const controller = new AbortController();
+        const response = await fetch(url, {signal: controller.signal});
+        const reason = testCase === 15 ? false : testCase === 16 ? 0 : '';
+        const read = response.text();
+        controller.abort(reason);
+        try {
+            await read;
+            return false;
+        } catch (error) {
+            return finishPendingResponseBodyCase(
+                isAbortError(error) && response.bodyUsed && cloneThrows(response),
+            );
+        }
+    }
+
+    if (testCase === 18) {
+        const response = await fetch(`http://localhost:${port}/clone-race-response-body`);
+        const canceled = response.clone();
+        const reader = canceled.body.getReader();
+        let pendingReadSettled = false;
+        const pendingRead = reader.read().finally(() => {
+            pendingReadSettled = true;
+        });
+        await fetch(`http://localhost:${port}/clone-race-release`);
+        // Preview 3's cancel-safe native read is the race under test. Preview 2 may deliver the
+        // available chunk before this continuation, but must still preserve it for the survivor.
+        const requiresPendingRace =
+            typeof response.nativeResponse.makeOpaqueRedirect === 'function';
+        const exercisedTargetRace = !requiresPendingRace || !pendingReadSettled;
+        const cancel = reader.cancel('cancel after bytes became available');
+        await pendingRead.catch(() => undefined);
+        const text = await response.text();
+        await cancel;
+        return finishPendingResponseBodyCase(
+            exercisedTargetRace && text === 'first chunksecond chunk',
         );
     }
 

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1388,10 +1388,12 @@ export async function abortPendingResponseBody(port, testCase) {
         await Promise.resolve();
         const pendingUntilSurvivorFinishes = !cancelSettled;
         await pendingRead.catch(() => undefined);
+        const pendingAfterCanceledReadSettled = !cancelSettled;
         const text = await response.text();
         await cancel;
         return finishPendingResponseBodyCase(
             pendingUntilSurvivorFinishes
+            && pendingAfterCanceledReadSettled
             && cancelSettled
             && text === 'first chunksecond chunk',
         );
@@ -1418,7 +1420,9 @@ export async function abortPendingResponseBody(port, testCase) {
         const canceled = response.clone();
         const requiresPendingRace =
             typeof response.nativeResponse.makeOpaqueRedirect === 'function';
-        const pauseArmed = requiresPendingRace
+        const hasRecoveryTestHook =
+            typeof canceled.nativeResponse.pauseNextBodyReadAfterReadyForTest === 'function';
+        const pauseArmed = hasRecoveryTestHook
             ? canceled.nativeResponse.pauseNextBodyReadAfterReadyForTest()
             : false;
         const reader = canceled.body.getReader();
@@ -1434,17 +1438,22 @@ export async function abortPendingResponseBody(port, testCase) {
         // Preview 3's cancel-safe native read is the race under test. Preview 2 may deliver the
         // available chunk before this continuation, but must still preserve it for the survivor.
         const exercisedTargetRace = !requiresPendingRace || !pendingReadSettled;
-        const cancel = reader.cancel('cancel after bytes became available');
+        let cancelSettled = false;
+        const cancel = reader.cancel('cancel after bytes became available').then(() => {
+            cancelSettled = true;
+        });
         await pendingRead.catch(() => undefined);
+        const pendingAfterCanceledReadSettled = !cancelSettled;
         await new Promise(resolve => setTimeout(resolve, 0));
-        const recoveredBytes = requiresPendingRace
+        const recoveredBytes = hasRecoveryTestHook
             ? response.nativeResponse.takeRecoveredBodyReadBytesForTest()
             : 0;
         const text = await response.text();
         await cancel;
         return finishPendingResponseBodyCase(
-            (!requiresPendingRace || pauseArmed)
+            (!requiresPendingRace || (hasRecoveryTestHook && pauseArmed))
             && exercisedTargetRace
+            && pendingAfterCanceledReadSettled
             && (!requiresPendingRace || recoveredBytes > 0)
             && text === 'first chunksecond chunk',
         );

--- a/examples/runtime/fetch/src/fetch.js
+++ b/examples/runtime/fetch/src/fetch.js
@@ -1277,7 +1277,7 @@ export async function abortPendingResponseBody(port, testCase) {
             return false;
         } catch (error) {
             return finishPendingResponseBodyCase(
-                error === null && response.bodyUsed && cloneThrows(response),
+                isAbortError(error) && response.bodyUsed && cloneThrows(response),
             );
         }
     }
@@ -1293,7 +1293,7 @@ export async function abortPendingResponseBody(port, testCase) {
             return false;
         } catch (error) {
             return finishPendingResponseBodyCase(
-                disturbedImmediately && response.bodyUsed && error === null,
+                disturbedImmediately && response.bodyUsed && isAbortError(error),
             );
         }
     }
@@ -1315,9 +1315,9 @@ export async function abortPendingResponseBody(port, testCase) {
             first.done === false
             && new TextDecoder().decode(first.value) === 'first chunk'
             && readerResult.status === 'rejected'
-            && readerResult.reason === null
+            && isAbortError(readerResult.reason)
             && cloneResult.status === 'rejected'
-            && cloneResult.reason === null,
+            && isAbortError(cloneResult.reason),
         );
     }
 
@@ -1354,6 +1354,29 @@ export async function abortPendingResponseBody(port, testCase) {
         const text = await response.text();
         return finishPendingResponseBodyCase(
             resolvedAtHead && text === '' && response.bodyUsed && cloneThrows(response),
+        );
+    }
+
+    if (testCase === 13) {
+        const response = await fetch(`http://localhost:${port}/clone-response-body`);
+        const canceled = response.clone();
+        await canceled.body.cancel('cancel before pull');
+        return finishPendingResponseBodyCase(
+            await response.text() === 'first chunksecond chunk',
+        );
+    }
+
+    if (testCase === 14) {
+        const response = await fetch(`http://localhost:${port}/clone-response-body`);
+        const canceled = response.clone();
+        const reader = canceled.body.getReader();
+        const pendingRead = reader.read();
+        await Promise.resolve();
+        const survivingRead = response.text();
+        await reader.cancel('cancel in-flight clone read');
+        await pendingRead.catch(() => undefined);
+        return finishPendingResponseBodyCase(
+            await survivingRead === 'first chunksecond chunk',
         );
     }
 

--- a/examples/runtime/fetch/wit/fetch.wit
+++ b/examples/runtime/fetch/wit/fetch.wit
@@ -42,4 +42,5 @@ world fetch {
   export abort-releases-upload: func(port: u16) -> bool;
   export abort-after-redirect: func(port: u16) -> bool;
   export abort-response-body: func(port: u16) -> bool;
+  export abort-pending-response-body: func(port: u16, test-case: u8) -> bool;
   }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -432,6 +432,24 @@ fn test_cache_lock(name: &str, feature_combination: FeatureCombination, kind: &s
     ))
 }
 
+fn shared_runtime_target_name(
+    target: TestTarget,
+    feature_combination: FeatureCombination,
+) -> String {
+    if matches!(
+        feature_combination,
+        FeatureCombination::InternalTestExecution
+    ) {
+        format!(
+            "rt-target{}-{}",
+            target.dir_suffix(),
+            feature_combination.label()
+        )
+    } else {
+        format!("rt-target{}", target.dir_suffix())
+    }
+}
+
 fn rustc_version_verbose() -> String {
     Command::new("rustc")
         .arg("-Vv")
@@ -693,6 +711,22 @@ mod tests {
         );
 
         assert_ne!(p2, p3);
+    }
+
+    #[test]
+    fn internal_test_runtime_targets_are_isolated() {
+        assert_eq!(
+            shared_runtime_target_name(TestTarget::P3, FeatureCombination::Normal),
+            "rt-target-p3"
+        );
+        assert_ne!(
+            shared_runtime_target_name(TestTarget::P3, FeatureCombination::Normal),
+            shared_runtime_target_name(TestTarget::P3, FeatureCombination::InternalTestExecution)
+        );
+        assert_ne!(
+            shared_runtime_target_name(TestTarget::P2, FeatureCombination::InternalTestExecution),
+            shared_runtime_target_name(TestTarget::P3, FeatureCombination::InternalTestExecution)
+        );
     }
 }
 
@@ -2182,11 +2216,11 @@ impl CompiledTest {
         let feature_label = format!("{}{}", feature_combination.label(), target.dir_suffix());
         let wrapper_crate_root = Utf8Path::new("tmp").join(name).join(&feature_label);
 
-        // shared_target is relative to wrapper_crate_root.
-        // this is a _different_ shared target than the one used in the compilation tests to make
-        // sure different feature combinations do not interfere with these tests. P3 uses its own
-        // shared target so P2 and P3 artifacts never collide.
-        let shared_target_name = format!("rt-target{}", target.dir_suffix());
+        // shared_target is relative to wrapper_crate_root. Internal-test builds are isolated from
+        // normal builds because runtime group 2 compiles both variants of the same fetch example
+        // in parallel; sharing the final Cargo output would let one overwrite the other. Other
+        // feature combinations retain the common target to avoid multiplying large build trees.
+        let shared_target_name = shared_runtime_target_name(target, feature_combination);
         let shared_target = Utf8Path::new("..").join("..").join(&shared_target_name);
         let wasm_file_name = format!("{}.wasm", name.to_snake_case());
         let compiled_wasm_path = if use_shared_target {

--- a/tests/common/test_server.rs
+++ b/tests/common/test_server.rs
@@ -312,6 +312,28 @@ pub async fn start_response_body_abort_test_server() -> (
                 let empty = request
                     .windows(b"/empty-response-body".len())
                     .any(|window| window == b"/empty-response-body");
+                let clone = request
+                    .windows(b"/clone-response-body".len())
+                    .any(|window| window == b"/clone-response-body");
+                if clone {
+                    socket
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 23\r\nConnection: close\r\n\r\n",
+                        )
+                        .await
+                        .unwrap();
+                    socket.flush().await.unwrap();
+                    let _ = released_tx.send(ResponseBodyServerEvent::HeadSent);
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                    socket.write_all(b"first chunk").await.unwrap();
+                    socket.flush().await.unwrap();
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    socket.write_all(b"second chunk").await.unwrap();
+                    socket.flush().await.unwrap();
+                    let _ = socket.shutdown().await;
+                    let _ = released_tx.send(ResponseBodyServerEvent::Released);
+                    return;
+                }
                 let response = if truncated {
                     b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 100\r\nConnection: close\r\n\r\npartial".as_slice()
                 } else if empty {

--- a/tests/common/test_server.rs
+++ b/tests/common/test_server.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{Mutex, Notify, mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio_util::io::ReaderStream;
 
@@ -288,11 +288,15 @@ pub async fn start_response_body_abort_test_server() -> (
     let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let (released_tx, released_rx) = mpsc::unbounded_channel();
+    let release_clone_race = Arc::new(Notify::new());
+    let clone_race_bytes_sent = Arc::new(Notify::new());
 
     let handle = tokio::spawn(async move {
         loop {
             let (mut socket, _) = listener.accept().await.unwrap();
             let released_tx = released_tx.clone();
+            let release_clone_race = release_clone_race.clone();
+            let clone_race_bytes_sent = clone_race_bytes_sent.clone();
             tokio::spawn(async move {
                 let mut request = Vec::new();
                 let mut buf = [0u8; 1024];
@@ -302,6 +306,22 @@ pub async fn start_response_body_abort_test_server() -> (
                         return;
                     }
                     request.extend_from_slice(&buf[..read]);
+                }
+
+                let clone_race_release = request
+                    .windows(b"/clone-race-release".len())
+                    .any(|window| window == b"/clone-race-release");
+                if clone_race_release {
+                    release_clone_race.notify_one();
+                    clone_race_bytes_sent.notified().await;
+                    socket
+                        .write_all(
+                            b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                        )
+                        .await
+                        .unwrap();
+                    let _ = socket.shutdown().await;
+                    return;
                 }
 
                 let _ = released_tx.send(ResponseBodyServerEvent::Connected);
@@ -315,7 +335,10 @@ pub async fn start_response_body_abort_test_server() -> (
                 let clone = request
                     .windows(b"/clone-response-body".len())
                     .any(|window| window == b"/clone-response-body");
-                if clone {
+                let clone_race = request
+                    .windows(b"/clone-race-response-body".len())
+                    .any(|window| window == b"/clone-race-response-body");
+                if clone || clone_race {
                     socket
                         .write_all(
                             b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 23\r\nConnection: close\r\n\r\n",
@@ -324,9 +347,16 @@ pub async fn start_response_body_abort_test_server() -> (
                         .unwrap();
                     socket.flush().await.unwrap();
                     let _ = released_tx.send(ResponseBodyServerEvent::HeadSent);
-                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                    if clone_race {
+                        release_clone_race.notified().await;
+                    } else {
+                        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                    }
                     socket.write_all(b"first chunk").await.unwrap();
                     socket.flush().await.unwrap();
+                    if clone_race {
+                        clone_race_bytes_sent.notify_one();
+                    }
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                     socket.write_all(b"second chunk").await.unwrap();
                     socket.flush().await.unwrap();

--- a/tests/common/test_server.rs
+++ b/tests/common/test_server.rs
@@ -270,8 +270,7 @@ pub async fn start_abort_test_server() -> (u16, TestServerHandle, mpsc::Unbounde
     (port, TestServerHandle::new(handle), arrived_rx)
 }
 
-/// Starts an endpoint that sends its response head and one chunk, then leaves the body pending.
-/// Dropping the client-side body closes the raw connection and reports through `released_rx`.
+/// Lifecycle events emitted by the pending response-body fixture.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseBodyServerEvent {
     Connected,
@@ -279,6 +278,8 @@ pub enum ResponseBodyServerEvent {
     Released,
 }
 
+/// Starts an endpoint that sends its response head and one chunk, then leaves the body pending.
+/// Dropping the client-side body closes the raw connection and reports through `released_rx`.
 pub async fn start_response_body_abort_test_server() -> (
     u16,
     TestServerHandle,
@@ -305,16 +306,23 @@ pub async fn start_response_body_abort_test_server() -> (
 
                 let _ = released_tx.send(ResponseBodyServerEvent::Connected);
 
-                socket
-                    .write_all(
-                        b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\nfirst chunk",
-                    )
-                    .await
-                    .unwrap();
+                let truncated = request
+                    .windows(b"/truncated-response-body".len())
+                    .any(|window| window == b"/truncated-response-body");
+                let response = if truncated {
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 100\r\nConnection: close\r\n\r\npartial".as_slice()
+                } else {
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\nfirst chunk".as_slice()
+                };
+                socket.write_all(response).await.unwrap();
                 socket.flush().await.unwrap();
                 let _ = released_tx.send(ResponseBodyServerEvent::HeadSent);
 
-                while socket.read(&mut buf).await.unwrap_or(0) != 0 {}
+                if truncated {
+                    let _ = socket.shutdown().await;
+                } else {
+                    while socket.read(&mut buf).await.unwrap_or(0) != 0 {}
+                }
                 let _ = released_tx.send(ResponseBodyServerEvent::Released);
             });
         }

--- a/tests/common/test_server.rs
+++ b/tests/common/test_server.rs
@@ -10,6 +10,7 @@ use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
 use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Mutex, mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio_util::io::ReaderStream;
@@ -267,6 +268,59 @@ pub async fn start_abort_test_server() -> (u16, TestServerHandle, mpsc::Unbounde
     });
 
     (port, TestServerHandle::new(handle), arrived_rx)
+}
+
+/// Starts an endpoint that sends its response head and one chunk, then leaves the body pending.
+/// Dropping the client-side body closes the raw connection and reports through `released_rx`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseBodyServerEvent {
+    Connected,
+    HeadSent,
+    Released,
+}
+
+pub async fn start_response_body_abort_test_server() -> (
+    u16,
+    TestServerHandle,
+    mpsc::UnboundedReceiver<ResponseBodyServerEvent>,
+) {
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (released_tx, released_rx) = mpsc::unbounded_channel();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let released_tx = released_tx.clone();
+            tokio::spawn(async move {
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    let read = socket.read(&mut buf).await.unwrap_or(0);
+                    if read == 0 {
+                        return;
+                    }
+                    request.extend_from_slice(&buf[..read]);
+                }
+
+                let _ = released_tx.send(ResponseBodyServerEvent::Connected);
+
+                socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\nfirst chunk",
+                    )
+                    .await
+                    .unwrap();
+                socket.flush().await.unwrap();
+                let _ = released_tx.send(ResponseBodyServerEvent::HeadSent);
+
+                while socket.read(&mut buf).await.unwrap_or(0) != 0 {}
+                let _ = released_tx.send(ResponseBodyServerEvent::Released);
+            });
+        }
+    });
+
+    (port, TestServerHandle::new(handle), released_rx)
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/tests/common/test_server.rs
+++ b/tests/common/test_server.rs
@@ -309,8 +309,14 @@ pub async fn start_response_body_abort_test_server() -> (
                 let truncated = request
                     .windows(b"/truncated-response-body".len())
                     .any(|window| window == b"/truncated-response-body");
+                let empty = request
+                    .windows(b"/empty-response-body".len())
+                    .any(|window| window == b"/empty-response-body");
                 let response = if truncated {
                     b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 100\r\nConnection: close\r\n\r\npartial".as_slice()
+                } else if empty {
+                    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        .as_slice()
                 } else {
                     b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 1000000\r\nConnection: close\r\n\r\nfirst chunk".as_slice()
                 };
@@ -318,7 +324,7 @@ pub async fn start_response_body_abort_test_server() -> (
                 socket.flush().await.unwrap();
                 let _ = released_tx.send(ResponseBodyServerEvent::HeadSent);
 
-                if truncated {
+                if truncated || empty {
                     let _ = socket.shutdown().await;
                 } else {
                     while socket.read(&mut buf).await.unwrap_or(0) != 0 {}

--- a/tests/goldenfiles/generated_types_fetch_exports.d.ts
+++ b/tests/goldenfiles/generated_types_fetch_exports.d.ts
@@ -40,4 +40,5 @@ declare module 'fetch' {
   export function abortReleasesUpload(port: number): Promise<boolean>;
   export function abortAfterRedirect(port: number): Promise<boolean>;
   export function abortResponseBody(port: number): Promise<boolean>;
+  export function abortPendingResponseBody(port: number, testCase: number): Promise<boolean>;
 }

--- a/tests/p3_generation.rs
+++ b/tests/p3_generation.rs
@@ -2681,7 +2681,8 @@ fn p3_streaming_fetch_manual_redirect_returns_opaqueredirect_filtered_response()
 }
 
 #[test]
-fn p3_streaming_fetch_truncated_final_body_rejects_like_buffered_path() -> anyhow::Result<()> {
+fn p3_streaming_fetch_truncated_final_body_resolves_headers_then_rejects_body() -> anyhow::Result<()>
+{
     let port = spawn_test_http_server();
     let temp = Utf8TempDir::new()?;
     write_fixture(
@@ -2738,7 +2739,10 @@ fn p3_streaming_fetch_truncated_final_body_rejects_like_buffered_path() -> anyho
     let wasm_path = build_p3(temp.path(), "p3_fetch_stream_truncated_final_body")?;
     let result = run_p3_string_export(&wasm_path, "run")?;
 
-    assert_eq!(result, "buffered=rejected;streaming=rejected");
+    assert_eq!(
+        result,
+        "buffered=rejected;streaming=resolved:200:body-rejected"
+    );
     Ok(())
 }
 

--- a/tests/runtime/fetch.rs
+++ b/tests/runtime/fetch.rs
@@ -1027,9 +1027,9 @@ async fn fetch_abort_pending_response_body(
     #[tagged_as("fetch")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {
     let (port, _server, mut released) = start_response_body_abort_test_server().await;
-    for test_case in 0..4u8 {
+    for test_case in 0..7u8 {
         let wasm_path = compiled.wasm_path().to_path_buf();
-        let invocation = tokio::spawn(async move {
+        let mut invocation = tokio::spawn(async move {
             invoke_and_capture_output(
                 &wasm_path,
                 None,
@@ -1052,6 +1052,21 @@ async fn fetch_abort_pending_response_body(
                 .expect("pending response fixture stopped before sending the response head"),
             ResponseBodyServerEvent::HeadSent,
         );
+        let release = tokio::time::timeout(std::time::Duration::from_secs(5), released.recv());
+        tokio::pin!(release);
+        tokio::select! {
+            event = &mut release => assert_eq!(
+                event
+                    .unwrap_or_else(|_| panic!(
+                        "server did not observe release for response body case {test_case}"
+                    ))
+                    .expect("response body test server stopped before observing release"),
+                ResponseBodyServerEvent::Released,
+            ),
+            result = &mut invocation => panic!(
+                "response body case {test_case} completed before releasing its native body: {result:?}"
+            ),
+        }
         let (result, output) = tokio::time::timeout(std::time::Duration::from_secs(10), invocation)
             .await
             .unwrap_or_else(|_| {
@@ -1060,16 +1075,7 @@ async fn fetch_abort_pending_response_body(
         assert_eq!(
             result?,
             Some(Val::Bool(true)),
-            "response body case {test_case} must reject with AbortError. Output:\n{output}"
-        );
-        assert_eq!(
-            tokio::time::timeout(std::time::Duration::from_secs(5), released.recv())
-                .await
-                .unwrap_or_else(|_| panic!(
-                    "server did not observe release for response body case {test_case}"
-                ))
-                .expect("response body test server stopped before observing release"),
-            ResponseBodyServerEvent::Released,
+            "response body case {test_case} must satisfy the abort/GC contract. Output:\n{output}"
         );
     }
     Ok(())

--- a/tests/runtime/fetch.rs
+++ b/tests/runtime/fetch.rs
@@ -2,7 +2,9 @@ use crate::common::test_server::{
     ResponseBodyServerEvent, start_abort_test_server, start_response_body_abort_test_server,
     start_test_server,
 };
-use crate::common::{CompiledTest, TestTarget, invoke_and_capture_output, test_target};
+use crate::common::{
+    CompiledTest, FeatureCombination, TestTarget, invoke_and_capture_output, test_target,
+};
 use camino::Utf8Path;
 
 use test_r::{test, test_dep};
@@ -16,6 +18,14 @@ async fn compiled_fetch() -> CompiledTest {
     CompiledTest::new(path, true)
         .await
         .expect("Failed to compile fetch")
+}
+
+#[test_dep(tagged_as = "fetch_internal", scope = Cloneable)]
+async fn compiled_fetch_internal() -> CompiledTest {
+    let path = Utf8Path::new("examples/runtime/fetch");
+    CompiledTest::new_with_features(path, true, FeatureCombination::InternalTestExecution)
+        .await
+        .expect("Failed to compile fetch with internal test instrumentation")
 }
 
 #[test]
@@ -1024,7 +1034,7 @@ async fn fetch_abort_response_body(
 
 #[test]
 async fn fetch_abort_pending_response_body(
-    #[tagged_as("fetch")] compiled: &CompiledTest,
+    #[tagged_as("fetch_internal")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {
     let (port, _server, mut released) = start_response_body_abort_test_server().await;
     for test_case in 0..20u8 {

--- a/tests/runtime/fetch.rs
+++ b/tests/runtime/fetch.rs
@@ -1027,7 +1027,7 @@ async fn fetch_abort_pending_response_body(
     #[tagged_as("fetch")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {
     let (port, _server, mut released) = start_response_body_abort_test_server().await;
-    for test_case in 0..13u8 {
+    for test_case in 0..15u8 {
         let wasm_path = compiled.wasm_path().to_path_buf();
         let mut invocation = tokio::spawn(async move {
             invoke_and_capture_output(
@@ -1052,20 +1052,29 @@ async fn fetch_abort_pending_response_body(
                 .expect("pending response fixture stopped before sending the response head"),
             ResponseBodyServerEvent::HeadSent,
         );
-        let release = tokio::time::timeout(std::time::Duration::from_secs(5), released.recv());
-        tokio::pin!(release);
-        tokio::select! {
-            event = &mut release => assert_eq!(
-                event
+        let release = async {
+            assert_eq!(
+                tokio::time::timeout(std::time::Duration::from_secs(5), released.recv())
+                    .await
                     .unwrap_or_else(|_| panic!(
                         "server did not observe release for response body case {test_case}"
                     ))
                     .expect("response body test server stopped before observing release"),
                 ResponseBodyServerEvent::Released,
-            ),
-            result = &mut invocation => panic!(
-                "response body case {test_case} completed before releasing its native body: {result:?}"
-            ),
+            );
+        };
+        tokio::pin!(release);
+        if matches!(test_case, 6 | 12 | 13 | 14) {
+            // These fixtures close their own finite/truncated connection. Their Released event
+            // validates server sequencing, but is not evidence that guest disposal caused release.
+            release.await;
+        } else {
+            tokio::select! {
+                () = &mut release => {}
+                result = &mut invocation => panic!(
+                    "response body case {test_case} completed before releasing its native body: {result:?}"
+                ),
+            }
         }
         let (result, output) = tokio::time::timeout(std::time::Duration::from_secs(10), invocation)
             .await

--- a/tests/runtime/fetch.rs
+++ b/tests/runtime/fetch.rs
@@ -1027,7 +1027,7 @@ async fn fetch_abort_pending_response_body(
     #[tagged_as("fetch")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {
     let (port, _server, mut released) = start_response_body_abort_test_server().await;
-    for test_case in 0..15u8 {
+    for test_case in 0..19u8 {
         let wasm_path = compiled.wasm_path().to_path_buf();
         let mut invocation = tokio::spawn(async move {
             invoke_and_capture_output(
@@ -1064,7 +1064,7 @@ async fn fetch_abort_pending_response_body(
             );
         };
         tokio::pin!(release);
-        if matches!(test_case, 6 | 12 | 13 | 14) {
+        if matches!(test_case, 6 | 12 | 13 | 14 | 18) {
             // These fixtures close their own finite/truncated connection. Their Released event
             // validates server sequencing, but is not evidence that guest disposal caused release.
             release.await;

--- a/tests/runtime/fetch.rs
+++ b/tests/runtime/fetch.rs
@@ -1,4 +1,7 @@
-use crate::common::test_server::{start_abort_test_server, start_test_server};
+use crate::common::test_server::{
+    ResponseBodyServerEvent, start_abort_test_server, start_response_body_abort_test_server,
+    start_test_server,
+};
 use crate::common::{CompiledTest, TestTarget, invoke_and_capture_output, test_target};
 use camino::Utf8Path;
 
@@ -1016,5 +1019,58 @@ async fn fetch_abort_response_body(
         Some(Val::Bool(true)),
         "response body consumption after abort must reject with AbortError. Output:\n{output}"
     );
+    Ok(())
+}
+
+#[test]
+async fn fetch_abort_pending_response_body(
+    #[tagged_as("fetch")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (port, _server, mut released) = start_response_body_abort_test_server().await;
+    for test_case in 0..4u8 {
+        let wasm_path = compiled.wasm_path().to_path_buf();
+        let invocation = tokio::spawn(async move {
+            invoke_and_capture_output(
+                &wasm_path,
+                None,
+                "abort-pending-response-body",
+                &[Val::U16(port), Val::U8(test_case)],
+            )
+            .await
+        });
+        assert_eq!(
+            tokio::time::timeout(ABORT_REQUEST_ARRIVAL_TIMEOUT, released.recv())
+                .await
+                .expect("request did not connect to the pending response fixture")
+                .expect("pending response fixture stopped before accepting the request"),
+            ResponseBodyServerEvent::Connected,
+        );
+        assert_eq!(
+            tokio::time::timeout(ABORT_REQUEST_ARRIVAL_TIMEOUT, released.recv())
+                .await
+                .expect("request did not send headers to the pending response fixture")
+                .expect("pending response fixture stopped before sending the response head"),
+            ResponseBodyServerEvent::HeadSent,
+        );
+        let (result, output) = tokio::time::timeout(std::time::Duration::from_secs(10), invocation)
+            .await
+            .unwrap_or_else(|_| {
+                panic!("response body case {test_case} kept the invocation alive")
+            })?;
+        assert_eq!(
+            result?,
+            Some(Val::Bool(true)),
+            "response body case {test_case} must reject with AbortError. Output:\n{output}"
+        );
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(5), released.recv())
+                .await
+                .unwrap_or_else(|_| panic!(
+                    "server did not observe release for response body case {test_case}"
+                ))
+                .expect("response body test server stopped before observing release"),
+            ResponseBodyServerEvent::Released,
+        );
+    }
     Ok(())
 }

--- a/tests/runtime/fetch.rs
+++ b/tests/runtime/fetch.rs
@@ -1017,7 +1017,7 @@ async fn fetch_abort_response_body(
     assert_eq!(
         result?,
         Some(Val::Bool(true)),
-        "response body consumption after abort must reject with AbortError. Output:\n{output}"
+        "response body consumption after abort must reject with the exact abort reason. Output:\n{output}"
     );
     Ok(())
 }
@@ -1027,7 +1027,7 @@ async fn fetch_abort_pending_response_body(
     #[tagged_as("fetch")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {
     let (port, _server, mut released) = start_response_body_abort_test_server().await;
-    for test_case in 0..7u8 {
+    for test_case in 0..13u8 {
         let wasm_path = compiled.wasm_path().to_path_buf();
         let mut invocation = tokio::spawn(async move {
             invoke_and_capture_output(

--- a/tests/runtime/fetch.rs
+++ b/tests/runtime/fetch.rs
@@ -1027,7 +1027,7 @@ async fn fetch_abort_pending_response_body(
     #[tagged_as("fetch")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {
     let (port, _server, mut released) = start_response_body_abort_test_server().await;
-    for test_case in 0..19u8 {
+    for test_case in 0..20u8 {
         let wasm_path = compiled.wasm_path().to_path_buf();
         let mut invocation = tokio::spawn(async move {
             invoke_and_capture_output(
@@ -1064,7 +1064,7 @@ async fn fetch_abort_pending_response_body(
             );
         };
         tokio::pin!(release);
-        if matches!(test_case, 6 | 12 | 13 | 14 | 18) {
+        if matches!(test_case, 6 | 12 | 13 | 14 | 18 | 19) {
             // These fixtures close their own finite/truncated connection. Their Released event
             // validates server sequencing, but is not evidence that guest disposal caused release.
             release.await;


### PR DESCRIPTION
- Resolves [GOL-404](https://linear.app/golem-cloud/issue/GOL-404/resolve-p3-fetch-after-response-headers-and-support-abortable-response)
- Resolves P3 fetch after response headers and streams native bodies lazily through `body`, `text()`, and `arrayBuffer()`
- Propagates active abort and disposal while preserving clone ownership, cancellation timing, common errors, and raced P3 bytes
- Adds deterministic P2/P3 regressions for host release, clones, falsy abort reasons, and cancel-safe read recovery