### PR TITLE
Unify HTTP response persistence decisions

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/builtin/mod.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/mod.rs
@@ -233,6 +233,7 @@ pub fn add_module_resolvers(
         .with_module("node:inspector")
         .with_module("inspector")
         .with_module("__wasm_rquickjs_builtin/node_http_native")
+        .with_module("__wasm_rquickjs_builtin/node_http_incoming")
         .with_module("__wasm_rquickjs_builtin/node_http_server")
         .with_module("node:_http_common")
         .with_module("_http_common")
@@ -487,6 +488,10 @@ pub fn module_loader() -> (
         .with_module("dns/promises", dns::REEXPORT_PROMISES_JS)
         .with_module("node:domain", domain::DOMAIN_JS)
         .with_module("domain", domain::REEXPORT_JS)
+        .with_module(
+            "__wasm_rquickjs_builtin/node_http_incoming",
+            node_http::HTTP_INCOMING_JS,
+        )
         .with_module(
             "__wasm_rquickjs_builtin/node_http_server",
             node_http::NODE_HTTP_SERVER_JS,

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http.js
@@ -3,6 +3,7 @@ import { NodeHttpClientRequest } from '__wasm_rquickjs_builtin/node_http_native'
 import { EventEmitter } from 'node:events';
 import { Buffer } from 'node:buffer';
 import Readable from '__wasm_rquickjs_builtin/internal/streams/readable';
+import { initializeIncomingMessage } from '__wasm_rquickjs_builtin/node_http_incoming';
 
 import { channel } from 'node:diagnostics_channel';
 import { kOutHeaders } from '__wasm_rquickjs_builtin/internal/http';
@@ -798,18 +799,9 @@ export function IncomingMessage(nativeRes, options) {
         this.httpVersionMajor = null;
         this.httpVersionMinor = null;
     }
-    this.complete = false;
+    initializeIncomingMessage(this, hasNativeResponse ? null : nativeRes);
     this.method = hasNativeResponse ? undefined : null;
     this.url = hasNativeResponse ? undefined : '';
-    this.socket = hasNativeResponse ? null : nativeRes;
-    this.client = this.socket;
-    this.trailers = {};
-    this.trailersDistinct = {};
-    this.rawTrailers = [];
-    this.aborted = false;
-    this._consuming = false;
-    this._dumped = false;
-    this._timeout = null;
 
     const joinDup = !!(options && options.joinDuplicateHeaders);
     const parsedHeaders = parseIncomingHeaders(
@@ -835,6 +827,13 @@ IncomingMessage.prototype.setTimeout = function setTimeout(ms, callback) {
     this._timeout = ms;
     if (callback) this.once('timeout', callback);
     return this;
+};
+
+IncomingMessage.prototype._dump = function _dump() {
+    if (this._dumped) return;
+    this._dumped = true;
+    this.removeAllListeners('data');
+    this.resume();
 };
 
 IncomingMessage.prototype._read = function _read(n) {
@@ -2150,7 +2149,7 @@ export class ClientRequest extends OutgoingMessage {
                 }
                 this._response = res;
                 res.req = this;
-                this.emit('response', res);
+                const responseHandled = this.emit('response', res);
 
                 if (this.aborted || this.destroyed) {
                     if (res._nativeRes && typeof res._nativeRes.discardBody === 'function') {
@@ -2159,16 +2158,8 @@ export class ClientRequest extends OutgoingMessage {
                     return;
                 }
 
-                const hasDataListeners = res.listenerCount('data') > 0;
-                const hasEndListeners = res.listenerCount('end') > 0;
-                const hasReadableListeners = res.listenerCount('readable') > 0;
-
-                if (hasDataListeners || hasEndListeners) {
-                    res.resume();
-                } else if (hasReadableListeners) {
-                    res.read(0);
-                } else {
-                    res.resume();
+                if (!responseHandled) {
+                    res._dump();
                 }
             }
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http.rs
@@ -776,6 +776,7 @@ async fn write_all_to_stream<'js>(
 
 pub const NODE_HTTP_JS: &str = include_str!("node_http.js");
 pub const NODE_HTTP_SERVER_JS: &str = include_str!("node_http_server.js");
+pub const HTTP_INCOMING_JS: &str = include_str!("node_http_incoming.js");
 pub const HTTP_COMMON_JS: &str = include_str!("node_http_common.js");
 pub const HTTP_AGENT_JS: &str = include_str!("node_http_agent.js");
 pub const REEXPORT_JS: &str = r#"export * from 'node:http'; export { default } from 'node:http';"#;

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_disabled.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_disabled.rs
@@ -3,6 +3,7 @@ pub mod native_module {}
 
 pub const NODE_HTTP_JS: &str = include_str!("node_http_disabled.js");
 pub const HTTP_COMMON_JS: &str = include_str!("node_http_common.js");
+pub const HTTP_INCOMING_JS: &str = include_str!("node_http_incoming.js");
 pub const REEXPORT_JS: &str = r#"export * from 'node:http'; export { default } from 'node:http';"#;
 
 pub const NODE_HTTP_SERVER_JS: &str = r#"

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_incoming.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_incoming.js
@@ -1,0 +1,13 @@
+export function initializeIncomingMessage(message, socket) {
+    message.complete = false;
+    message.socket = socket;
+    message.connection = socket;
+    message.client = socket;
+    message.trailers = {};
+    message.trailersDistinct = {};
+    message.rawTrailers = [];
+    message.aborted = false;
+    message._consuming = false;
+    message._dumped = false;
+    message._timeout = null;
+}

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_p3.rs
@@ -721,6 +721,7 @@ fn fields_to_pairs(fields: &Fields) -> Vec<Vec<String>> {
 
 pub const NODE_HTTP_JS: &str = include_str!("node_http.js");
 pub const NODE_HTTP_SERVER_JS: &str = include_str!("node_http_server.js");
+pub const HTTP_INCOMING_JS: &str = include_str!("node_http_incoming.js");
 pub const HTTP_COMMON_JS: &str = include_str!("node_http_common.js");
 pub const HTTP_AGENT_JS: &str = include_str!("node_http_agent.js");
 pub const REEXPORT_JS: &str = r#"export * from 'node:http'; export { default } from 'node:http';"#;

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
@@ -3,6 +3,7 @@ import { Server as NetServer } from 'node:net';
 import { EventEmitter } from 'node:events';
 import { Buffer } from 'node:buffer';
 import Readable from '__wasm_rquickjs_builtin/internal/streams/readable';
+import { initializeIncomingMessage } from '__wasm_rquickjs_builtin/node_http_incoming';
 import { ERR_HTTP_BODY_NOT_ALLOWED, ERR_HTTP_CONTENT_LENGTH_MISMATCH, ERR_HTTP_HEADERS_SENT, ERR_HTTP_SOCKET_ASSIGNED, ERR_INVALID_ARG_TYPE, ERR_INVALID_ARG_VALUE, ERR_STREAM_NULL_VALUES, ERR_STREAM_WRITE_AFTER_END } from '__wasm_rquickjs_builtin/internal/errors';
 // STATUS_CODES is duplicated here to avoid circular dependency with node:http
 const STATUS_CODES = {
@@ -121,8 +122,7 @@ function ServerIncomingMessage(socket, method, url, httpVersion, rawHeaderPairs,
 
     Readable.call(this, {});
 
-    this.socket = socket;
-    this.connection = socket;
+    initializeIncomingMessage(this, socket);
     this.method = method;
     this.url = url;
     this.httpVersion = httpVersion;
@@ -136,28 +136,42 @@ function ServerIncomingMessage(socket, method, url, httpVersion, rawHeaderPairs,
     this.headersDistinct = parsed.headersDistinct;
     this.rawHeaders = parsed.rawHeaders;
 
-    this.complete = false;
-    this.aborted = false;
-    this.trailers = {};
-    this.trailersDistinct = {};
-    this.rawTrailers = [];
-    this.client = socket;
-    this._consuming = false;
-    this._dumped = false;
-    this._timeout = null;
 }
 
 Object.setPrototypeOf(ServerIncomingMessage.prototype, Readable.prototype);
 Object.setPrototypeOf(ServerIncomingMessage, Readable);
 
 ServerIncomingMessage.prototype._read = function _read() {
-    // no-op: parser pushes data via this.push()
+    this._consuming = true;
 };
 
-ServerIncomingMessage.prototype.setTimeout = function setTimeout(ms, cb) {
-    this._timeout = ms;
-    if (cb) this.once('timeout', cb);
-    return this;
+ServerIncomingMessage.prototype._destroy = function _destroy(_err, cb) {
+    const aborted = !this.readableEnded || !this.complete;
+    let destroyFinished = false;
+    const finishDestroy = () => {
+        if (destroyFinished) return;
+        destroyFinished = true;
+        process.nextTick(() => {
+            cb(_err && this.listenerCount('error') > 0 ? _err : null);
+        });
+    };
+    if (aborted) {
+        this.aborted = true;
+        this.emit('aborted');
+    }
+    if (aborted && this.socket && !this.socket.destroyed) {
+        const socket = this.socket;
+        const onSocketFinished = () => {
+            socket.removeListener('error', onSocketFinished);
+            socket.removeListener('close', onSocketFinished);
+            finishDestroy();
+        };
+        socket.once('error', onSocketFinished);
+        socket.once('close', onSocketFinished);
+        this.socket.destroy(_err || undefined);
+        return;
+    }
+    finishDestroy();
 };
 
 // ===== Status code validation =====
@@ -1441,6 +1455,12 @@ function createConnectionParser(server, socket) {
                             !isDroppedRequest &&
                             !res._last &&
                             !server._closeRequested;
+                        const resumeScheduled = req._readableState &&
+                            req._readableState.resumeScheduled;
+                        if (!req._consuming && !resumeScheduled &&
+                            typeof req._dump === 'function') {
+                            req._dump();
+                        }
                         maybeFinalizeResponse(context);
                     });
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
@@ -220,8 +220,10 @@ function ServerResponse(req, options) {
     this._chunked = false;
     this._hasBody = true;
     this._keepAlive = false;
+    this._acceptOverflowRequest = false;
     this._keepAliveTimeout = 5000;
     this._keepAliveMaxRequests = 0;
+    this._last = false;
     this._sentContentLength = false;
     this._headersSentWire = false;
     this._rejectNonStandardBodyWrites = !!(options && options.rejectNonStandardBodyWrites);
@@ -339,6 +341,10 @@ ServerResponse.prototype.setHeader = function setHeader(name, value) {
     const lower = name.toLowerCase();
     if (lower === 'connection') {
         this._removedConnection = false;
+    } else if (lower === 'content-length') {
+        this._removedContLen = false;
+    } else if (lower === 'transfer-encoding') {
+        this._removedTE = false;
     }
     this._headers[lower] = value;
     this._headerNames[lower] = name;
@@ -366,6 +372,10 @@ ServerResponse.prototype.removeHeader = function removeHeader(name) {
         // re-added implicitly. The connection lifecycle is unchanged (HTTP/1.1
         // persists, HTTP/1.0 closes after the response).
         this._removedConnection = true;
+    } else if (lower === 'content-length') {
+        this._removedContLen = true;
+    } else if (lower === 'transfer-encoding') {
+        this._removedTE = true;
     }
     delete this._headers[lower];
     delete this._headerNames[lower];
@@ -538,7 +548,7 @@ ServerResponse.prototype._buildHeaderString = function _buildHeaderString() {
     } else if (this.hasHeader('transfer-encoding')) {
         const te = String(this.getHeader('transfer-encoding')).toLowerCase();
         this._chunked = te === 'chunked';
-    } else if (!isHeadRequest) {
+    } else if (!isHeadRequest && !this._removedTE) {
         // Neither Content-Length nor Transfer-Encoding set, body expected
         if (requestHttpVersion === '1.1') {
             this._chunked = true;
@@ -565,29 +575,42 @@ ServerResponse.prototype._buildHeaderString = function _buildHeaderString() {
 
     // Implicit Connection header (after user headers)
     const userConnection = this.getHeader('connection');
-    const userConnectionTokens = typeof userConnection === 'string'
-        ? userConnection.split(',').map((t) => t.trim().toLowerCase()).filter(Boolean)
-        : [];
+    const userConnectionValues = Array.isArray(userConnection)
+        ? userConnection
+        : (userConnection === undefined ? [] : [userConnection]);
+    const userConnectionTokens = userConnectionValues.flatMap((value) =>
+        String(value).split(',').map((token) => token.trim().toLowerCase()).filter(Boolean)
+    );
     const userSaysClose = userConnectionTokens.includes('close');
-    const userSaysKeepAlive = userConnectionTokens.includes('keep-alive');
     const canKeepAlive = !!this._keepAlive;
-    // The user may narrow a keep-alive response to close, but must not widen
-    // a close response to keep-alive: header semantics must match the actual
-    // socket lifecycle decided elsewhere (maxRequestsPerSocket, server.close()).
-    const effectiveKeepAlive = userConnection === undefined
-        ? canKeepAlive
-        : (canKeepAlive && userSaysKeepAlive && !userSaysClose);
+    const canPersistForOverflow = !!this._acceptOverflowRequest;
+    const selfDelimited = !this._hasBody || this._sentContentLength || this._chunked;
+
+    // Finalize the same private persistence decision that response completion
+    // consumes. maxRequestsPerSocket is the Node-compatible exception: its
+    // boundary response advertises close but remains able to serve a 503 for an
+    // already-arriving overflow request.
+    this._last =
+        !(canKeepAlive || canPersistForOverflow) ||
+        userSaysClose ||
+        !selfDelimited;
+
+    // Explicit Keep-Alive is user-owned and suppresses automatic generation.
+    this._defaultKeepAlive = this.getHeader('keep-alive') === undefined;
+    const effectiveKeepAlive = canKeepAlive && !this._last;
 
     if (userConnection === undefined && !this._removedConnection) {
         head += 'Connection: ' + (effectiveKeepAlive ? 'keep-alive' : 'close') + '\r\n';
     }
 
-    if (effectiveKeepAlive && !this._removedConnection && this.getHeader('keep-alive') === undefined) {
-        const timeoutMs = typeof this._keepAliveTimeout === 'number' && this._keepAliveTimeout >= 0
-            ? this._keepAliveTimeout
-            : 5000;
-        if (timeoutMs > 0) {
-            const timeoutSeconds = Math.trunc(timeoutMs / 1000);
+    if (effectiveKeepAlive &&
+        userConnection === undefined &&
+        !this._removedConnection &&
+        this._defaultKeepAlive) {
+        const timeoutSeconds = this._keepAliveTimeout && typeof this._keepAliveTimeout === 'number'
+            ? Math.floor(this._keepAliveTimeout / 1000)
+            : undefined;
+        if (timeoutSeconds !== undefined) {
             head += 'Keep-Alive: timeout=' + timeoutSeconds;
             if (this._keepAliveMaxRequests > 0) {
                 head += ', max=' + this._keepAliveMaxRequests;
@@ -832,7 +855,11 @@ ServerResponse.prototype.end = function end(data, encoding, cb) {
     }
 
     if (!this._headersSentWire) {
-        if (data && !this.headersSent && !this.hasHeader('content-length') && !this.hasHeader('transfer-encoding')) {
+        if (data &&
+            !this.headersSent &&
+            !this._removedContLen &&
+            !this.hasHeader('content-length') &&
+            !this.hasHeader('transfer-encoding')) {
             // writeHead() was NOT called and full body is known at end-time:
             // set Content-Length and combine headers + body into a single write.
             const body = typeof data === 'string' ? Buffer.from(data, encoding || 'utf8') : Buffer.from(data);
@@ -851,6 +878,7 @@ ServerResponse.prototype.end = function end(data, encoding, cb) {
             // letting chunked encoding handle the body (matches Node.js behavior).
             if (!data &&
                 !this.headersSent &&
+                !this._removedContLen &&
                 !this.hasHeader('content-length') &&
                 !this.hasHeader('transfer-encoding')) {
                 this.setHeader('Content-Length', 0);
@@ -1399,17 +1427,10 @@ function createConnectionParser(server, socket) {
                     // Set up finish handler for request sequencing
                     res.on('finish', function onFinish() {
                         context.responseFinished = true;
-                        const responseConnection = res.getHeader('connection');
-                        const responseCloses =
-                            typeof responseConnection === 'string' &&
-                            responseConnection
-                                .toLowerCase()
-                                .split(',')
-                                .some((token) => token.trim() === 'close');
                         context.shouldKeepAliveAfterResponse =
                             (res._keepAlive || res._acceptOverflowRequest) &&
                             !isDroppedRequest &&
-                            !responseCloses &&
+                            !res._last &&
                             !server._closeRequested;
                         maybeFinalizeResponse(context);
                     });

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
@@ -225,6 +225,7 @@ function ServerResponse(req, options) {
     this._keepAliveMaxRequests = 0;
     this._last = false;
     this._sentContentLength = false;
+    this._header = null;
     this._headersSentWire = false;
     this._rejectNonStandardBodyWrites = !!(options && options.rejectNonStandardBodyWrites);
 
@@ -320,7 +321,7 @@ ServerResponse.prototype._implicitHeader = function _implicitHeader() {
 };
 
 ServerResponse.prototype.setHeader = function setHeader(name, value) {
-    if (this._headersSentWire) {
+    if (this.headersSent) {
         throw new ERR_HTTP_HEADERS_SENT('set');
     }
     if (typeof name !== 'string' || !/^[\x21-\x7e]+$/.test(name)) {
@@ -360,7 +361,7 @@ ServerResponse.prototype.hasHeader = function hasHeader(name) {
 };
 
 ServerResponse.prototype.removeHeader = function removeHeader(name) {
-    if (this._headersSentWire) {
+    if (this.headersSent) {
         throw new ERR_HTTP_HEADERS_SENT('remove');
     }
     const lower = name.toLowerCase();
@@ -509,13 +510,15 @@ ServerResponse.prototype.writeHead = function writeHead(statusCode, statusMessag
         }
     }
 
-    this.headersSent = true;
+    // Node commits both the serialized header and its private persistence
+    // decision at writeHead(). Keep the bytes buffered until the response is
+    // active, but reject and ignore subsequent header mutations immediately.
+    this._buildHeaderString();
     return this;
 };
 
 ServerResponse.prototype._buildHeaderString = function _buildHeaderString() {
-    if (this._headersSentWire) return '';
-    this._headersSentWire = true;
+    if (this._header !== null) return this._header;
     this.headersSent = true;
 
     const statusMessage = _validateStatusMessage(
@@ -585,6 +588,7 @@ ServerResponse.prototype._buildHeaderString = function _buildHeaderString() {
     const canKeepAlive = !!this._keepAlive;
     const canPersistForOverflow = !!this._acceptOverflowRequest;
     const selfDelimited = !this._hasBody || this._sentContentLength || this._chunked;
+    const chunkedWithoutTerminator = isNoBodyStatus && this._chunked;
 
     // Finalize the same private persistence decision that response completion
     // consumes. maxRequestsPerSocket is the Node-compatible exception: its
@@ -593,6 +597,7 @@ ServerResponse.prototype._buildHeaderString = function _buildHeaderString() {
     this._last =
         !(canKeepAlive || canPersistForOverflow) ||
         userSaysClose ||
+        chunkedWithoutTerminator ||
         !selfDelimited;
 
     // Explicit Keep-Alive is user-owned and suppresses automatic generation.
@@ -625,11 +630,14 @@ ServerResponse.prototype._buildHeaderString = function _buildHeaderString() {
     }
 
     head += '\r\n';
-    return head;
+    this._header = head;
+    return this._header;
 };
 
 ServerResponse.prototype._sendHeaders = function _sendHeaders() {
+    if (this._headersSentWire) return;
     const head = this._buildHeaderString();
+    this._headersSentWire = true;
     if (head) {
         this._writeOutput(Buffer.from(head));
     }
@@ -865,6 +873,7 @@ ServerResponse.prototype.end = function end(data, encoding, cb) {
             const body = typeof data === 'string' ? Buffer.from(data, encoding || 'utf8') : Buffer.from(data);
             this.setHeader('Content-Length', body.length);
             const head = this._buildHeaderString();
+            this._headersSentWire = true;
             if (this._hasBody && head) {
                 const headerBuf = Buffer.from(head);
                 const combined = Buffer.concat([headerBuf, body]);

--- a/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
@@ -294,6 +294,7 @@ pub fn add_module_resolvers(
         .with_module("node:inspector")
         .with_module("inspector")
         .with_module("__wasm_rquickjs_builtin/node_http_native")
+        .with_module("__wasm_rquickjs_builtin/node_http_incoming")
         .with_module("__wasm_rquickjs_builtin/node_http_server")
         .with_module("node:_http_common")
         .with_module("_http_common")
@@ -556,6 +557,10 @@ pub fn module_loader() -> (
         .with_module("dns/promises", dns::REEXPORT_PROMISES_JS)
         .with_module("node:domain", domain::DOMAIN_JS)
         .with_module("domain", domain::REEXPORT_JS)
+        .with_module(
+            "__wasm_rquickjs_builtin/node_http_incoming",
+            node_http::HTTP_INCOMING_JS,
+        )
         .with_module(
             "__wasm_rquickjs_builtin/node_http_server",
             node_http::NODE_HTTP_SERVER_JS,

--- a/examples/runtime/node-http/src/node-http.js
+++ b/examples/runtime/node-http/src/node-http.js
@@ -836,6 +836,185 @@ export async function httpCloseIdleConnections() {
     });
 }
 
+function getConnectionCount(server) {
+    return new Promise((resolve, reject) => {
+        server.getConnections((error, count) => {
+            if (error) reject(error);
+            else resolve(count);
+        });
+    });
+}
+
+function waitForConnectionCount(server, expected, attempts = 25) {
+    return new Promise((resolve) => {
+        const check = () => {
+            server.getConnections((error, count) => {
+                if (error || count === expected || attempts-- === 0) {
+                    resolve(!error && count === expected);
+                } else {
+                    setTimeout(check, 20);
+                }
+            });
+        };
+        check();
+    });
+}
+
+export async function httpIdleResourceReclamation() {
+    const sockets = new Set();
+    let handled = 0;
+    const server = http.createServer((_req, res) => {
+        handled++;
+        res.end('ok');
+    });
+    server.keepAliveTimeout = 40;
+
+    const closeServer = () =>
+        new Promise((resolve) => {
+            for (const socket of sockets) socket.destroy();
+            server.closeAllConnections();
+            if (server.listening) server.close(resolve);
+            else resolve();
+        });
+
+    try {
+        await new Promise((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(0, resolve);
+        });
+
+        const runBatch = async (batchSize) => {
+            const port = server.address().port;
+            await Promise.all(
+                Array.from(
+                    { length: batchSize },
+                    () =>
+                        new Promise((resolve, reject) => {
+                            let wire = '';
+                            let settled = false;
+                            const socket = net.connect({ port });
+                            sockets.add(socket);
+                            const timeout = setTimeout(
+                                () => finish(new Error('idle connection did not close')),
+                                1500
+                            );
+                            const finish = (error) => {
+                                if (settled) return;
+                                settled = true;
+                                clearTimeout(timeout);
+                                sockets.delete(socket);
+                                if (error) reject(error);
+                                else resolve();
+                            };
+                            socket.on('connect', () => {
+                                socket.write('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n');
+                            });
+                            socket.on('data', (chunk) => {
+                                wire += chunk.toString('latin1');
+                            });
+                            socket.on('close', () => {
+                                const responseComplete =
+                                    wire.includes('HTTP/1.1 200') &&
+                                    wire.includes('\r\nConnection: keep-alive\r\n') &&
+                                    wire.includes('\r\n\r\n') &&
+                                    wire.includes('ok');
+                                finish(
+                                    responseComplete
+                                        ? undefined
+                                        : new Error('incomplete keep-alive response')
+                                );
+                            });
+                            socket.on('error', finish);
+                        })
+                )
+            );
+            return (await getConnectionCount(server)) === 0;
+        };
+
+        const firstReclaimed = await runBatch(6);
+        const secondReclaimed = firstReclaimed && (await runBatch(6));
+        return firstReclaimed && secondReclaimed && handled === 12;
+    } catch (_error) {
+        return false;
+    } finally {
+        await closeServer();
+    }
+}
+
+export async function httpZeroKeepAliveTimeout() {
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let secondRequestScheduled = false;
+        let explicitCleanupRequested = false;
+        let closedBeforeExplicitCleanup = false;
+        const server = http.createServer((_req, res) => {
+            handled++;
+            if (handled === 2) {
+                res.on('finish', () => {
+                    explicitCleanupRequested = true;
+                    setImmediate(() => server.closeIdleConnections());
+                });
+            }
+            res.end(`ok-${handled}`);
+        });
+        server.keepAliveTimeout = 0;
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(overallTimeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            const complete = () => resolve(result);
+            if (server.listening) server.close(complete);
+            else complete();
+        };
+        const overallTimeout = setTimeout(() => finish(false), 2500);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write('GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n');
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!secondRequestScheduled && handled === 1 && wire.includes('ok-1')) {
+                    secondRequestScheduled = true;
+                    setTimeout(() => {
+                        if (socket.destroyed) {
+                            closedBeforeExplicitCleanup = true;
+                            finish(false);
+                            return;
+                        }
+                        socket.write('GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n');
+                    }, 120);
+                }
+            });
+            socket.on('end', () => {
+                if (!explicitCleanupRequested) closedBeforeExplicitCleanup = true;
+            });
+            socket.on('close', () => {
+                const connectionHeaders = wire.match(/\r\nConnection: keep-alive\r\n/g) || [];
+                waitForConnectionCount(server, 0).then((countReachedZero) => {
+                    finish(
+                        countReachedZero &&
+                            handled === 2 &&
+                            !closedBeforeExplicitCleanup &&
+                            connectionHeaders.length === 2 &&
+                            !wire.includes('\r\nKeep-Alive:') &&
+                            wire.includes('ok-1') &&
+                            wire.includes('ok-2')
+                    );
+                });
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+}
+
 export async function httpInformationalWriteAfterClose() {
     return new Promise((resolve) => {
         let settled = false;

--- a/examples/runtime/node-http/src/node-http.js
+++ b/examples/runtime/node-http/src/node-http.js
@@ -1213,3 +1213,167 @@ export async function httpCustomConnectionRejected() {
     return rejectsAsynchronously && agentHookIgnoredExplicitly && destroyBeforeRejection &&
         connectDoesNotOpenSocket && plainConnectRejected;
 }
+
+export async function httpResponsePersistence() {
+    const runCase = (options) => new Promise((resolve) => {
+        let settled = false;
+        let wire = '';
+        let responseComplete = false;
+        let socketEnded = false;
+        let socket;
+        const server = http.createServer((_req, res) => {
+            if (options.serverCloseBeforeCommit) {
+                server.close();
+            }
+            for (const [name, value] of options.headers || []) {
+                res.setHeader(name, value);
+            }
+            if (options.removeConnection) {
+                res.removeHeader('Connection');
+            }
+            if (options.removeFraming) {
+                res.removeHeader('Connection');
+                res.removeHeader('Content-Length');
+                res.removeHeader('Transfer-Encoding');
+            }
+            if (options.writeHeadFirst) {
+                res.writeHead(200);
+            }
+            res.end('ok');
+        });
+        if (Object.hasOwn(options, 'keepAliveTimeout')) {
+            server.keepAliveTimeout = options.keepAliveTimeout;
+        }
+        if (Object.hasOwn(options, 'maxRequestsPerSocket')) {
+            server.maxRequestsPerSocket = options.maxRequestsPerSocket;
+        }
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            if (server.listening) {
+                server.close(() => resolve(result));
+            } else {
+                resolve(result);
+            }
+        };
+
+        const headerValues = (name) => {
+            const headerEnd = wire.indexOf('\r\n\r\n');
+            if (headerEnd === -1) return [];
+            const prefix = name.toLowerCase() + ':';
+            return wire.slice(0, headerEnd).split('\r\n')
+                .filter((line) => line.toLowerCase().startsWith(prefix))
+                .map((line) => line.slice(line.indexOf(':') + 1).trim());
+        };
+
+        const headersMatch = () => {
+            const primaryMatch = JSON.stringify(headerValues('connection')) ===
+                JSON.stringify(options.connection || []) &&
+            JSON.stringify(headerValues('keep-alive')) ===
+                JSON.stringify(options.keepAlive || []);
+            const contentLengthMatch = !Object.hasOwn(options, 'contentLength') ||
+                JSON.stringify(headerValues('content-length')) ===
+                    JSON.stringify(options.contentLength);
+            const transferEncodingMatch = !Object.hasOwn(options, 'transferEncoding') ||
+                JSON.stringify(headerValues('transfer-encoding')) ===
+                    JSON.stringify(options.transferEncoding);
+            return primaryMatch && contentLengthMatch && transferEncodingMatch;
+        };
+
+        const timeout = setTimeout(() => finish(false), 1500);
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(options.request ||
+                    'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n');
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!responseComplete &&
+                    wire.includes('\r\n\r\n') &&
+                    wire.endsWith('ok')) {
+                    responseComplete = true;
+                    if (!options.expectEnd) {
+                        setTimeout(() => finish(headersMatch() && !socketEnded), 30);
+                    }
+                }
+            });
+            socket.on('end', () => {
+                socketEnded = true;
+                if (options.expectEnd) {
+                    finish(responseComplete && headersMatch());
+                } else {
+                    finish(false);
+                }
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+
+    const cases = [
+        { connection: ['keep-alive'], keepAlive: ['timeout=5'] },
+        { keepAliveTimeout: 0, connection: ['keep-alive'] },
+        { keepAliveTimeout: null, connection: ['keep-alive'] },
+        { keepAliveTimeout: undefined, connection: ['keep-alive'] },
+        { keepAliveTimeout: NaN, connection: ['keep-alive'] },
+        { keepAliveTimeout: -1, connection: ['keep-alive'], keepAlive: ['timeout=-1'] },
+        { keepAliveTimeout: 500, connection: ['keep-alive'], keepAlive: ['timeout=0'] },
+        { keepAliveTimeout: 1500, connection: ['keep-alive'], keepAlive: ['timeout=1'] },
+        { headers: [['Connection', 'keep-alive']], connection: ['keep-alive'] },
+        { headers: [['Connection', 'close']], connection: ['close'], expectEnd: true },
+        { headers: [['Connection', ['close']]], connection: ['close'], expectEnd: true },
+        {
+            headers: [['Connection', ['keep-alive', 'close']]],
+            connection: ['keep-alive', 'close'],
+            expectEnd: true,
+        },
+        {
+            headers: [['Connection', ['keep-alive', 'upgrade']]],
+            connection: ['keep-alive', 'upgrade'],
+        },
+        {
+            headers: [['Connection', 'Keep-Alive, ClOsE']],
+            connection: ['Keep-Alive, ClOsE'],
+            expectEnd: true,
+        },
+        {
+            headers: [['Connection', 'upgrade'], ['Keep-Alive', 'custom=1']],
+            connection: ['upgrade'],
+            keepAlive: ['custom=1'],
+        },
+        { removeConnection: true },
+        {
+            removeFraming: true,
+            contentLength: [],
+            transferEncoding: [],
+            expectEnd: true,
+        },
+        {
+            request: 'GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n',
+            connection: ['close'],
+            expectEnd: true,
+        },
+        {
+            request: 'GET / HTTP/1.0\r\n\r\n',
+            writeHeadFirst: true,
+            connection: ['close'],
+            expectEnd: true,
+        },
+        { maxRequestsPerSocket: 1, connection: ['close'] },
+        {
+            serverCloseBeforeCommit: true,
+            connection: ['keep-alive'],
+            keepAlive: ['timeout=5'],
+            expectEnd: true,
+        },
+    ];
+
+    for (const options of cases) {
+        if (!await runCase(options)) return false;
+    }
+    return true;
+}

--- a/examples/runtime/node-http/src/node-http.js
+++ b/examples/runtime/node-http/src/node-http.js
@@ -1015,6 +1015,587 @@ export async function httpZeroKeepAliveTimeout() {
     });
 }
 
+export async function httpUnreadRequestBodyDisposal() {
+    const runCycle = () => new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let resumed = false;
+        let listenerRemoved = false;
+        let dumpedBody = '';
+        let sentBodyAndNextRequest = false;
+        const requestBody = 'unread-body!';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/early') {
+                const ignoredDataListener = () => {};
+                req.pause();
+                req.on('data', ignoredDataListener);
+                req.on('resume', () => {
+                    resumed = true;
+                    listenerRemoved = req.listenerCount('data') === 0;
+                    req.on('data', (chunk) => {
+                        dumpedBody += chunk.toString();
+                    });
+                });
+                res.end('early');
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /early HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(requestBody)}\r\n\r\n`
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentBodyAndNextRequest && wire.includes('early')) {
+                    sentBodyAndNextRequest = true;
+                    socket.write(
+                        requestBody +
+                        'GET /next HTTP/1.1\r\n' +
+                        'Host: localhost\r\n' +
+                        'Connection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    resumed &&
+                    listenerRemoved &&
+                    dumpedBody === requestBody &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+        if (!await runCycle()) return false;
+    }
+    return true;
+}
+
+export async function httpServerRequestDestroy() {
+    const runIncomplete = (
+        withError,
+        listenForError = withError,
+        attachErrorListenerAfterDestroy = false,
+        attachErrorListenerOnNextTick = false
+    ) => new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let events = [];
+        let erroredMatches = false;
+        let socketErrorMatches = !withError;
+        let socketClosed = false;
+        const expectedError = new Error('destroy incomplete request');
+        const server = http.createServer((req, _res) => {
+            req.socket.on('error', (error) => {
+                socketErrorMatches = error === expectedError;
+                events.push('socket-error');
+            });
+            req.socket.on('close', () => {
+                socketClosed = true;
+                events.push('socket-close');
+            });
+            req.on('aborted', () => events.push('aborted'));
+            const onRequestError = (error) => {
+                erroredMatches = error === expectedError;
+                events.push(attachErrorListenerOnNextTick ?
+                    'nexttick-error' :
+                    attachErrorListenerAfterDestroy ? 'late-error' : 'error');
+            };
+            if (listenForError && !attachErrorListenerAfterDestroy) {
+                req.on('error', onRequestError);
+            }
+            req.on('close', () => {
+                events.push('close');
+            });
+            req.destroy(withError ? expectedError : undefined);
+            if (listenForError && attachErrorListenerAfterDestroy) {
+                if (attachErrorListenerOnNextTick) {
+                    process.nextTick(() => req.on('error', onRequestError));
+                } else {
+                    req.on('error', onRequestError);
+                }
+            }
+            if (!listenForError) {
+                erroredMatches = withError ?
+                    req.errored === expectedError : req.errored === null;
+            }
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 2000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /incomplete HTTP/1.1\r\n' +
+                    'Host: localhost\r\nContent-Length: 5\r\n\r\n'
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+            });
+            socket.on('close', () => {
+                setImmediate(() => {
+                    server.getConnections((error, count) => {
+                        const errorEvent = attachErrorListenerOnNextTick ?
+                            'nexttick-error' :
+                            attachErrorListenerAfterDestroy ? 'late-error' : 'error';
+                        const terminalEvents = withError ?
+                            events.filter((event) => event !== 'socket-close') : events;
+                        const expectedEvents = withError ?
+                            listenForError ?
+                                `aborted,socket-error,${errorEvent},close` :
+                                'aborted,socket-error,close' :
+                            'aborted,socket-close,close';
+                        finish(
+                            !error &&
+                            count === 0 &&
+                            wire === '' &&
+                            erroredMatches &&
+                            socketErrorMatches &&
+                            socketClosed &&
+                            terminalEvents.join(',') === expectedEvents
+                        );
+                    });
+                });
+            });
+            socket.on('error', () => {});
+        });
+    });
+
+    const runCompletedError = () => new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let connections = 0;
+        let completeAtDestroy = false;
+        let errorObserved = false;
+        let requestClosed = false;
+        let requestAborted = false;
+        let sentSecond = false;
+        const expectedError = new Error('destroy completed request');
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/first') {
+                req.on('aborted', () => {
+                    requestAborted = true;
+                });
+                req.on('error', (error) => {
+                    errorObserved = error === expectedError;
+                });
+                req.on('close', () => {
+                    requestClosed = true;
+                });
+                req.on('end', () => {
+                    completeAtDestroy = req.complete && req.readableEnded;
+                    req.destroy(expectedError);
+                    res.end('first');
+                });
+                req.resume();
+                return;
+            }
+            res.end('second');
+        });
+        server.on('connection', () => {
+            connections++;
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write('GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n');
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentSecond && wire.includes('first')) {
+                    sentSecond = true;
+                    socket.write(
+                        'GET /second HTTP/1.1\r\n' +
+                        'Host: localhost\r\nConnection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const firstBody = wire.indexOf('first', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', firstBody);
+                const secondBody = wire.indexOf('second', secondStatus);
+                finish(
+                    handled === 2 &&
+                    connections === 1 &&
+                    completeAtDestroy &&
+                    errorObserved &&
+                    requestClosed &&
+                    !requestAborted &&
+                    firstStatus !== -1 &&
+                    firstBody > firstStatus &&
+                    secondStatus > firstBody &&
+                    secondBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+
+    return await runIncomplete(true) &&
+        await runIncomplete(true, true, true) &&
+        await runIncomplete(true, true, true, true) &&
+        await runIncomplete(true, false) &&
+        await runIncomplete(false) &&
+        await runCompletedError();
+}
+
+export async function httpPartiallyConsumedRequestBody() {
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let partialRequest;
+        let firstChunk = '';
+        let unexpectedResume = false;
+        let sentRemainderAndNext = false;
+        const firstPart = 'part-';
+        const remainder = 'body!';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/partial') {
+                partialRequest = req;
+                req.once('data', (chunk) => {
+                    firstChunk = chunk.toString();
+                    req.pause();
+                    req.on('resume', () => {
+                        unexpectedResume = true;
+                    });
+                    res.end('early');
+                });
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /partial HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(firstPart + remainder)}\r\n\r\n` +
+                    firstPart
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentRemainderAndNext && wire.includes('early')) {
+                    sentRemainderAndNext = true;
+                    socket.write(
+                        remainder +
+                        'GET /next HTTP/1.1\r\n' +
+                        'Host: localhost\r\n' +
+                        'Connection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    firstChunk === firstPart &&
+                    partialRequest.complete &&
+                    !unexpectedResume &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+}
+
+export async function httpResumeScheduledRequestBody() {
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let listenerPreserved = false;
+        let receivedBody = '';
+        let sentBodyAndNextRequest = false;
+        const requestBody = 'scheduled-body';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/scheduled') {
+                req.on('data', (chunk) => {
+                    receivedBody += chunk.toString();
+                });
+                req.resume();
+                res.end('early');
+                listenerPreserved = req.listenerCount('data') === 1;
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /scheduled HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(requestBody)}\r\n\r\n`
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentBodyAndNextRequest && wire.includes('early')) {
+                    sentBodyAndNextRequest = true;
+                    socket.write(
+                        requestBody +
+                        'GET /next HTTP/1.1\r\n' +
+                        'Host: localhost\r\n' +
+                        'Connection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    listenerPreserved &&
+                    receivedBody === requestBody &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+}
+
+export async function httpCompleteUnreadRequestBody() {
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let completeBeforeResponse = false;
+        let resumed = false;
+        let listenerRemoved = false;
+        let dumpedBody = '';
+        const requestBody = 'buffered-body';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/buffered') {
+                req.pause();
+                req.on('data', () => {});
+                req.on('resume', () => {
+                    resumed = true;
+                    listenerRemoved = req.listenerCount('data') === 0;
+                    req.on('data', (chunk) => {
+                        dumpedBody += chunk.toString();
+                    });
+                });
+                setImmediate(() => {
+                    completeBeforeResponse = req.complete;
+                    res.end('early');
+                });
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /buffered HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(requestBody)}\r\n\r\n` +
+                    requestBody +
+                    'GET /next HTTP/1.1\r\n' +
+                    'Host: localhost\r\nConnection: close\r\n\r\n'
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    completeBeforeResponse &&
+                    resumed &&
+                    listenerRemoved &&
+                    dumpedBody === requestBody &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+}
+
+export async function httpClientResponseOwnership() {
+    const server = http.createServer((_req, res) => {
+        res.end('response-body');
+    });
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const unownedDisposed = await new Promise((resolve) => {
+        let settled = false;
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            resolve(result);
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+        const req = http.request({ port, path: '/unowned' });
+        req.on('error', () => finish(false));
+        req.on('close', () => {
+            const response = req._response;
+            const checkComplete = (attempts) => {
+                if (response && response.complete) {
+                    finish(response._dumped === true);
+                } else if (attempts > 0) {
+                    setTimeout(() => checkComplete(attempts - 1), 10);
+                } else {
+                    finish(false);
+                }
+            };
+            checkComplete(50);
+        });
+        req.end();
+    });
+
+    const ownedDelayed = await new Promise((resolve) => {
+        let settled = false;
+        let body = '';
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            resolve(result);
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+        const req = http.request({ port, path: '/owned' }, (res) => {
+            const untouched = res._dumped === false && res.readableFlowing === null;
+            setTimeout(() => {
+                res.on('data', (chunk) => {
+                    body += chunk.toString();
+                });
+                res.on('end', () => {
+                    finish(untouched && body === 'response-body');
+                });
+            }, 25);
+        });
+        req.on('error', () => finish(false));
+        req.end();
+    });
+
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+    return unownedDisposed && ownedDelayed;
+}
+
 export async function httpInformationalWriteAfterClose() {
     return new Promise((resolve) => {
         let settled = false;

--- a/examples/runtime/node-http/src/node-http.js
+++ b/examples/runtime/node-http/src/node-http.js
@@ -1219,6 +1219,7 @@ export async function httpResponsePersistence() {
         let settled = false;
         let wire = '';
         let responseComplete = false;
+        let serverBehaviorMatch = true;
         let socketEnded = false;
         let socket;
         const server = http.createServer((_req, res) => {
@@ -1237,9 +1238,24 @@ export async function httpResponsePersistence() {
                 res.removeHeader('Transfer-Encoding');
             }
             if (options.writeHeadFirst) {
-                res.writeHead(200);
+                res.writeHead(options.statusCode || 200);
             }
-            res.end('ok');
+            if (options.mutateAfterWriteHead) {
+                let mutationErrors = 0;
+                try {
+                    res.setHeader('X-Late', 'rejected');
+                } catch (error) {
+                    mutationErrors += error.code === 'ERR_HTTP_HEADERS_SENT' ? 1 : 0;
+                }
+                try {
+                    res.removeHeader('Connection');
+                } catch (error) {
+                    mutationErrors += error.code === 'ERR_HTTP_HEADERS_SENT' ? 1 : 0;
+                }
+                options.headers[0][1].push('close');
+                serverBehaviorMatch = mutationErrors === 2;
+            }
+            res.end(options.noBody ? undefined : 'ok');
         });
         if (Object.hasOwn(options, 'keepAliveTimeout')) {
             server.keepAliveTimeout = options.keepAliveTimeout;
@@ -1281,7 +1297,10 @@ export async function httpResponsePersistence() {
             const transferEncodingMatch = !Object.hasOwn(options, 'transferEncoding') ||
                 JSON.stringify(headerValues('transfer-encoding')) ===
                     JSON.stringify(options.transferEncoding);
-            return primaryMatch && contentLengthMatch && transferEncodingMatch;
+            const noChunkTerminatorMatch = !options.noChunkTerminator ||
+                !wire.slice(wire.indexOf('\r\n\r\n') + 4).includes('0\r\n\r\n');
+            return serverBehaviorMatch && primaryMatch && contentLengthMatch &&
+                transferEncodingMatch && noChunkTerminatorMatch;
         };
 
         const timeout = setTimeout(() => finish(false), 1500);
@@ -1293,9 +1312,10 @@ export async function httpResponsePersistence() {
             });
             socket.on('data', (chunk) => {
                 wire += chunk.toString('latin1');
+                const body = wire.slice(wire.indexOf('\r\n\r\n') + 4);
                 if (!responseComplete &&
                     wire.includes('\r\n\r\n') &&
-                    wire.endsWith('ok')) {
+                    (options.noBody || body.includes('ok'))) {
                     responseComplete = true;
                     if (!options.expectEnd) {
                         setTimeout(() => finish(headersMatch() && !socketEnded), 30);
@@ -1344,6 +1364,37 @@ export async function httpResponsePersistence() {
             headers: [['Connection', 'upgrade'], ['Keep-Alive', 'custom=1']],
             connection: ['upgrade'],
             keepAlive: ['custom=1'],
+        },
+        {
+            headers: [['Keep-Alive', 'custom=2']],
+            connection: ['keep-alive'],
+            keepAlive: ['custom=2'],
+        },
+        {
+            headers: [['Connection', ['keep-alive']]],
+            writeHeadFirst: true,
+            mutateAfterWriteHead: true,
+            connection: ['keep-alive'],
+        },
+        {
+            headers: [['Transfer-Encoding', 'chunked']],
+            statusCode: 204,
+            writeHeadFirst: true,
+            connection: ['close'],
+            transferEncoding: ['chunked'],
+            noBody: true,
+            noChunkTerminator: true,
+            expectEnd: true,
+        },
+        {
+            headers: [['Transfer-Encoding', 'chunked']],
+            statusCode: 304,
+            writeHeadFirst: true,
+            connection: ['close'],
+            transferEncoding: ['chunked'],
+            noBody: true,
+            noChunkTerminator: true,
+            expectEnd: true,
         },
         { removeConnection: true },
         {

--- a/examples/runtime/node-http/wit/node-http.wit
+++ b/examples/runtime/node-http/wit/node-http.wit
@@ -15,6 +15,8 @@ world node-http {
   export http-pipelined-connection-close: func() -> bool;
   export http-pipelined-active-timeout: func() -> bool;
   export http-close-idle-connections: func() -> bool;
+  export http-idle-resource-reclamation: func() -> bool;
+  export http-zero-keep-alive-timeout: func() -> bool;
   export http-informational-write-after-close: func() -> bool;
   export http-max-requests-closes-socket: func() -> bool;
   export net-writev-boundaries: func() -> bool;

--- a/examples/runtime/node-http/wit/node-http.wit
+++ b/examples/runtime/node-http/wit/node-http.wit
@@ -17,6 +17,12 @@ world node-http {
   export http-close-idle-connections: func() -> bool;
   export http-idle-resource-reclamation: func() -> bool;
   export http-zero-keep-alive-timeout: func() -> bool;
+  export http-unread-request-body-disposal: func() -> bool;
+  export http-server-request-destroy: func() -> bool;
+  export http-partially-consumed-request-body: func() -> bool;
+  export http-resume-scheduled-request-body: func() -> bool;
+  export http-complete-unread-request-body: func() -> bool;
+  export http-client-response-ownership: func() -> bool;
   export http-informational-write-after-close: func() -> bool;
   export http-max-requests-closes-socket: func() -> bool;
   export net-writev-boundaries: func() -> bool;

--- a/examples/runtime/node-http/wit/node-http.wit
+++ b/examples/runtime/node-http/wit/node-http.wit
@@ -20,4 +20,5 @@ world node-http {
   export net-writev-boundaries: func() -> bool;
   export http-pipelined-max-requests: func() -> bool;
   export http-custom-connection-rejected: func() -> bool;
+  export http-response-persistence: func() -> bool;
 }

--- a/tests/goldenfiles/generated_types_node-http_exports.d.ts
+++ b/tests/goldenfiles/generated_types_node-http_exports.d.ts
@@ -15,6 +15,12 @@ declare module 'node-http' {
   export function httpCloseIdleConnections(): Promise<boolean>;
   export function httpIdleResourceReclamation(): Promise<boolean>;
   export function httpZeroKeepAliveTimeout(): Promise<boolean>;
+  export function httpUnreadRequestBodyDisposal(): Promise<boolean>;
+  export function httpServerRequestDestroy(): Promise<boolean>;
+  export function httpPartiallyConsumedRequestBody(): Promise<boolean>;
+  export function httpResumeScheduledRequestBody(): Promise<boolean>;
+  export function httpCompleteUnreadRequestBody(): Promise<boolean>;
+  export function httpClientResponseOwnership(): Promise<boolean>;
   export function httpInformationalWriteAfterClose(): Promise<boolean>;
   export function httpMaxRequestsClosesSocket(): Promise<boolean>;
   export function netWritevBoundaries(): Promise<boolean>;

--- a/tests/goldenfiles/generated_types_node-http_exports.d.ts
+++ b/tests/goldenfiles/generated_types_node-http_exports.d.ts
@@ -13,6 +13,8 @@ declare module 'node-http' {
   export function httpPipelinedConnectionClose(): Promise<boolean>;
   export function httpPipelinedActiveTimeout(): Promise<boolean>;
   export function httpCloseIdleConnections(): Promise<boolean>;
+  export function httpIdleResourceReclamation(): Promise<boolean>;
+  export function httpZeroKeepAliveTimeout(): Promise<boolean>;
   export function httpInformationalWriteAfterClose(): Promise<boolean>;
   export function httpMaxRequestsClosesSocket(): Promise<boolean>;
   export function netWritevBoundaries(): Promise<boolean>;

--- a/tests/goldenfiles/generated_types_node-http_exports.d.ts
+++ b/tests/goldenfiles/generated_types_node-http_exports.d.ts
@@ -18,4 +18,5 @@ declare module 'node-http' {
   export function netWritevBoundaries(): Promise<boolean>;
   export function httpPipelinedMaxRequests(): Promise<boolean>;
   export function httpCustomConnectionRejected(): Promise<boolean>;
+  export function httpResponsePersistence(): Promise<boolean>;
 }

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -5016,7 +5016,7 @@
     "parallel/test-domain-async-id-map-leak.js": { "category": "known-gap", "reason": "domain/async_hooks integration for AsyncResource domain tracking and async-id map behavior is incomplete" },
 
     // === Additional node:http tests (require HTTP server or internals) ===
-    "parallel/test-http-1.0-keep-alive.js": {},
+    "parallel/test-http-1.0-keep-alive.js": { "category": "known-gap", "reason": "HTTP/1.0 TE: chunked request negotiation does not enable implicit chunked response framing and persistence" },
     "parallel/test-http-1.0.js": {
       "split": true,
       "subtests": {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4606,7 +4606,7 @@
     "parallel/test-http-raw-headers.js": { "category": "known-gap", "reason": "rawHeaders/rawTrailers casing and duplicate-header preservation differ from Node semantics" },
     "parallel/test-http-readable-data-event.js": {},
     "parallel/test-http-remove-connection-header-persists-connection.js": {},
-    "parallel/test-http-remove-header-stays-removed.js": { "category": "known-gap", "reason": "removing hop-by-hop/framing headers is not serialized with Node-compatible behavior" },
+    "parallel/test-http-remove-header-stays-removed.js": {},
     "parallel/test-http-req-close-robust-from-tampering.js": { "category": "node-internals", "reason": "invokes private req.client._events.close handlers directly" },
     "parallel/test-http-request-arguments.js": {},
     "parallel/test-http-request-dont-override-options.js": {},

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4386,7 +4386,7 @@
       }
     },
     "parallel/test-http-chunk-problem.js": { "category": "wasi-impossible", "reason": "requires external shell pipeline and cat subprocess via child_process" },
-    "parallel/test-http-chunked-304.js": { "category": "known-gap", "reason": "HTTP server incorrectly emits chunked terminator semantics for 204/304 responses" },
+    "parallel/test-http-chunked-304.js": {},
     "parallel/test-http-chunked-smuggling.js": { "category": "known-gap", "reason": "HTTP parser accepts invalid chunk extensions and mishandles smuggling-style input" },
     "parallel/test-http-chunked.js": {},
     "parallel/test-http-client-abort-destroy.js": {
@@ -4761,7 +4761,7 @@
     "parallel/test-http-upgrade-client2.js": { "category": "wasi-impossible", "reason": "wasi:http does not support HTTP Upgrade/101 socket takeover for node:http clients" },
     "parallel/test-http-upgrade-reconsume-stream.js": { "category": "wasi-impossible", "reason": "requires HTTP Upgrade socket takeover plus tls.TLSSocket, unavailable in WASI" },
     "parallel/test-http-upgrade-server2.js": { "category": "known-gap", "reason": "server-side Upgrade event/error propagation is incomplete" },
-    "parallel/test-http-wget.js": { "category": "known-gap", "reason": "HTTP/1.0 keep-alive response connection-closing semantics are not Node-compatible" },
+    "parallel/test-http-wget.js": {},
     "parallel/test-http-writable-true-after-close.js": { "category": "known-gap", "reason": "response writable state around aborted proxy close is not Node-compatible" },
     "parallel/test-http-write-callbacks.js": { "category": "known-gap", "reason": "checkContinue/write callback ordering and completion semantics are incomplete" },
     "parallel/test-http-write-empty-string.js": {},
@@ -5016,7 +5016,7 @@
     "parallel/test-domain-async-id-map-leak.js": { "category": "known-gap", "reason": "domain/async_hooks integration for AsyncResource domain tracking and async-id map behavior is incomplete" },
 
     // === Additional node:http tests (require HTTP server or internals) ===
-    "parallel/test-http-1.0-keep-alive.js": { "category": "known-gap", "reason": "HTTP/1.0 keep-alive client/server framing is not Node-compatible; consistently fails on CI even with retries" },
+    "parallel/test-http-1.0-keep-alive.js": {},
     "parallel/test-http-1.0.js": {
       "split": true,
       "subtests": {

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4471,7 +4471,7 @@
         }
       }
     },
-    "parallel/test-http-dump-req-when-res-ends.js": { "category": "known-gap", "reason": "request auto-dump/resume when response ends early is incomplete, causing the request/response lifecycle to hang" },
+    "parallel/test-http-dump-req-when-res-ends.js": { "category": "known-gap", "reason": "wasi:http client cannot expose an early response before the request body is finished, so this bidirectional streaming fixture deadlocks" },
     "parallel/test-http-early-hints-invalid-argument.js": { "category": "known-gap", "reason": "ServerResponse.writeEarlyHints() argument validation is incomplete (missing expected ERR_INVALID_ARG_VALUE throws)" },
     "parallel/test-http-early-hints.js": {
       "split": true,
@@ -4568,7 +4568,7 @@
     },
     "parallel/test-http-multiple-headers.js": { "category": "known-gap", "reason": "rawHeaders/rawTrailers duplicate-header ordering and casing are not Node-compatible" },
     "parallel/test-http-mutable-headers.js": { "category": "known-gap", "reason": "OutgoingMessage.getHeaders() shape is not Node-compatible (null-prototype object expected)" },
-    "parallel/test-http-no-read-no-dump.js": { "category": "known-gap", "reason": "keep-alive request sequencing with unread request bodies has non-Node lifecycle behavior" },
+    "parallel/test-http-no-read-no-dump.js": { "category": "known-gap", "reason": "wasi:http client cannot expose an early response before the request body is finished, so this bidirectional streaming fixture deadlocks" },
     "parallel/test-http-nodelay.js": { "category": "known-gap", "reason": "node:http client path does not honor/verify net.Socket connect noDelay semantics like Node" },
     "parallel/test-http-outgoing-destroyed.js": {
       "split": true,
@@ -4696,7 +4696,7 @@
     "parallel/test-http-server-headers-timeout-interrupted-headers.js": { "category": "known-gap", "reason": "server.headersTimeout 408 behavior for interrupted header lines is incomplete" },
     "parallel/test-http-server-headers-timeout-keepalive.js": { "category": "known-gap", "reason": "server.headersTimeout handling across keep-alive requests is not Node-compatible" },
     "parallel/test-http-server-headers-timeout-pipelining.js": { "category": "known-gap", "reason": "server.headersTimeout handling for pipelined requests is not Node-compatible" },
-    "parallel/test-http-server-incomingmessage-destroy.js": { "category": "known-gap", "reason": "req.destroy() on server-side IncomingMessage does not propagate Node-compatible ECONNRESET client behavior" },
+    "parallel/test-http-server-incomingmessage-destroy.js": { "category": "known-gap", "reason": "wasi:http client does not translate an incomplete response after server request destruction into the expected ECONNRESET request error" },
     "parallel/test-http-server-keep-alive-defaults.js": {},
     "parallel/test-http-server-keep-alive-max-requests-null.js": {},
     "parallel/test-http-server-keepalive-end.js": { "category": "node-internals", "reason": "asserts private req.socket.parser.incoming lifecycle after keep-alive request end" },

--- a/tests/node_compat/report.md
+++ b/tests/node_compat/report.md
@@ -8,21 +8,21 @@ This report is generated from `config.jsonc` only. It does **not** run the vendo
 
 Primary compatibility is measured over the public API surface we can provide: CI-enforced passing (`runnable`) plus `known-gap`. WASI-impossible tests, engine differences, unevaluated tests, and Node.js-internals tests are acknowledged separately and excluded from the primary percentage.
 
-**Primary compatibility (CI-enforced):** 3174/4387 (72.4%)
+**Primary compatibility (CI-enforced):** 3175/4387 (72.4%)
 
 When comparing revisions, read the runnable count and secondary full-public percentage alongside the primary percentage. Reclassifying a test into an excluded category can increase the primary percentage without increasing runnable coverage.
 
 | Classification | Count | Primary % | Public inventory % | All listed % |
 |----------------|-------|-----------|--------------------|--------------|
-| ✅ passing (runnable) | 3174 | 72.4% | 55.2% | 46.2% |
-| 🧩 known gap | 1213 | 27.6% | 21.1% | 17.6% |
+| ✅ passing (runnable) | 3175 | 72.4% | 55.2% | 46.2% |
+| 🧩 known gap | 1212 | 27.6% | 21.1% | 17.6% |
 | 🚫 WASI-impossible (excluded) | 1195 | — | 20.8% | 17.4% |
 | ⚙️ engine difference (excluded) | 168 | — | 2.9% | 2.4% |
 | ❔ unevaluated (excluded) | 0 | — | 0.0% | 0.0% |
 | 🔒 Node.js internals (excluded) | 1123 | — | — | 16.3% |
 | **Total** | **6873** |  |  | **100.0%** |
 
-Secondary full-public compatibility, including public tests that are currently excluded from primary: **3174/5750 (55.2%)**.
+Secondary full-public compatibility, including public tests that are currently excluded from primary: **3175/5750 (55.2%)**.
 
 ## Inventory by Module
 
@@ -52,7 +52,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | fs | 482 | 339 | 46 | 21 | 5 | 0 | 71 | 88.1% | 82.5% |
 | global | 11 | 4 | 5 | 0 | 0 | 0 | 2 | 44.4% | 44.4% |
 | heap | 22 | 0 | 0 | 15 | 7 | 0 | 0 | 0.0% | 0.0% |
-| http | 898 | 229 | 286 | 301 | 2 | 0 | 80 | 44.5% | 28.0% |
+| http | 898 | 230 | 285 | 301 | 2 | 0 | 80 | 44.7% | 28.1% |
 | inspector | 95 | 1 | 0 | 93 | 0 | 0 | 1 | 100.0% | 1.1% |
 | internal | 53 | 1 | 0 | 0 | 0 | 0 | 52 | 100.0% | 100.0% |
 | module | 174 | 122 | 32 | 7 | 1 | 0 | 12 | 79.2% | 75.3% |
@@ -686,7 +686,7 @@ Secondary full-public compatibility, including public tests that are currently e
 
 ## Classified Non-Runnable Tests
 
-### known gap (1213)
+### known gap (1212)
 
 | Reason | Count | Example entries |
 |--------|-------|-----------------|
@@ -1201,7 +1201,6 @@ Secondary full-public compatibility, including public tests that are currently e
 | rawHeaders/rawTrailers duplicate-header ordering and casing are not Node-compatible | 1 | `parallel/test-http-multiple-headers.js` |
 | receiveBlockList filtering/close behavior is incomplete | 1 | `parallel/test-dgram-blocklist.js#block_02_block_02` |
 | receiveMessageOnPort() behavior and argument validation are not implemented | 1 | `parallel/test-worker-message-port-receive-message.js` |
-| removing hop-by-hop/framing headers is not serialized with Node-compatible behavior | 1 | `parallel/test-http-remove-header-stays-removed.js` |
 | req.connection.setTimeout timeout/error flow on server-side connections is incomplete | 1 | `parallel/test-http-set-timeout.js` |
 | req.destroy() on server-side IncomingMessage does not propagate Node-compatible ECONNRESET client behavior | 1 | `parallel/test-http-server-incomingmessage-destroy.js` |
 | req.setTimeout() handling for actively consumed request bodies is not Node-compatible | 1 | `parallel/test-http-server-consumed-timeout.js` |

--- a/tests/node_compat/report.md
+++ b/tests/node_compat/report.md
@@ -8,21 +8,21 @@ This report is generated from `config.jsonc` only. It does **not** run the vendo
 
 Primary compatibility is measured over the public API surface we can provide: CI-enforced passing (`runnable`) plus `known-gap`. WASI-impossible tests, engine differences, unevaluated tests, and Node.js-internals tests are acknowledged separately and excluded from the primary percentage.
 
-**Primary compatibility (CI-enforced):** 3175/4387 (72.4%)
+**Primary compatibility (CI-enforced):** 3178/4387 (72.4%)
 
 When comparing revisions, read the runnable count and secondary full-public percentage alongside the primary percentage. Reclassifying a test into an excluded category can increase the primary percentage without increasing runnable coverage.
 
 | Classification | Count | Primary % | Public inventory % | All listed % |
 |----------------|-------|-----------|--------------------|--------------|
-| ✅ passing (runnable) | 3175 | 72.4% | 55.2% | 46.2% |
-| 🧩 known gap | 1212 | 27.6% | 21.1% | 17.6% |
+| ✅ passing (runnable) | 3178 | 72.4% | 55.3% | 46.2% |
+| 🧩 known gap | 1209 | 27.6% | 21.0% | 17.6% |
 | 🚫 WASI-impossible (excluded) | 1195 | — | 20.8% | 17.4% |
 | ⚙️ engine difference (excluded) | 168 | — | 2.9% | 2.4% |
 | ❔ unevaluated (excluded) | 0 | — | 0.0% | 0.0% |
 | 🔒 Node.js internals (excluded) | 1123 | — | — | 16.3% |
 | **Total** | **6873** |  |  | **100.0%** |
 
-Secondary full-public compatibility, including public tests that are currently excluded from primary: **3175/5750 (55.2%)**.
+Secondary full-public compatibility, including public tests that are currently excluded from primary: **3178/5750 (55.3%)**.
 
 ## Inventory by Module
 
@@ -52,7 +52,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | fs | 482 | 339 | 46 | 21 | 5 | 0 | 71 | 88.1% | 82.5% |
 | global | 11 | 4 | 5 | 0 | 0 | 0 | 2 | 44.4% | 44.4% |
 | heap | 22 | 0 | 0 | 15 | 7 | 0 | 0 | 0.0% | 0.0% |
-| http | 898 | 230 | 285 | 301 | 2 | 0 | 80 | 44.7% | 28.1% |
+| http | 898 | 233 | 282 | 301 | 2 | 0 | 80 | 45.2% | 28.5% |
 | inspector | 95 | 1 | 0 | 93 | 0 | 0 | 1 | 100.0% | 1.1% |
 | internal | 53 | 1 | 0 | 0 | 0 | 0 | 52 | 100.0% | 100.0% |
 | module | 174 | 122 | 32 | 7 | 1 | 0 | 12 | 79.2% | 75.3% |
@@ -686,7 +686,7 @@ Secondary full-public compatibility, including public tests that are currently e
 
 ## Classified Non-Runnable Tests
 
-### known gap (1212)
+### known gap (1209)
 
 | Reason | Count | Example entries |
 |--------|-------|-----------------|
@@ -889,11 +889,8 @@ Secondary full-public compatibility, including public tests that are currently e
 | HTTP server close/reopen ECONNREFUSED sequencing is not Node-compatible | 1 | `sequential/test-http-econnrefused.js` |
 | HTTP server duplicate request-header coalescing for allowed/forbidden header sets is not Node-compatible | 1 | `parallel/test-http-server-multiheaders2.js` |
 | HTTP server duplicate request-header coalescing/deduplication is not Node-compatible | 1 | `parallel/test-http-server-multiheaders.js` |
-| HTTP server incorrectly emits chunked terminator semantics for 204/304 responses | 1 | `parallel/test-http-chunked-304.js` |
 | HTTP server parser does not emit Node-compatible HPE_HEADER_OVERFLOW/431 behavior for oversized headers | 1 | `parallel/test-http-header-overflow.js` |
 | HTTP server socket.setEncoding('') error path (ERR_HTTP_SOCKET_ENCODING) is not Node-compatible | 1 | `parallel/test-http-socket-encoding-error.js` |
-| HTTP/1.0 keep-alive client/server framing is not Node-compatible; consistently fails on CI even with retries | 1 | `parallel/test-http-1.0-keep-alive.js` |
-| HTTP/1.0 keep-alive response connection-closing semantics are not Node-compatible | 1 | `parallel/test-http-wget.js` |
 | Happy Eyeballs autoSelectFamily over custom dual-stack DNS is not wired through wasi:http transport | 1 | `parallel/test-http-autoselectfamily.js` |
 | Host header generation ignores globalAgent.defaultPort and incorrectly includes the port | 1 | `parallel/test-http-default-port.js` |
 | Host header generation/handling in node:http is not fully Node-compatible | 1 | `parallel/test-http-host-headers.js` |

--- a/tests/node_compat/report.md
+++ b/tests/node_compat/report.md
@@ -8,21 +8,21 @@ This report is generated from `config.jsonc` only. It does **not** run the vendo
 
 Primary compatibility is measured over the public API surface we can provide: CI-enforced passing (`runnable`) plus `known-gap`. WASI-impossible tests, engine differences, unevaluated tests, and Node.js-internals tests are acknowledged separately and excluded from the primary percentage.
 
-**Primary compatibility (CI-enforced):** 3178/4387 (72.4%)
+**Primary compatibility (CI-enforced):** 3177/4387 (72.4%)
 
 When comparing revisions, read the runnable count and secondary full-public percentage alongside the primary percentage. Reclassifying a test into an excluded category can increase the primary percentage without increasing runnable coverage.
 
 | Classification | Count | Primary % | Public inventory % | All listed % |
 |----------------|-------|-----------|--------------------|--------------|
-| ✅ passing (runnable) | 3178 | 72.4% | 55.3% | 46.2% |
-| 🧩 known gap | 1209 | 27.6% | 21.0% | 17.6% |
+| ✅ passing (runnable) | 3177 | 72.4% | 55.3% | 46.2% |
+| 🧩 known gap | 1210 | 27.6% | 21.0% | 17.6% |
 | 🚫 WASI-impossible (excluded) | 1195 | — | 20.8% | 17.4% |
 | ⚙️ engine difference (excluded) | 168 | — | 2.9% | 2.4% |
 | ❔ unevaluated (excluded) | 0 | — | 0.0% | 0.0% |
 | 🔒 Node.js internals (excluded) | 1123 | — | — | 16.3% |
 | **Total** | **6873** |  |  | **100.0%** |
 
-Secondary full-public compatibility, including public tests that are currently excluded from primary: **3178/5750 (55.3%)**.
+Secondary full-public compatibility, including public tests that are currently excluded from primary: **3177/5750 (55.3%)**.
 
 ## Inventory by Module
 
@@ -52,7 +52,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | fs | 482 | 339 | 46 | 21 | 5 | 0 | 71 | 88.1% | 82.5% |
 | global | 11 | 4 | 5 | 0 | 0 | 0 | 2 | 44.4% | 44.4% |
 | heap | 22 | 0 | 0 | 15 | 7 | 0 | 0 | 0.0% | 0.0% |
-| http | 898 | 233 | 282 | 301 | 2 | 0 | 80 | 45.2% | 28.5% |
+| http | 898 | 232 | 283 | 301 | 2 | 0 | 80 | 45.0% | 28.4% |
 | inspector | 95 | 1 | 0 | 93 | 0 | 0 | 1 | 100.0% | 1.1% |
 | internal | 53 | 1 | 0 | 0 | 0 | 0 | 52 | 100.0% | 100.0% |
 | module | 174 | 122 | 32 | 7 | 1 | 0 | 12 | 79.2% | 75.3% |
@@ -686,7 +686,7 @@ Secondary full-public compatibility, including public tests that are currently e
 
 ## Classified Non-Runnable Tests
 
-### known gap (1209)
+### known gap (1210)
 
 | Reason | Count | Example entries |
 |--------|-------|-----------------|
@@ -891,6 +891,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | HTTP server duplicate request-header coalescing/deduplication is not Node-compatible | 1 | `parallel/test-http-server-multiheaders.js` |
 | HTTP server parser does not emit Node-compatible HPE_HEADER_OVERFLOW/431 behavior for oversized headers | 1 | `parallel/test-http-header-overflow.js` |
 | HTTP server socket.setEncoding('') error path (ERR_HTTP_SOCKET_ENCODING) is not Node-compatible | 1 | `parallel/test-http-socket-encoding-error.js` |
+| HTTP/1.0 TE: chunked request negotiation does not enable implicit chunked response framing and persistence | 1 | `parallel/test-http-1.0-keep-alive.js` |
 | Happy Eyeballs autoSelectFamily over custom dual-stack DNS is not wired through wasi:http transport | 1 | `parallel/test-http-autoselectfamily.js` |
 | Host header generation ignores globalAgent.defaultPort and incorrectly includes the port | 1 | `parallel/test-http-default-port.js` |
 | Host header generation/handling in node:http is not fully Node-compatible | 1 | `parallel/test-http-host-headers.js` |

--- a/tests/node_compat/report.md
+++ b/tests/node_compat/report.md
@@ -813,6 +813,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | tls.connect() stub throws instead of constructing a TLSSocket for allowHalfOpen option checks | 2 | `parallel/test-tls-connect-allow-half-open-option.js#block_00_block_00`, `parallel/test-tls-connect-allow-half-open-option.js#block_01_block_01` |
 | uncaughtExceptionMonitor event behavior in child_process flows is incomplete | 2 | `parallel/test-process-uncaught-exception-monitor.js#block_00_block_00`, `parallel/test-process-uncaught-exception-monitor.js#block_01_block_01` |
 | vm timeout interrupt is surfaced as a wasm trap instead of ERR_SCRIPT_EXECUTION_TIMEOUT | 2 | `parallel/test-vm-timeout.js`, `sequential/test-vm-timeout-rethrow.js` |
+| wasi:http client cannot expose an early response before the request body is finished, so this bidirectional streaming fixture deadlocks | 2 | `parallel/test-http-dump-req-when-res-ends.js`, `parallel/test-http-no-read-no-dump.js` |
 | wasi:http client path does not surface HPE_UNEXPECTED_CONTENT_LENGTH parse errors | 2 | `parallel/test-http-response-multi-content-length.js#block_00_test_adding_an_extra_content_length_header_using_setheader`, `parallel/test-http-response-multi-content-length.js#block_01_test_adding_an_extra_content_length_header_using_writehead` |
 | wasi:http request body is not finalized/sent until end(), so write()-only request flow diverges from Node | 2 | `parallel/test-http-outgoing-destroyed.js#block_00_block_00`, `parallel/test-http-outgoing-destroyed.js#block_01_block_01` |
 | --disable-proto=delete semantics differ in QuickJS (__proto__ yields null) | 1 | `parallel/test-disable-proto-delete.js` |
@@ -1132,7 +1133,6 @@ Secondary full-public compatibility, including public tests that are currently e
 | invalid URL parsing errors lack Node's TypeError and ERR_INVALID_URL shape | 1 | `parallel/test-whatwg-url-custom-parsing.js` |
 | invalid repeated Transfer-Encoding handling differs from Node | 1 | `parallel/test-http-transfer-encoding-repeated-chunked.js` |
 | keep-alive free-socket lifecycle (free event + req.destroyed transitions) is not Node-compatible | 1 | `parallel/test-http-keepalive-free.js` |
-| keep-alive request sequencing with unread request bodies has non-Node lifecycle behavior | 1 | `parallel/test-http-no-read-no-dump.js` |
 | keep-alive socket timeout/reuse race handling is not Node-compatible | 1 | `parallel/test-http-keep-alive-timeout-race-condition.js` |
 | large raw pipelined request load (10k) exhausts current WASM/runtime resources | 1 | `parallel/test-http-pipeline-requests-connection-leak.js` |
 | loader hooks in this vendored file are exercised through spawned process.execPath CLI loader flags/eval, deferred to simulated Node CLI mode support | 1 | `es-module/test-esm-loader-hooks.mjs` |
@@ -1200,9 +1200,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | receiveBlockList filtering/close behavior is incomplete | 1 | `parallel/test-dgram-blocklist.js#block_02_block_02` |
 | receiveMessageOnPort() behavior and argument validation are not implemented | 1 | `parallel/test-worker-message-port-receive-message.js` |
 | req.connection.setTimeout timeout/error flow on server-side connections is incomplete | 1 | `parallel/test-http-set-timeout.js` |
-| req.destroy() on server-side IncomingMessage does not propagate Node-compatible ECONNRESET client behavior | 1 | `parallel/test-http-server-incomingmessage-destroy.js` |
 | req.setTimeout() handling for actively consumed request bodies is not Node-compatible | 1 | `parallel/test-http-server-consumed-timeout.js` |
-| request auto-dump/resume when response ends early is incomplete, causing the request/response lifecycle to hang | 1 | `parallel/test-http-dump-req-when-res-ends.js` |
 | request drain captureRejections path hangs when request is never finalized with end() under wasi:http | 1 | `parallel/test-http-outgoing-message-capture-rejection.js#block_01_block_01` |
 | request header population/normalization (for example Accept) is incomplete | 1 | `parallel/test-http.js` |
 | request/response pause-resume flow control does not complete with Node-compatible behavior | 1 | `parallel/test-http-pause.js` |
@@ -1324,6 +1322,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | wasi:http client does not surface informational 1xx responses with Node-compatible status/raw headers | 1 | `parallel/test-http-information-headers.js` |
 | wasi:http client does not surface llhttp parse errors/rawPacket for malformed raw TCP responses | 1 | `parallel/test-http-client-error-rawbytes.js` |
 | wasi:http client does not surface llhttp parser errors for malformed raw TCP responses | 1 | `parallel/test-http-client-parse-error.js` |
+| wasi:http client does not translate an incomplete response after server request destruction into the expected ECONNRESET request error | 1 | `parallel/test-http-server-incomingmessage-destroy.js` |
 | wasi:http response header filtering strips headers like Host/Proxy-Authorization, so duplicate-header expectations diverge | 1 | `parallel/test-http-response-multiheaders.js` |
 | wasi:http strips forbidden hop-by-hop headers like Connection, so automatic response headers differ | 1 | `parallel/test-http-automatic-headers.js` |
 | wasi:http strips hop-by-hop response headers, so 'Keep-Alive' is not visible to node:http clients | 1 | `parallel/test-http-keep-alive-timeout-custom.js` |

--- a/tests/runtime/node_http.rs
+++ b/tests/runtime/node_http.rs
@@ -349,3 +349,15 @@ async fn node_http_custom_connection_rejected(
     assert_eq!(result?, Some(Val::Bool(true)));
     Ok(())
 }
+
+#[test]
+async fn node_http_response_persistence(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (result, output) =
+        invoke_and_capture_output(compiled.wasm_path(), None, "http-response-persistence", &[])
+            .await;
+    println!("{output}");
+    assert_eq!(result?, Some(Val::Bool(true)));
+    Ok(())
+}

--- a/tests/runtime/node_http.rs
+++ b/tests/runtime/node_http.rs
@@ -308,6 +308,102 @@ async fn node_http_zero_keep_alive_timeout(
 }
 
 #[test]
+async fn node_http_unread_request_body_disposal(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-unread-request-body-disposal",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_server_request_destroy(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-server-request-destroy",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_partially_consumed_request_body(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-partially-consumed-request-body",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_resume_scheduled_request_body(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-resume-scheduled-request-body",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_complete_unread_request_body(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-complete-unread-request-body",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_client_response_ownership(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-client-response-ownership",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
 async fn node_http_informational_write_after_close(
     #[tagged_as("node_http")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {

--- a/tests/runtime/node_http.rs
+++ b/tests/runtime/node_http.rs
@@ -276,6 +276,38 @@ async fn node_http_close_idle_connections(
 }
 
 #[test]
+async fn node_http_idle_resource_reclamation(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-idle-resource-reclamation",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_zero_keep_alive_timeout(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-zero-keep-alive-timeout",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
 async fn node_http_informational_write_after_close(
     #[tagged_as("node_http")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
- resolves https://linear.app/golem-cloud/issue/GOL-396
- resolves https://linear.app/golem-cloud/issue/GOL-397
- resolves https://linear.app/golem-cloud/issue/GOL-401
- finalizes one cached response-persistence decision while constructing headers and consumes it from socket finalization
- aligns automatic and explicit keep-alive ownership, idle reclamation, framing close, `maxRequestsPerSocket`, and `server.close()` behavior with Node.js 22.14
- unifies `IncomingMessage` initialization and automatically drains request or client-response bodies only when no listener owns them
- covers unread, partially consumed, resumed, completed, destroyed, delayed-owned, zero-timeout, and pipelined response lifecycles
- retains the explicit HTTP/1.0 transfer-encoding gap and keeps GOL-405 separate

### Node compatibility

- enables `test-http-chunked-304.js`, `test-http-remove-header-stays-removed.js`, and `test-http-wget.js`
- primary CI-enforced: `3174/4387` → `3177/4387`
- full public: `3174/5750` → `3177/5750`
- regenerates the compatibility inventory; vendored fixtures were unavailable in this checkout, so the checked-in classifications were not represented as locally re-executed evidence

Nine focused GOL-396/397/401 cases pass in both P2 and P3, along with inherited P3 stream-lifecycle checks, at exact combined SHA `07b58cc79bb6dceee6e848cf517f69f03780f68e`.
