### PR TITLE
GOL-401 Unify IncomingMessage body ownership

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/builtin/mod.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/mod.rs
@@ -233,6 +233,7 @@ pub fn add_module_resolvers(
         .with_module("node:inspector")
         .with_module("inspector")
         .with_module("__wasm_rquickjs_builtin/node_http_native")
+        .with_module("__wasm_rquickjs_builtin/node_http_incoming")
         .with_module("__wasm_rquickjs_builtin/node_http_server")
         .with_module("node:_http_common")
         .with_module("_http_common")
@@ -487,6 +488,10 @@ pub fn module_loader() -> (
         .with_module("dns/promises", dns::REEXPORT_PROMISES_JS)
         .with_module("node:domain", domain::DOMAIN_JS)
         .with_module("domain", domain::REEXPORT_JS)
+        .with_module(
+            "__wasm_rquickjs_builtin/node_http_incoming",
+            node_http::HTTP_INCOMING_JS,
+        )
         .with_module(
             "__wasm_rquickjs_builtin/node_http_server",
             node_http::NODE_HTTP_SERVER_JS,

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http.js
@@ -3,6 +3,7 @@ import { NodeHttpClientRequest } from '__wasm_rquickjs_builtin/node_http_native'
 import { EventEmitter } from 'node:events';
 import { Buffer } from 'node:buffer';
 import Readable from '__wasm_rquickjs_builtin/internal/streams/readable';
+import { initializeIncomingMessage } from '__wasm_rquickjs_builtin/node_http_incoming';
 
 import { channel } from 'node:diagnostics_channel';
 import { kOutHeaders } from '__wasm_rquickjs_builtin/internal/http';
@@ -798,18 +799,9 @@ export function IncomingMessage(nativeRes, options) {
         this.httpVersionMajor = null;
         this.httpVersionMinor = null;
     }
-    this.complete = false;
+    initializeIncomingMessage(this, hasNativeResponse ? null : nativeRes);
     this.method = hasNativeResponse ? undefined : null;
     this.url = hasNativeResponse ? undefined : '';
-    this.socket = hasNativeResponse ? null : nativeRes;
-    this.client = this.socket;
-    this.trailers = {};
-    this.trailersDistinct = {};
-    this.rawTrailers = [];
-    this.aborted = false;
-    this._consuming = false;
-    this._dumped = false;
-    this._timeout = null;
 
     const joinDup = !!(options && options.joinDuplicateHeaders);
     const parsedHeaders = parseIncomingHeaders(
@@ -835,6 +827,13 @@ IncomingMessage.prototype.setTimeout = function setTimeout(ms, callback) {
     this._timeout = ms;
     if (callback) this.once('timeout', callback);
     return this;
+};
+
+IncomingMessage.prototype._dump = function _dump() {
+    if (this._dumped) return;
+    this._dumped = true;
+    this.removeAllListeners('data');
+    this.resume();
 };
 
 IncomingMessage.prototype._read = function _read(n) {
@@ -2150,7 +2149,7 @@ export class ClientRequest extends OutgoingMessage {
                 }
                 this._response = res;
                 res.req = this;
-                this.emit('response', res);
+                const responseHandled = this.emit('response', res);
 
                 if (this.aborted || this.destroyed) {
                     if (res._nativeRes && typeof res._nativeRes.discardBody === 'function') {
@@ -2159,16 +2158,8 @@ export class ClientRequest extends OutgoingMessage {
                     return;
                 }
 
-                const hasDataListeners = res.listenerCount('data') > 0;
-                const hasEndListeners = res.listenerCount('end') > 0;
-                const hasReadableListeners = res.listenerCount('readable') > 0;
-
-                if (hasDataListeners || hasEndListeners) {
-                    res.resume();
-                } else if (hasReadableListeners) {
-                    res.read(0);
-                } else {
-                    res.resume();
+                if (!responseHandled) {
+                    res._dump();
                 }
             }
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http.rs
@@ -776,6 +776,7 @@ async fn write_all_to_stream<'js>(
 
 pub const NODE_HTTP_JS: &str = include_str!("node_http.js");
 pub const NODE_HTTP_SERVER_JS: &str = include_str!("node_http_server.js");
+pub const HTTP_INCOMING_JS: &str = include_str!("node_http_incoming.js");
 pub const HTTP_COMMON_JS: &str = include_str!("node_http_common.js");
 pub const HTTP_AGENT_JS: &str = include_str!("node_http_agent.js");
 pub const REEXPORT_JS: &str = r#"export * from 'node:http'; export { default } from 'node:http';"#;

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_disabled.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_disabled.rs
@@ -3,6 +3,7 @@ pub mod native_module {}
 
 pub const NODE_HTTP_JS: &str = include_str!("node_http_disabled.js");
 pub const HTTP_COMMON_JS: &str = include_str!("node_http_common.js");
+pub const HTTP_INCOMING_JS: &str = include_str!("node_http_incoming.js");
 pub const REEXPORT_JS: &str = r#"export * from 'node:http'; export { default } from 'node:http';"#;
 
 pub const NODE_HTTP_SERVER_JS: &str = r#"

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_incoming.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_incoming.js
@@ -1,0 +1,13 @@
+export function initializeIncomingMessage(message, socket) {
+    message.complete = false;
+    message.socket = socket;
+    message.connection = socket;
+    message.client = socket;
+    message.trailers = {};
+    message.trailersDistinct = {};
+    message.rawTrailers = [];
+    message.aborted = false;
+    message._consuming = false;
+    message._dumped = false;
+    message._timeout = null;
+}

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_p3.rs
@@ -721,6 +721,7 @@ fn fields_to_pairs(fields: &Fields) -> Vec<Vec<String>> {
 
 pub const NODE_HTTP_JS: &str = include_str!("node_http.js");
 pub const NODE_HTTP_SERVER_JS: &str = include_str!("node_http_server.js");
+pub const HTTP_INCOMING_JS: &str = include_str!("node_http_incoming.js");
 pub const HTTP_COMMON_JS: &str = include_str!("node_http_common.js");
 pub const HTTP_AGENT_JS: &str = include_str!("node_http_agent.js");
 pub const REEXPORT_JS: &str = r#"export * from 'node:http'; export { default } from 'node:http';"#;

--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http_server.js
@@ -3,6 +3,7 @@ import { Server as NetServer } from 'node:net';
 import { EventEmitter } from 'node:events';
 import { Buffer } from 'node:buffer';
 import Readable from '__wasm_rquickjs_builtin/internal/streams/readable';
+import { initializeIncomingMessage } from '__wasm_rquickjs_builtin/node_http_incoming';
 import { ERR_HTTP_BODY_NOT_ALLOWED, ERR_HTTP_CONTENT_LENGTH_MISMATCH, ERR_HTTP_HEADERS_SENT, ERR_HTTP_SOCKET_ASSIGNED, ERR_INVALID_ARG_TYPE, ERR_INVALID_ARG_VALUE, ERR_STREAM_NULL_VALUES, ERR_STREAM_WRITE_AFTER_END } from '__wasm_rquickjs_builtin/internal/errors';
 // STATUS_CODES is duplicated here to avoid circular dependency with node:http
 const STATUS_CODES = {
@@ -121,8 +122,7 @@ function ServerIncomingMessage(socket, method, url, httpVersion, rawHeaderPairs,
 
     Readable.call(this, {});
 
-    this.socket = socket;
-    this.connection = socket;
+    initializeIncomingMessage(this, socket);
     this.method = method;
     this.url = url;
     this.httpVersion = httpVersion;
@@ -136,28 +136,42 @@ function ServerIncomingMessage(socket, method, url, httpVersion, rawHeaderPairs,
     this.headersDistinct = parsed.headersDistinct;
     this.rawHeaders = parsed.rawHeaders;
 
-    this.complete = false;
-    this.aborted = false;
-    this.trailers = {};
-    this.trailersDistinct = {};
-    this.rawTrailers = [];
-    this.client = socket;
-    this._consuming = false;
-    this._dumped = false;
-    this._timeout = null;
 }
 
 Object.setPrototypeOf(ServerIncomingMessage.prototype, Readable.prototype);
 Object.setPrototypeOf(ServerIncomingMessage, Readable);
 
 ServerIncomingMessage.prototype._read = function _read() {
-    // no-op: parser pushes data via this.push()
+    this._consuming = true;
 };
 
-ServerIncomingMessage.prototype.setTimeout = function setTimeout(ms, cb) {
-    this._timeout = ms;
-    if (cb) this.once('timeout', cb);
-    return this;
+ServerIncomingMessage.prototype._destroy = function _destroy(_err, cb) {
+    const aborted = !this.readableEnded || !this.complete;
+    let destroyFinished = false;
+    const finishDestroy = () => {
+        if (destroyFinished) return;
+        destroyFinished = true;
+        process.nextTick(() => {
+            cb(_err && this.listenerCount('error') > 0 ? _err : null);
+        });
+    };
+    if (aborted) {
+        this.aborted = true;
+        this.emit('aborted');
+    }
+    if (aborted && this.socket && !this.socket.destroyed) {
+        const socket = this.socket;
+        const onSocketFinished = () => {
+            socket.removeListener('error', onSocketFinished);
+            socket.removeListener('close', onSocketFinished);
+            finishDestroy();
+        };
+        socket.once('error', onSocketFinished);
+        socket.once('close', onSocketFinished);
+        this.socket.destroy(_err || undefined);
+        return;
+    }
+    finishDestroy();
 };
 
 // ===== Status code validation =====
@@ -1441,6 +1455,12 @@ function createConnectionParser(server, socket) {
                             !isDroppedRequest &&
                             !res._last &&
                             !server._closeRequested;
+                        const resumeScheduled = req._readableState &&
+                            req._readableState.resumeScheduled;
+                        if (!req._consuming && !resumeScheduled &&
+                            typeof req._dump === 'function') {
+                            req._dump();
+                        }
                         maybeFinalizeResponse(context);
                     });
 

--- a/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/builtin_p3.rs
@@ -294,6 +294,7 @@ pub fn add_module_resolvers(
         .with_module("node:inspector")
         .with_module("inspector")
         .with_module("__wasm_rquickjs_builtin/node_http_native")
+        .with_module("__wasm_rquickjs_builtin/node_http_incoming")
         .with_module("__wasm_rquickjs_builtin/node_http_server")
         .with_module("node:_http_common")
         .with_module("_http_common")
@@ -556,6 +557,10 @@ pub fn module_loader() -> (
         .with_module("dns/promises", dns::REEXPORT_PROMISES_JS)
         .with_module("node:domain", domain::DOMAIN_JS)
         .with_module("domain", domain::REEXPORT_JS)
+        .with_module(
+            "__wasm_rquickjs_builtin/node_http_incoming",
+            node_http::HTTP_INCOMING_JS,
+        )
         .with_module(
             "__wasm_rquickjs_builtin/node_http_server",
             node_http::NODE_HTTP_SERVER_JS,

--- a/examples/runtime/node-http/src/node-http.js
+++ b/examples/runtime/node-http/src/node-http.js
@@ -1015,6 +1015,587 @@ export async function httpZeroKeepAliveTimeout() {
     });
 }
 
+export async function httpUnreadRequestBodyDisposal() {
+    const runCycle = () => new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let resumed = false;
+        let listenerRemoved = false;
+        let dumpedBody = '';
+        let sentBodyAndNextRequest = false;
+        const requestBody = 'unread-body!';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/early') {
+                const ignoredDataListener = () => {};
+                req.pause();
+                req.on('data', ignoredDataListener);
+                req.on('resume', () => {
+                    resumed = true;
+                    listenerRemoved = req.listenerCount('data') === 0;
+                    req.on('data', (chunk) => {
+                        dumpedBody += chunk.toString();
+                    });
+                });
+                res.end('early');
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /early HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(requestBody)}\r\n\r\n`
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentBodyAndNextRequest && wire.includes('early')) {
+                    sentBodyAndNextRequest = true;
+                    socket.write(
+                        requestBody +
+                        'GET /next HTTP/1.1\r\n' +
+                        'Host: localhost\r\n' +
+                        'Connection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    resumed &&
+                    listenerRemoved &&
+                    dumpedBody === requestBody &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+        if (!await runCycle()) return false;
+    }
+    return true;
+}
+
+export async function httpServerRequestDestroy() {
+    const runIncomplete = (
+        withError,
+        listenForError = withError,
+        attachErrorListenerAfterDestroy = false,
+        attachErrorListenerOnNextTick = false
+    ) => new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let events = [];
+        let erroredMatches = false;
+        let socketErrorMatches = !withError;
+        let socketClosed = false;
+        const expectedError = new Error('destroy incomplete request');
+        const server = http.createServer((req, _res) => {
+            req.socket.on('error', (error) => {
+                socketErrorMatches = error === expectedError;
+                events.push('socket-error');
+            });
+            req.socket.on('close', () => {
+                socketClosed = true;
+                events.push('socket-close');
+            });
+            req.on('aborted', () => events.push('aborted'));
+            const onRequestError = (error) => {
+                erroredMatches = error === expectedError;
+                events.push(attachErrorListenerOnNextTick ?
+                    'nexttick-error' :
+                    attachErrorListenerAfterDestroy ? 'late-error' : 'error');
+            };
+            if (listenForError && !attachErrorListenerAfterDestroy) {
+                req.on('error', onRequestError);
+            }
+            req.on('close', () => {
+                events.push('close');
+            });
+            req.destroy(withError ? expectedError : undefined);
+            if (listenForError && attachErrorListenerAfterDestroy) {
+                if (attachErrorListenerOnNextTick) {
+                    process.nextTick(() => req.on('error', onRequestError));
+                } else {
+                    req.on('error', onRequestError);
+                }
+            }
+            if (!listenForError) {
+                erroredMatches = withError ?
+                    req.errored === expectedError : req.errored === null;
+            }
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 2000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /incomplete HTTP/1.1\r\n' +
+                    'Host: localhost\r\nContent-Length: 5\r\n\r\n'
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+            });
+            socket.on('close', () => {
+                setImmediate(() => {
+                    server.getConnections((error, count) => {
+                        const errorEvent = attachErrorListenerOnNextTick ?
+                            'nexttick-error' :
+                            attachErrorListenerAfterDestroy ? 'late-error' : 'error';
+                        const terminalEvents = withError ?
+                            events.filter((event) => event !== 'socket-close') : events;
+                        const expectedEvents = withError ?
+                            listenForError ?
+                                `aborted,socket-error,${errorEvent},close` :
+                                'aborted,socket-error,close' :
+                            'aborted,socket-close,close';
+                        finish(
+                            !error &&
+                            count === 0 &&
+                            wire === '' &&
+                            erroredMatches &&
+                            socketErrorMatches &&
+                            socketClosed &&
+                            terminalEvents.join(',') === expectedEvents
+                        );
+                    });
+                });
+            });
+            socket.on('error', () => {});
+        });
+    });
+
+    const runCompletedError = () => new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let connections = 0;
+        let completeAtDestroy = false;
+        let errorObserved = false;
+        let requestClosed = false;
+        let requestAborted = false;
+        let sentSecond = false;
+        const expectedError = new Error('destroy completed request');
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/first') {
+                req.on('aborted', () => {
+                    requestAborted = true;
+                });
+                req.on('error', (error) => {
+                    errorObserved = error === expectedError;
+                });
+                req.on('close', () => {
+                    requestClosed = true;
+                });
+                req.on('end', () => {
+                    completeAtDestroy = req.complete && req.readableEnded;
+                    req.destroy(expectedError);
+                    res.end('first');
+                });
+                req.resume();
+                return;
+            }
+            res.end('second');
+        });
+        server.on('connection', () => {
+            connections++;
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write('GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n');
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentSecond && wire.includes('first')) {
+                    sentSecond = true;
+                    socket.write(
+                        'GET /second HTTP/1.1\r\n' +
+                        'Host: localhost\r\nConnection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const firstBody = wire.indexOf('first', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', firstBody);
+                const secondBody = wire.indexOf('second', secondStatus);
+                finish(
+                    handled === 2 &&
+                    connections === 1 &&
+                    completeAtDestroy &&
+                    errorObserved &&
+                    requestClosed &&
+                    !requestAborted &&
+                    firstStatus !== -1 &&
+                    firstBody > firstStatus &&
+                    secondStatus > firstBody &&
+                    secondBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+
+    return await runIncomplete(true) &&
+        await runIncomplete(true, true, true) &&
+        await runIncomplete(true, true, true, true) &&
+        await runIncomplete(true, false) &&
+        await runIncomplete(false) &&
+        await runCompletedError();
+}
+
+export async function httpPartiallyConsumedRequestBody() {
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let partialRequest;
+        let firstChunk = '';
+        let unexpectedResume = false;
+        let sentRemainderAndNext = false;
+        const firstPart = 'part-';
+        const remainder = 'body!';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/partial') {
+                partialRequest = req;
+                req.once('data', (chunk) => {
+                    firstChunk = chunk.toString();
+                    req.pause();
+                    req.on('resume', () => {
+                        unexpectedResume = true;
+                    });
+                    res.end('early');
+                });
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /partial HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(firstPart + remainder)}\r\n\r\n` +
+                    firstPart
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentRemainderAndNext && wire.includes('early')) {
+                    sentRemainderAndNext = true;
+                    socket.write(
+                        remainder +
+                        'GET /next HTTP/1.1\r\n' +
+                        'Host: localhost\r\n' +
+                        'Connection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    firstChunk === firstPart &&
+                    partialRequest.complete &&
+                    !unexpectedResume &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+}
+
+export async function httpResumeScheduledRequestBody() {
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let listenerPreserved = false;
+        let receivedBody = '';
+        let sentBodyAndNextRequest = false;
+        const requestBody = 'scheduled-body';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/scheduled') {
+                req.on('data', (chunk) => {
+                    receivedBody += chunk.toString();
+                });
+                req.resume();
+                res.end('early');
+                listenerPreserved = req.listenerCount('data') === 1;
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /scheduled HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(requestBody)}\r\n\r\n`
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+                if (!sentBodyAndNextRequest && wire.includes('early')) {
+                    sentBodyAndNextRequest = true;
+                    socket.write(
+                        requestBody +
+                        'GET /next HTTP/1.1\r\n' +
+                        'Host: localhost\r\n' +
+                        'Connection: close\r\n\r\n'
+                    );
+                }
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    listenerPreserved &&
+                    receivedBody === requestBody &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+}
+
+export async function httpCompleteUnreadRequestBody() {
+    return new Promise((resolve) => {
+        let settled = false;
+        let socket;
+        let wire = '';
+        let handled = 0;
+        let completeBeforeResponse = false;
+        let resumed = false;
+        let listenerRemoved = false;
+        let dumpedBody = '';
+        const requestBody = 'buffered-body';
+        const server = http.createServer((req, res) => {
+            handled++;
+            if (req.url === '/buffered') {
+                req.pause();
+                req.on('data', () => {});
+                req.on('resume', () => {
+                    resumed = true;
+                    listenerRemoved = req.listenerCount('data') === 0;
+                    req.on('data', (chunk) => {
+                        dumpedBody += chunk.toString();
+                    });
+                });
+                setImmediate(() => {
+                    completeBeforeResponse = req.complete;
+                    res.end('early');
+                });
+                return;
+            }
+            res.end('next');
+        });
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (socket) socket.destroy();
+            server.closeAllConnections();
+            server.close(() => resolve(result));
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+
+        server.listen(0, () => {
+            socket = net.connect({ port: server.address().port });
+            socket.on('connect', () => {
+                socket.write(
+                    'POST /buffered HTTP/1.1\r\n' +
+                    'Host: localhost\r\n' +
+                    `Content-Length: ${Buffer.byteLength(requestBody)}\r\n\r\n` +
+                    requestBody +
+                    'GET /next HTTP/1.1\r\n' +
+                    'Host: localhost\r\nConnection: close\r\n\r\n'
+                );
+            });
+            socket.on('data', (chunk) => {
+                wire += chunk.toString('latin1');
+            });
+            socket.on('end', () => {
+                const firstStatus = wire.indexOf('HTTP/1.1 200');
+                const earlyBody = wire.indexOf('early', firstStatus);
+                const secondStatus = wire.indexOf('HTTP/1.1 200', earlyBody);
+                const nextBody = wire.indexOf('next', secondStatus);
+                finish(
+                    handled === 2 &&
+                    completeBeforeResponse &&
+                    resumed &&
+                    listenerRemoved &&
+                    dumpedBody === requestBody &&
+                    firstStatus !== -1 &&
+                    earlyBody > firstStatus &&
+                    secondStatus > earlyBody &&
+                    nextBody > secondStatus
+                );
+            });
+            socket.on('error', () => finish(false));
+        });
+    });
+}
+
+export async function httpClientResponseOwnership() {
+    const server = http.createServer((_req, res) => {
+        res.end('response-body');
+    });
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const unownedDisposed = await new Promise((resolve) => {
+        let settled = false;
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            resolve(result);
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+        const req = http.request({ port, path: '/unowned' });
+        req.on('error', () => finish(false));
+        req.on('close', () => {
+            const response = req._response;
+            const checkComplete = (attempts) => {
+                if (response && response.complete) {
+                    finish(response._dumped === true);
+                } else if (attempts > 0) {
+                    setTimeout(() => checkComplete(attempts - 1), 10);
+                } else {
+                    finish(false);
+                }
+            };
+            checkComplete(50);
+        });
+        req.end();
+    });
+
+    const ownedDelayed = await new Promise((resolve) => {
+        let settled = false;
+        let body = '';
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            resolve(result);
+        };
+        const timeout = setTimeout(() => finish(false), 3000);
+        const req = http.request({ port, path: '/owned' }, (res) => {
+            const untouched = res._dumped === false && res.readableFlowing === null;
+            setTimeout(() => {
+                res.on('data', (chunk) => {
+                    body += chunk.toString();
+                });
+                res.on('end', () => {
+                    finish(untouched && body === 'response-body');
+                });
+            }, 25);
+        });
+        req.on('error', () => finish(false));
+        req.end();
+    });
+
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+    return unownedDisposed && ownedDelayed;
+}
+
 export async function httpInformationalWriteAfterClose() {
     return new Promise((resolve) => {
         let settled = false;

--- a/examples/runtime/node-http/wit/node-http.wit
+++ b/examples/runtime/node-http/wit/node-http.wit
@@ -17,6 +17,12 @@ world node-http {
   export http-close-idle-connections: func() -> bool;
   export http-idle-resource-reclamation: func() -> bool;
   export http-zero-keep-alive-timeout: func() -> bool;
+  export http-unread-request-body-disposal: func() -> bool;
+  export http-server-request-destroy: func() -> bool;
+  export http-partially-consumed-request-body: func() -> bool;
+  export http-resume-scheduled-request-body: func() -> bool;
+  export http-complete-unread-request-body: func() -> bool;
+  export http-client-response-ownership: func() -> bool;
   export http-informational-write-after-close: func() -> bool;
   export http-max-requests-closes-socket: func() -> bool;
   export net-writev-boundaries: func() -> bool;

--- a/tests/goldenfiles/generated_types_node-http_exports.d.ts
+++ b/tests/goldenfiles/generated_types_node-http_exports.d.ts
@@ -15,6 +15,12 @@ declare module 'node-http' {
   export function httpCloseIdleConnections(): Promise<boolean>;
   export function httpIdleResourceReclamation(): Promise<boolean>;
   export function httpZeroKeepAliveTimeout(): Promise<boolean>;
+  export function httpUnreadRequestBodyDisposal(): Promise<boolean>;
+  export function httpServerRequestDestroy(): Promise<boolean>;
+  export function httpPartiallyConsumedRequestBody(): Promise<boolean>;
+  export function httpResumeScheduledRequestBody(): Promise<boolean>;
+  export function httpCompleteUnreadRequestBody(): Promise<boolean>;
+  export function httpClientResponseOwnership(): Promise<boolean>;
   export function httpInformationalWriteAfterClose(): Promise<boolean>;
   export function httpMaxRequestsClosesSocket(): Promise<boolean>;
   export function netWritevBoundaries(): Promise<boolean>;

--- a/tests/node_compat/config.jsonc
+++ b/tests/node_compat/config.jsonc
@@ -4471,7 +4471,7 @@
         }
       }
     },
-    "parallel/test-http-dump-req-when-res-ends.js": { "category": "known-gap", "reason": "request auto-dump/resume when response ends early is incomplete, causing the request/response lifecycle to hang" },
+    "parallel/test-http-dump-req-when-res-ends.js": { "category": "known-gap", "reason": "wasi:http client cannot expose an early response before the request body is finished, so this bidirectional streaming fixture deadlocks" },
     "parallel/test-http-early-hints-invalid-argument.js": { "category": "known-gap", "reason": "ServerResponse.writeEarlyHints() argument validation is incomplete (missing expected ERR_INVALID_ARG_VALUE throws)" },
     "parallel/test-http-early-hints.js": {
       "split": true,
@@ -4568,7 +4568,7 @@
     },
     "parallel/test-http-multiple-headers.js": { "category": "known-gap", "reason": "rawHeaders/rawTrailers duplicate-header ordering and casing are not Node-compatible" },
     "parallel/test-http-mutable-headers.js": { "category": "known-gap", "reason": "OutgoingMessage.getHeaders() shape is not Node-compatible (null-prototype object expected)" },
-    "parallel/test-http-no-read-no-dump.js": { "category": "known-gap", "reason": "keep-alive request sequencing with unread request bodies has non-Node lifecycle behavior" },
+    "parallel/test-http-no-read-no-dump.js": { "category": "known-gap", "reason": "wasi:http client cannot expose an early response before the request body is finished, so this bidirectional streaming fixture deadlocks" },
     "parallel/test-http-nodelay.js": { "category": "known-gap", "reason": "node:http client path does not honor/verify net.Socket connect noDelay semantics like Node" },
     "parallel/test-http-outgoing-destroyed.js": {
       "split": true,
@@ -4696,7 +4696,7 @@
     "parallel/test-http-server-headers-timeout-interrupted-headers.js": { "category": "known-gap", "reason": "server.headersTimeout 408 behavior for interrupted header lines is incomplete" },
     "parallel/test-http-server-headers-timeout-keepalive.js": { "category": "known-gap", "reason": "server.headersTimeout handling across keep-alive requests is not Node-compatible" },
     "parallel/test-http-server-headers-timeout-pipelining.js": { "category": "known-gap", "reason": "server.headersTimeout handling for pipelined requests is not Node-compatible" },
-    "parallel/test-http-server-incomingmessage-destroy.js": { "category": "known-gap", "reason": "req.destroy() on server-side IncomingMessage does not propagate Node-compatible ECONNRESET client behavior" },
+    "parallel/test-http-server-incomingmessage-destroy.js": { "category": "known-gap", "reason": "wasi:http client does not translate an incomplete response after server request destruction into the expected ECONNRESET request error" },
     "parallel/test-http-server-keep-alive-defaults.js": {},
     "parallel/test-http-server-keep-alive-max-requests-null.js": {},
     "parallel/test-http-server-keepalive-end.js": { "category": "node-internals", "reason": "asserts private req.socket.parser.incoming lifecycle after keep-alive request end" },

--- a/tests/node_compat/report.md
+++ b/tests/node_compat/report.md
@@ -813,6 +813,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | tls.connect() stub throws instead of constructing a TLSSocket for allowHalfOpen option checks | 2 | `parallel/test-tls-connect-allow-half-open-option.js#block_00_block_00`, `parallel/test-tls-connect-allow-half-open-option.js#block_01_block_01` |
 | uncaughtExceptionMonitor event behavior in child_process flows is incomplete | 2 | `parallel/test-process-uncaught-exception-monitor.js#block_00_block_00`, `parallel/test-process-uncaught-exception-monitor.js#block_01_block_01` |
 | vm timeout interrupt is surfaced as a wasm trap instead of ERR_SCRIPT_EXECUTION_TIMEOUT | 2 | `parallel/test-vm-timeout.js`, `sequential/test-vm-timeout-rethrow.js` |
+| wasi:http client cannot expose an early response before the request body is finished, so this bidirectional streaming fixture deadlocks | 2 | `parallel/test-http-dump-req-when-res-ends.js`, `parallel/test-http-no-read-no-dump.js` |
 | wasi:http client path does not surface HPE_UNEXPECTED_CONTENT_LENGTH parse errors | 2 | `parallel/test-http-response-multi-content-length.js#block_00_test_adding_an_extra_content_length_header_using_setheader`, `parallel/test-http-response-multi-content-length.js#block_01_test_adding_an_extra_content_length_header_using_writehead` |
 | wasi:http request body is not finalized/sent until end(), so write()-only request flow diverges from Node | 2 | `parallel/test-http-outgoing-destroyed.js#block_00_block_00`, `parallel/test-http-outgoing-destroyed.js#block_01_block_01` |
 | --disable-proto=delete semantics differ in QuickJS (__proto__ yields null) | 1 | `parallel/test-disable-proto-delete.js` |
@@ -1132,7 +1133,6 @@ Secondary full-public compatibility, including public tests that are currently e
 | invalid URL parsing errors lack Node's TypeError and ERR_INVALID_URL shape | 1 | `parallel/test-whatwg-url-custom-parsing.js` |
 | invalid repeated Transfer-Encoding handling differs from Node | 1 | `parallel/test-http-transfer-encoding-repeated-chunked.js` |
 | keep-alive free-socket lifecycle (free event + req.destroyed transitions) is not Node-compatible | 1 | `parallel/test-http-keepalive-free.js` |
-| keep-alive request sequencing with unread request bodies has non-Node lifecycle behavior | 1 | `parallel/test-http-no-read-no-dump.js` |
 | keep-alive socket timeout/reuse race handling is not Node-compatible | 1 | `parallel/test-http-keep-alive-timeout-race-condition.js` |
 | large raw pipelined request load (10k) exhausts current WASM/runtime resources | 1 | `parallel/test-http-pipeline-requests-connection-leak.js` |
 | loader hooks in this vendored file are exercised through spawned process.execPath CLI loader flags/eval, deferred to simulated Node CLI mode support | 1 | `es-module/test-esm-loader-hooks.mjs` |
@@ -1200,9 +1200,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | receiveBlockList filtering/close behavior is incomplete | 1 | `parallel/test-dgram-blocklist.js#block_02_block_02` |
 | receiveMessageOnPort() behavior and argument validation are not implemented | 1 | `parallel/test-worker-message-port-receive-message.js` |
 | req.connection.setTimeout timeout/error flow on server-side connections is incomplete | 1 | `parallel/test-http-set-timeout.js` |
-| req.destroy() on server-side IncomingMessage does not propagate Node-compatible ECONNRESET client behavior | 1 | `parallel/test-http-server-incomingmessage-destroy.js` |
 | req.setTimeout() handling for actively consumed request bodies is not Node-compatible | 1 | `parallel/test-http-server-consumed-timeout.js` |
-| request auto-dump/resume when response ends early is incomplete, causing the request/response lifecycle to hang | 1 | `parallel/test-http-dump-req-when-res-ends.js` |
 | request drain captureRejections path hangs when request is never finalized with end() under wasi:http | 1 | `parallel/test-http-outgoing-message-capture-rejection.js#block_01_block_01` |
 | request header population/normalization (for example Accept) is incomplete | 1 | `parallel/test-http.js` |
 | request/response pause-resume flow control does not complete with Node-compatible behavior | 1 | `parallel/test-http-pause.js` |
@@ -1324,6 +1322,7 @@ Secondary full-public compatibility, including public tests that are currently e
 | wasi:http client does not surface informational 1xx responses with Node-compatible status/raw headers | 1 | `parallel/test-http-information-headers.js` |
 | wasi:http client does not surface llhttp parse errors/rawPacket for malformed raw TCP responses | 1 | `parallel/test-http-client-error-rawbytes.js` |
 | wasi:http client does not surface llhttp parser errors for malformed raw TCP responses | 1 | `parallel/test-http-client-parse-error.js` |
+| wasi:http client does not translate an incomplete response after server request destruction into the expected ECONNRESET request error | 1 | `parallel/test-http-server-incomingmessage-destroy.js` |
 | wasi:http response header filtering strips headers like Host/Proxy-Authorization, so duplicate-header expectations diverge | 1 | `parallel/test-http-response-multiheaders.js` |
 | wasi:http strips forbidden hop-by-hop headers like Connection, so automatic response headers differ | 1 | `parallel/test-http-automatic-headers.js` |
 | wasi:http strips hop-by-hop response headers, so 'Keep-Alive' is not visible to node:http clients | 1 | `parallel/test-http-keep-alive-timeout-custom.js` |

--- a/tests/runtime/node_http.rs
+++ b/tests/runtime/node_http.rs
@@ -308,6 +308,102 @@ async fn node_http_zero_keep_alive_timeout(
 }
 
 #[test]
+async fn node_http_unread_request_body_disposal(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-unread-request-body-disposal",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_server_request_destroy(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-server-request-destroy",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_partially_consumed_request_body(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-partially-consumed-request-body",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_resume_scheduled_request_body(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-resume-scheduled-request-body",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_complete_unread_request_body(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-complete-unread-request-body",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
+async fn node_http_client_response_ownership(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (r, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-client-response-ownership",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(r?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
 async fn node_http_informational_write_after_close(
     #[tagged_as("node_http")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

- centralize shared `IncomingMessage` lifecycle state for HTTP client and server paths
- drain only unowned request/response bodies while preserving explicit, delayed, partial, and scheduled consumption
- align request destruction with Node's aborted/error/close behavior, including late error listeners and completed-request keep-alive reuse

## Validation

- P2 and P3 nine-case HTTP ownership/lifecycle matrices
- P2 and P3 focused six-variant request-destroy matrices
- Node compatibility inventory/report validation against the pinned Node.js 22.14.0 suite
- DTS golden generation and verification
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -Dwarnings`
- `cargo fmt -- --check`
- JavaScript syntax checks plus AI dev-tools Prettier, ESLint, and TypeScript checks
- three read-only exact-SHA reviews passed for the implementation at `c09c2e536ca04a0d4c463a0240db9b0c84a996ff`
- the disabled-feature registration correction and focused `all-golem-imports_lite` regression passed three delta reviews at `7c40b4fe6c7e4e336e4e4e0029465631253c78f6`

## Notes

- Stacked on #140 (`gol-397-http-idle-resource-reclamation`).
- Three upstream Node HTTP cases remain deferred for existing `wasi:http` limitations: early-response bidirectional deadlock and incomplete-response error mapping.
- Skeleton-wide strict Clippy still has the inherited `module_loading.rs` warning baseline handled separately by #131 / GOL-421; the root all-target strict Clippy gate is green.
