### PR TITLE
Fix P3 stream cleanup on payload failures

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/internal/p3.rs
+++ b/crates/wasm-rquickjs/skeleton/src/internal/p3.rs
@@ -10,8 +10,8 @@ use futures::future::{AbortHandle, Abortable};
 use rquickjs::function::{Args, Constructor, IntoArgs, This};
 use rquickjs::promise::Promised;
 use rquickjs::{
-    AsyncContext, AsyncRuntime, CatchResultExt, CaughtError, Ctx, Error, Filter, FromJs, Function,
-    IntoJs, Module, Object, Persistent, Promise, String as JsString, Value, async_with,
+    AsyncContext, AsyncRuntime, CatchResultExt, CaughtError, Ctx, Error, Exception, Filter, FromJs,
+    Function, IntoJs, Module, Object, Persistent, Promise, String as JsString, Value, async_with,
 };
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -147,18 +147,27 @@ impl JsState {
                     }
                     if (iterable != null && typeof iterable[Symbol.iterator] === 'function') {
                         const it = iterable[Symbol.iterator]();
+                        const continueFromSync = async function (result) {
+                            if (result == null || typeof result !== 'object') {
+                                throw new TypeError('stream sync iterator method did not return an object');
+                            }
+                            return {
+                                done: Boolean(result.done),
+                                value: await result.value,
+                            };
+                        };
                         return {
-                            next() { return Promise.resolve(it.next()); },
-                            async return(value) {
+                            next() { return continueFromSync(it.next()); },
+                            return(value) {
                                 return typeof it.return === 'function'
-                                    ? it.return(value)
-                                    : { done: true, value };
+                                    ? continueFromSync(it.return(value))
+                                    : Promise.resolve({ done: true, value });
                             },
-                            async throw(reason) {
+                            throw(reason) {
                                 if (typeof it.throw === 'function') {
-                                    return it.throw(reason);
+                                    return continueFromSync(it.throw(reason));
                                 }
-                                throw reason;
+                                return Promise.reject(reason);
                             },
                         };
                     }
@@ -191,7 +200,21 @@ impl JsState {
                         }
                         // A sync iterable normalized into an async iterator can still yield
                         // promise-valued items; `for await` awaits each value, so do the same.
-                        const keepGoing = await writeOne(await result.value);
+                        let keepGoing;
+                        try {
+                            keepGoing = await writeOne(await result.value);
+                        } catch (error) {
+                            // This is an abrupt failure while consuming an item, so mirror
+                            // AsyncIteratorClose. Keep the payload/write error primary if cleanup
+                            // also rejects. A rejection from next() itself is outside this block
+                            // and must not call return().
+                            try {
+                                await globalThis.__wasm_rquickjs_close_async_iterator(iterator);
+                            } catch (_cleanupError) {
+                                // Preserve the primary consumption failure.
+                            }
+                            throw error;
+                        }
                         if (!keepGoing) {
                             await globalThis.__wasm_rquickjs_close_async_iterator(iterator);
                             return;
@@ -1512,7 +1535,7 @@ pub fn format_caught_error(caught: CaughtError) -> String {
 /// Awaits a JavaScript value, transparently resolving it if it is a promise, and converts the
 /// result to `R`. Panics (traps) if the promise rejects or the value cannot be converted, since
 /// `future<T>` has no error channel.
-async fn resolve_js_value<'js, R>(ctx: &Ctx<'js>, value: Value<'js>) -> R
+async fn try_resolve_js_value<'js, R>(ctx: &Ctx<'js>, value: Value<'js>) -> Result<R, String>
 where
     R: FromJs<'js>,
 {
@@ -1521,25 +1544,34 @@ where
             .into_promise()
             .expect("value.is_promise() returned true but conversion to Promise failed");
         match promise.into_future::<R>().await {
-            Ok(v) => v,
+            Ok(v) => Ok(v),
             Err(Error::Exception) => {
                 let exception = ctx.catch();
-                panic!(
+                Err(format!(
                     "A JavaScript promise backing a component future/stream payload rejected:\n{}",
                     format_js_exception(&exception)
-                );
+                ))
             }
-            Err(e) => panic!(
+            Err(e) => Err(format!(
                 "Error awaiting a JavaScript promise for a component future/stream payload: {e:?}"
-            ),
+            )),
         }
     } else {
-        R::from_js(ctx, value).unwrap_or_else(|e| {
-            panic!(
+        R::from_js(ctx, value).map_err(|e| {
+            format!(
                 "Failed to convert a JavaScript value to a component future/stream payload: {e:?}"
             )
         })
     }
+}
+
+async fn resolve_js_value<'js, R>(ctx: &Ctx<'js>, value: Value<'js>) -> R
+where
+    R: FromJs<'js>,
+{
+    try_resolve_js_value(ctx, value)
+        .await
+        .unwrap_or_else(|error| panic!("{error}"))
 }
 
 /// Calls an exported JS function and returns its raw return value (a promise or a plain value)
@@ -1622,21 +1654,34 @@ pub fn spawn_future_writer<T, R, F>(
     spawn_local(future_writer_task(js_value, writer, convert));
 }
 
-async fn close_js_stream_iterator(iterator: Persistent<Object<'static>>) {
+async fn try_close_js_stream_iterator(iterator: Persistent<Object<'static>>) -> Result<(), String> {
     async_with!(get_js_state().ctx => |ctx| {
         let iterator = iterator
             .restore(&ctx)
-            .expect("Failed to restore a persisted stream iterator during cleanup");
+            .map_err(|error| format!("Failed to restore a persisted stream iterator during cleanup: {error:?}"))?;
         let close: Function = ctx
             .globals()
             .get("__wasm_rquickjs_close_async_iterator")
-            .expect("async-value helper __wasm_rquickjs_close_async_iterator is missing");
+            .map_err(|error| format!("async-value helper __wasm_rquickjs_close_async_iterator is missing: {error:?}"))?;
         let result: Value = close
             .call((iterator,))
-            .unwrap_or_else(|e| panic!("Failed to close a component stream<T> iterator: {e:?}"));
-        let _: Value = resolve_js_value(&ctx, result).await;
+            .map_err(|error| format!("Failed to close a component stream<T> iterator: {error:?}"))?;
+        let _: Value = try_resolve_js_value(&ctx, result).await?;
+        Ok(())
     })
-    .await;
+    .await
+}
+
+async fn close_js_stream_iterator(iterator: Persistent<Object<'static>>) {
+    try_close_js_stream_iterator(iterator)
+        .await
+        .unwrap_or_else(|error| panic!("{error}"));
+}
+
+enum StreamWriterItem<T> {
+    Done,
+    Item(T),
+    PayloadError(String),
 }
 
 /// The future produced by [`spawn_stream_writer`], factored out so it can also be composed with
@@ -1680,7 +1725,7 @@ pub async fn stream_writer_task<T, R, F>(
         // Clone the persisted iterator handle per iteration so the `async_with!` closure moves
         // a fresh clone each time rather than the shared handle (which the loop reuses).
         let iterator_for_next = iterator.clone();
-        let item: Option<T> = async_with!(get_js_state().ctx => |ctx| {
+        let item: StreamWriterItem<T> = async_with!(get_js_state().ctx => |ctx| {
                 let iterator = iterator_for_next
                     .restore(&ctx)
                     .expect("Failed to restore a persisted stream iterator");
@@ -1696,7 +1741,7 @@ pub async fn stream_writer_task<T, R, F>(
                     .unwrap_or_else(|| panic!("stream iterator next() did not resolve to an object"));
                 let done: bool = result_obj.get("done").unwrap_or(false);
                 if done {
-                    None
+                    StreamWriterItem::Done
                 } else {
                     let value: Value = result_obj
                         .get("value")
@@ -1704,22 +1749,31 @@ pub async fn stream_writer_task<T, R, F>(
                     // A sync iterable normalized into an async iterator can still yield
                     // promise-valued items; JS `for await` awaits each value (AsyncFromSyncIterator
                     // semantics), so resolve promises before converting to the payload type.
-                    let r: R = resolve_js_value::<R>(&ctx, value).await;
-                    Some(convert(r))
+                    match try_resolve_js_value::<R>(&ctx, value).await {
+                        Ok(r) => StreamWriterItem::Item(convert(r)),
+                        Err(error) => StreamWriterItem::PayloadError(error),
+                    }
                 }
             })
             .await;
 
         match item {
-            Some(item) => {
+            StreamWriterItem::Item(item) => {
                 if writer.write_one(item).await.is_some() {
                     // The reader hung up; stop producing further items and await source cleanup.
                     close_js_stream_iterator(iterator.clone()).await;
                     break;
                 }
             }
-            None => {
+            StreamWriterItem::Done => {
                 break;
+            }
+            StreamWriterItem::PayloadError(error) => {
+                // `next()` succeeded and yielded an item, so close the iterator before surfacing
+                // the payload failure. Cleanup is best-effort here: the primary conversion or
+                // promise-rejection diagnostic must not be replaced by a secondary close error.
+                let _ = try_close_js_stream_iterator(iterator.clone()).await;
+                panic!("{error}");
             }
         }
     }
@@ -1978,9 +2032,14 @@ where
             Some(group) => with_export_result_writer_group(group, converted),
             None => converted(),
         }
-        .unwrap_or_else(|e| {
-            panic!("Failed to convert a JavaScript value to a component stream payload: {e:?}")
-        });
+        .map_err(|error| {
+            Exception::throw_message(
+                &cb_ctx,
+                &format!(
+                    "Failed to convert a JavaScript value to a component stream payload: {error:?}"
+                ),
+            )
+        })?;
         let payload = convert(wrapped);
         let (ack_tx, ack_rx) = futures::channel::oneshot::channel::<bool>();
         // If the pure task already exited (reader hung up) the send fails; report "stop".
@@ -1988,13 +2047,13 @@ where
             .borrow()
             .as_ref()
             .is_some_and(|cmd_tx| cmd_tx.unbounded_send((payload, ack_tx)).is_ok());
-        Promised(async move {
+        Ok::<_, rquickjs::Error>(Promised(async move {
             if accepted {
                 ack_rx.await.unwrap_or(false)
             } else {
                 false
             }
-        })
+        }))
     })?;
 
     let drive: Function = ctx

--- a/examples/p3/async-values-import/src/async-values-import.js
+++ b/examples/p3/async-values-import/src/async-values-import.js
@@ -139,3 +139,46 @@ export async function runStreamCleanupFailure() {
   await new Promise(resolve => setTimeout(resolve, 10));
   return 'clean-eof';
 }
+
+export async function runStreamConversionFailure() {
+  let nextCalls = 0;
+  const source = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          nextCalls += 1;
+          return { done: false, value: 'not-a-u8' };
+        },
+        async return() {
+          host.cleanupComplete();
+          throw new Error('secondary-cleanup-failed');
+        },
+      };
+    },
+  };
+
+  await host.consumeStream(source);
+  return `clean-eof|${nextCalls}`;
+}
+
+export async function runSyncStreamPromiseRejection() {
+  const source = {
+    [Symbol.iterator]() {
+      return {
+        next() {
+          return {
+            done: false,
+            value: Promise.reject(new Error('sync-item-failed')),
+          };
+        },
+        return() {
+          host.cleanupComplete();
+          return { done: true, value: undefined };
+        },
+      };
+    },
+  };
+
+  await host.consumeStream(source);
+  return 'clean-eof';
+}

--- a/examples/p3/async-values-import/wit/world.wit
+++ b/examples/p3/async-values-import/wit/world.wit
@@ -15,6 +15,7 @@ interface host {
   consume-stream-with-backpressure: async func(s: stream<u8>);
   store-future: async func(f: future<u32>);
   read-stored-future: async func() -> u32;
+  cleanup-complete: func();
 }
 
 world async-values-import {
@@ -27,4 +28,6 @@ world async-values-import {
   export run-stream-backpressure: async func() -> string;
   export run-stream-failure: async func() -> string;
   export run-stream-cleanup-failure: async func() -> string;
+  export run-stream-conversion-failure: async func() -> string;
+  export run-sync-stream-promise-rejection: async func() -> string;
 }

--- a/examples/p3/async-values/src/async-values.js
+++ b/examples/p3/async-values/src/async-values.js
@@ -190,6 +190,19 @@ export async function runObservedStream() {
   };
 }
 
+export async function runInvalidObservedStream() {
+  async function* invalid() {
+    try {
+      yield 'not-a-u8';
+    } finally {
+      observer.cleanupComplete();
+      throw new Error('secondary-export-cleanup-failed');
+    }
+  }
+
+  return invalid();
+}
+
 export async function readObservedStreamState() {
   await Promise.race([
     observedStreamState.cleanupCompleted,

--- a/examples/p3/async-values/wit/world.wit
+++ b/examples/p3/async-values/wit/world.wit
@@ -37,5 +37,6 @@ world async-values {
   export close-pending-stream: async func(s: stream<u8>) -> string;
   export run-nested-observed-stream: async func(cleanup-failure: bool) -> result<nested-values, string>;
   export run-observed-stream: async func() -> stream<u8>;
+  export run-invalid-observed-stream: async func() -> stream<u8>;
   export read-observed-stream-state: async func() -> string;
 }

--- a/examples/p3/host-runner/src/bin/async_values.rs
+++ b/examples/p3/host-runner/src/bin/async_values.rs
@@ -10,7 +10,7 @@ use anyhow::{Result, anyhow};
 use futures::StreamExt;
 use futures::channel::{mpsc, oneshot};
 use p3_host_runner::util::{OneshotConsumer, OneshotProducer, PipeConsumer, PipeProducer};
-use wasmtime::component::{Component, FutureReader, Linker, StreamReader, bindgen};
+use wasmtime::component::{Component, FutureReader, HasSelf, Linker, StreamReader, bindgen};
 use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{ResourceTable, WasiCtxBuilder, WasiCtxView};
 use wasmtime_wasi_http::WasiHttpCtx;
@@ -44,6 +44,10 @@ impl WasiHttpView for Host {
             hooks: wasmtime_wasi_http::p3::default_hooks(),
         }
     }
+}
+
+impl test::async_values::observer::Host for Host {
+    fn cleanup_complete(&mut self) {}
 }
 
 fn component_path() -> Result<String> {
@@ -83,7 +87,9 @@ fn component_path() -> Result<String> {
     let target_dir = json["target_directory"]
         .as_str()
         .ok_or_else(|| anyhow!("missing target_directory"))?;
-    Ok(format!("{target_dir}/wasm32-wasip2/debug/async_values.wasm"))
+    Ok(format!(
+        "{target_dir}/wasm32-wasip2/debug/async_values.wasm"
+    ))
 }
 
 async fn instantiate() -> Result<(Store<Host>, AsyncValues)> {
@@ -99,6 +105,7 @@ async fn instantiate() -> Result<(Store<Host>, AsyncValues)> {
     wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
     wasmtime_wasi::p3::add_to_linker(&mut linker)?;
     wasmtime_wasi_http::p3::add_to_linker(&mut linker)?;
+    test::async_values::observer::add_to_linker::<Host, HasSelf<Host>>(&mut linker, |host| host)?;
 
     let wasi = WasiCtxBuilder::new().inherit_stdio().build();
     let mut store = Store::new(
@@ -170,7 +177,10 @@ async fn call_take_stream(items: Vec<u8>) -> Result<u32> {
 #[tokio::main]
 async fn main() -> Result<()> {
     let run_future = call_run_future().await?;
-    assert_eq!(run_future, 42, "expected run_future() == 42, got {run_future}");
+    assert_eq!(
+        run_future, 42,
+        "expected run_future() == 42, got {run_future}"
+    );
 
     let run_stream = call_run_stream().await?;
     assert_eq!(

--- a/examples/p3/host-runner/src/bin/async_values_import.rs
+++ b/examples/p3/host-runner/src/bin/async_values_import.rs
@@ -9,7 +9,10 @@
 use anyhow::{Result, anyhow};
 use futures::StreamExt;
 use futures::channel::{mpsc, oneshot};
-use p3_host_runner::util::{OneshotConsumer, OneshotProducer, PipeConsumer, PipeProducer};
+use p3_host_runner::util::{
+    BackpressureDropConsumer, OneshotConsumer, OneshotProducer, PipeConsumer, PipeProducer,
+    PrefixConsumer,
+};
 use wasmtime::component::{
     Access, Accessor, Component, FutureReader, HasSelf, Linker, StreamReader, bindgen,
 };
@@ -34,6 +37,7 @@ struct Host {
     wasi: wasmtime_wasi::WasiCtx,
     http: WasiHttpCtx,
     table: ResourceTable,
+    stored_future: Option<oneshot::Receiver<u32>>,
 }
 
 impl wasmtime_wasi::WasiView for Host {
@@ -55,7 +59,9 @@ impl WasiHttpView for Host {
     }
 }
 
-impl test::async_values_import::host::Host for Host {}
+impl test::async_values_import::host::Host for Host {
+    fn cleanup_complete(&mut self) {}
+}
 
 impl test::async_values_import::host::HostWithStore for HasSelf<Host> {
     fn make_future<T>(mut host: Access<T, Self>, x: u32) -> FutureReader<u32> {
@@ -72,10 +78,7 @@ impl test::async_values_import::host::HostWithStore for HasSelf<Host> {
             .expect("failed to create stream")
     }
 
-    async fn consume_future<T: Send>(
-        accessor: &Accessor<T, Self>,
-        f: FutureReader<u32>,
-    ) -> u32 {
+    async fn consume_future<T: Send>(accessor: &Accessor<T, Self>, f: FutureReader<u32>) -> u32 {
         let (tx, rx) = oneshot::channel();
         accessor
             .with(|access| f.pipe(access, OneshotConsumer::new(tx)))
@@ -83,10 +86,7 @@ impl test::async_values_import::host::HostWithStore for HasSelf<Host> {
         rx.await.expect("host future did not resolve")
     }
 
-    async fn consume_stream<T: Send>(
-        accessor: &Accessor<T, Self>,
-        s: StreamReader<u8>,
-    ) -> u32 {
+    async fn consume_stream<T: Send>(accessor: &Accessor<T, Self>, s: StreamReader<u8>) -> u32 {
         let (tx, rx) = mpsc::channel::<u8>(16);
         accessor
             .with(|access| s.pipe(access, PipeConsumer::new(tx)))
@@ -94,6 +94,43 @@ impl test::async_values_import::host::HostWithStore for HasSelf<Host> {
         rx.map(|b| b as u32)
             .fold(0u32, |acc, v| async move { acc + v })
             .await
+    }
+
+    async fn consume_stream_prefix<T: Send>(
+        accessor: &Accessor<T, Self>,
+        s: StreamReader<u8>,
+    ) -> u8 {
+        let (tx, rx) = oneshot::channel();
+        accessor
+            .with(|access| s.pipe(access, PrefixConsumer::new(tx)))
+            .expect("failed to pipe prefix stream");
+        rx.await.expect("prefix stream did not yield an item")
+    }
+
+    async fn consume_stream_with_backpressure<T: Send>(
+        accessor: &Accessor<T, Self>,
+        s: StreamReader<u8>,
+    ) {
+        accessor
+            .with(|access| s.pipe(access, BackpressureDropConsumer::default()))
+            .expect("failed to pipe backpressure stream");
+    }
+
+    async fn store_future<T: Send>(accessor: &Accessor<T, Self>, f: FutureReader<u32>) {
+        let (tx, rx) = oneshot::channel();
+        accessor
+            .with(|mut access| {
+                access.get().stored_future = Some(rx);
+                f.pipe(access, OneshotConsumer::new(tx))
+            })
+            .expect("failed to pipe stored host future");
+    }
+
+    async fn read_stored_future<T: Send>(accessor: &Accessor<T, Self>) -> u32 {
+        let rx = accessor
+            .with(|mut access| access.get().stored_future.take())
+            .expect("stored future was not set");
+        rx.await.expect("stored future did not resolve")
     }
 }
 
@@ -161,6 +198,7 @@ async fn instantiate() -> Result<(Store<Host>, AsyncValuesImport)> {
             wasi,
             http: WasiHttpCtx::new(),
             table: ResourceTable::new(),
+            stored_future: None,
         },
     );
     let bindings = AsyncValuesImport::instantiate_async(&mut store, &component, &linker).await?;

--- a/examples/p3/host-runner/src/util.rs
+++ b/examples/p3/host-runner/src/util.rs
@@ -68,6 +68,62 @@ impl<T, S> PipeConsumer<T, S> {
     }
 }
 
+/// Consumes one stream item and then drops the readable end.
+pub struct PrefixConsumer<T>(Option<oneshot::Sender<T>>);
+
+impl<T> PrefixConsumer<T> {
+    pub fn new(tx: oneshot::Sender<T>) -> Self {
+        Self(Some(tx))
+    }
+}
+
+impl<D, T: Lift + Send + 'static> StreamConsumer<D> for PrefixConsumer<T> {
+    type Item = T;
+
+    fn poll_consume(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        store: StoreContextMut<D>,
+        mut source: Source<Self::Item>,
+        _: bool,
+    ) -> Poll<Result<StreamResult>> {
+        let value = &mut None;
+        source.read(store, value)?;
+        let value = value.take().expect("prefix stream write had no item");
+        let _ = self.get_mut().0.take().unwrap().send(value);
+        Poll::Ready(Ok(StreamResult::Dropped))
+    }
+}
+
+/// Applies one round of backpressure and then drops the readable end.
+#[derive(Default)]
+pub struct BackpressureDropConsumer {
+    delayed_once: bool,
+}
+
+impl<D> StreamConsumer<D> for BackpressureDropConsumer {
+    type Item = u8;
+
+    fn poll_consume(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        _: StoreContextMut<D>,
+        _: Source<Self::Item>,
+        finish: bool,
+    ) -> Poll<Result<StreamResult>> {
+        if finish {
+            return Poll::Ready(Ok(StreamResult::Cancelled));
+        }
+        if self.delayed_once {
+            Poll::Ready(Ok(StreamResult::Dropped))
+        } else {
+            self.delayed_once = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
 impl<D, T: Lift + 'static, S: Sink<T, Error: std::error::Error + Send + Sync> + Send + 'static>
     StreamConsumer<D> for PipeConsumer<T, S>
 {

--- a/tests/p3_async_values.rs
+++ b/tests/p3_async_values.rs
@@ -101,7 +101,11 @@ impl WasiHttpView for Host {
     }
 }
 
-impl test::async_values_import::host::Host for Host {}
+impl test::async_values_import::host::Host for Host {
+    fn cleanup_complete(&mut self) {
+        self.nested_cleanup_calls += 1;
+    }
+}
 
 impl export_bindings::test::async_values::observer::Host for Host {
     fn cleanup_complete(&mut self) {
@@ -518,6 +522,32 @@ async fn run_export_stream_producer_cleanup(component_path: &Utf8Path) -> Result
         .await?
 }
 
+async fn run_export_stream_conversion_failure(
+    component_path: &Utf8Path,
+) -> Result<(Result<Vec<u8>>, usize, String)> {
+    let engine = engine()?;
+    let component = Component::from_file(&engine, component_path)?;
+    let linker = base_linker(&engine)?;
+    let mut store = new_store(&engine);
+    let bindings = AsyncValues::instantiate_async(&mut store, &component, &linker).await?;
+
+    let result = match store
+        .run_concurrent(async move |accessor| -> Result<Vec<u8>> {
+            let reader = bindings.call_run_invalid_observed_stream(accessor).await?;
+            let (tx, rx) = mpsc::channel(16);
+            accessor.with(|access| reader.pipe(access, PipeConsumer::new(tx)))?;
+            Ok(rx.collect().await)
+        })
+        .await
+    {
+        Ok(result) => result,
+        Err(error) => Err(error),
+    };
+    let cleanup_calls = store.data().nested_cleanup_calls;
+    let stderr = String::from_utf8_lossy(&store.data().stderr.contents()).into_owned();
+    Ok((result, cleanup_calls, stderr))
+}
+
 async fn run_export_sibling_streams(component_path: &Utf8Path) -> Result<(Vec<u8>, Vec<u8>)> {
     let engine = engine()?;
     let component = Component::from_file(&engine, component_path)?;
@@ -688,6 +718,56 @@ async fn run_import_world_stream_failure(
     };
     let stderr = String::from_utf8_lossy(&store.data().stderr.contents()).into_owned();
     Ok((result, stderr))
+}
+
+async fn run_import_world_stream_conversion_failure(
+    component_path: &Utf8Path,
+) -> Result<(Result<String>, usize, String)> {
+    let engine = engine()?;
+    let component = Component::from_file(&engine, component_path)?;
+    let mut linker = base_linker(&engine)?;
+    test::async_values_import::host::add_to_linker::<Host, HasSelf<Host>>(&mut linker, |h| h)?;
+
+    let mut store = new_store(&engine);
+    let bindings = AsyncValuesImport::instantiate_async(&mut store, &component, &linker).await?;
+    let result = match store
+        .run_concurrent(async move |accessor| {
+            bindings.call_run_stream_conversion_failure(accessor).await
+        })
+        .await
+    {
+        Ok(result) => result,
+        Err(error) => Err(error),
+    };
+    let cleanup_calls = store.data().nested_cleanup_calls;
+    let stderr = String::from_utf8_lossy(&store.data().stderr.contents()).into_owned();
+    Ok((result, cleanup_calls, stderr))
+}
+
+async fn run_import_world_sync_stream_promise_rejection(
+    component_path: &Utf8Path,
+) -> Result<(Result<String>, usize, String)> {
+    let engine = engine()?;
+    let component = Component::from_file(&engine, component_path)?;
+    let mut linker = base_linker(&engine)?;
+    test::async_values_import::host::add_to_linker::<Host, HasSelf<Host>>(&mut linker, |h| h)?;
+
+    let mut store = new_store(&engine);
+    let bindings = AsyncValuesImport::instantiate_async(&mut store, &component, &linker).await?;
+    let result = match store
+        .run_concurrent(async move |accessor| {
+            bindings
+                .call_run_sync_stream_promise_rejection(accessor)
+                .await
+        })
+        .await
+    {
+        Ok(result) => result,
+        Err(error) => Err(error),
+    };
+    let cleanup_calls = store.data().nested_cleanup_calls;
+    let stderr = String::from_utf8_lossy(&store.data().stderr.contents()).into_owned();
+    Ok((result, cleanup_calls, stderr))
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -909,6 +989,28 @@ fn p3_exported_js_stream_peer_drop_runs_iterator_cleanup() {
 }
 
 #[test]
+fn p3_exported_js_stream_conversion_failure_closes_iterator() {
+    let temp = Utf8TempDir::new().expect("temp dir");
+    let wasm = generate_and_build(&temp, "async-values", "async_values").expect("generate + build");
+
+    let (result, cleanup_calls, stderr) =
+        block_on_with_timeout(120, run_export_stream_conversion_failure(&wasm));
+    result.expect_err("invalid exported stream payload must fail the active stream session");
+    assert_eq!(
+        cleanup_calls, 1,
+        "payload conversion failure must close the JavaScript iterator exactly once"
+    );
+    assert!(
+        stderr.contains("Failed to convert a JavaScript value"),
+        "conversion failure should preserve its diagnostic, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("secondary-export-cleanup-failed"),
+        "secondary cleanup failure must not replace the primary conversion failure: {stderr}"
+    );
+}
+
+#[test]
 fn p3_exported_sibling_streams_can_exceed_buffer_capacity() {
     let temp = Utf8TempDir::new().expect("temp dir");
     let wasm = generate_and_build(&temp, "async-values", "async_values").expect("generate + build");
@@ -987,6 +1089,48 @@ fn p3_js_stream_cleanup_rejection_fails_active_consumer() {
     assert!(
         stderr.contains("cleanup-failed"),
         "cleanup failure should preserve its diagnostic, got: {stderr}"
+    );
+}
+
+#[test]
+fn p3_js_stream_conversion_failure_closes_iterator_and_preserves_primary_error() {
+    let temp = Utf8TempDir::new().expect("temp dir");
+    let wasm = generate_and_build(&temp, "async-values-import", "async_values_import")
+        .expect("generate + build");
+
+    let (result, cleanup_calls, stderr) =
+        block_on_with_timeout(120, run_import_world_stream_conversion_failure(&wasm));
+    result.expect_err("invalid imported stream payload must fail the active stream consumer");
+    assert_eq!(
+        cleanup_calls, 1,
+        "payload conversion failure must close the JavaScript iterator exactly once"
+    );
+    assert!(
+        stderr.contains("Failed to convert a JavaScript value"),
+        "primary conversion failure should remain visible, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("secondary-cleanup-failed"),
+        "secondary cleanup failure must not replace the primary conversion failure: {stderr}"
+    );
+}
+
+#[test]
+fn p3_sync_stream_rejected_item_does_not_close_iterator() {
+    let temp = Utf8TempDir::new().expect("temp dir");
+    let wasm = generate_and_build(&temp, "async-values-import", "async_values_import")
+        .expect("generate + build");
+
+    let (result, cleanup_calls, stderr) =
+        block_on_with_timeout(120, run_import_world_sync_stream_promise_rejection(&wasm));
+    result.expect_err("rejected synchronous stream item must fail the active consumer");
+    assert_eq!(
+        cleanup_calls, 0,
+        "AsyncFromSyncIterator next() rejection must not call iterator.return()"
+    );
+    assert!(
+        stderr.contains("sync-item-failed"),
+        "the rejected item diagnostic should remain visible, got: {stderr}"
     );
 }
 


### PR DESCRIPTION
- fixes iterator cleanup when P3 stream payload resolution, conversion, or writing fails after a successful `next()`
- preserves the primary payload failure when `return()` cleanup also rejects, without closing iterators whose normalized `next()` rejects under the Node.js 22.14 compatibility baseline
- updates both standalone P3 host runners for the WIT interfaces introduced by the parent PR
- adds focused regressions for both stream-lowering owners, cleanup-error precedence, and synchronous yielded-promise rejection

Validation:

- `cargo test --test p3_async_values p3_exported_js_stream_conversion_failure_closes_iterator -- --exact`
- `cargo test --test p3_async_values p3_js_stream_conversion_failure_closes_iterator_and_preserves_primary_error -- --exact`
- `cargo test --test p3_async_values p3_sync_stream_rejected_item_does_not_close_iterator -- --exact`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -Dwarnings`
- `cargo check --manifest-path examples/p3/host-runner/Cargo.toml --bins`
- `cargo clippy --manifest-path examples/p3/host-runner/Cargo.toml --bins -- -D warnings`

The standalone skeleton-wide Clippy gate remains blocked by pre-existing warnings in `internal/module_loading.rs` under the current toolchain; the generated P3 components containing this change compile and pass the focused tests above.
