### PR TITLE
Measure TypeScript transform latency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ name = "agentic_ts"
 harness = false
 
 [[test]]
+name = "typescript_transform_latency"
+harness = false
+
+[[test]]
 name = "migrate_config_split"
 harness = false
 

--- a/examples/runtime/typescript-transform-latency/src/typescript-transform-latency.js
+++ b/examples/runtime/typescript-transform-latency/src/typescript-transform-latency.js
@@ -1,0 +1,170 @@
+import fs from 'node:fs';
+import { stripTypeScriptTypes } from 'node:module';
+import { runJavaScript, startJavaScript } from 'wasm-rquickjs:execution';
+
+const ROOT = '/typescript-transform-latency';
+
+function stringify(value) {
+    return JSON.stringify(value);
+}
+
+function typedPrefix(sourceBytes) {
+    const lines = [];
+    let length = 0;
+    for (let index = 0; length < sourceBytes; index++) {
+        const line = `type Padding${index} = { value: number; next?: Padding${index} };\n`;
+        lines.push(line);
+        length += line.length;
+    }
+    return lines.join('');
+}
+
+function sourceFor(kind, sourceBytes) {
+    const prefix = typedPrefix(Number(sourceBytes));
+    if (kind === 'inline') return `${prefix}return 42 as number;`;
+    if (kind === 'transform-only') {
+        return `${prefix}enum Direction { Up, Down } return 41 + Direction.Down;`;
+    }
+    if (kind === 'entry' || kind === 'esm') {
+        return `${prefix}export default function run(): number { return 42; }`;
+    }
+    if (kind === 'cjs') {
+        return `${prefix}exports.run = function run(): number { return 42; };`;
+    }
+    throw new Error(`unknown transform case: ${kind}`);
+}
+
+function pathFor(kind, sourceBytes, sample) {
+    const extension = kind === 'cjs' ? 'cts' : kind === 'prepared-esm' ? 'mjs' : 'mts';
+    return `${ROOT}/${kind}-${sourceBytes}-${sample}.${extension}`;
+}
+
+export async function measureCase(kind, sourceBytes, sample) {
+    fs.mkdirSync(ROOT, { recursive: true });
+    const source = sourceFor(kind === 'api' || kind === 'prepared-esm' ? 'esm' : kind, sourceBytes);
+    let preparedPath;
+    if (kind === 'prepared-esm') {
+        preparedPath = pathFor(kind, sourceBytes, sample);
+        fs.writeFileSync(
+            preparedPath,
+            stripTypeScriptTypes(source, { mode: process.features.typescript }),
+        );
+    }
+    const started = performance.now();
+    let result;
+    if (kind === 'api') {
+        const code = stripTypeScriptTypes(source, { mode: process.features.typescript });
+        result = { value: code.length, overflowed: false };
+    } else if (kind === 'prepared-esm') {
+        result = await runJavaScript({ source: `
+            const loaded = await import(${JSON.stringify(preparedPath)});
+            return loaded.default();
+        ` });
+    } else if (kind === 'inline' || kind === 'transform-only') {
+        result = await runJavaScript({ language: 'typescript', source });
+    } else {
+        const path = pathFor(kind, sourceBytes, sample);
+        fs.writeFileSync(path, source);
+        if (kind === 'entry') {
+            result = await runJavaScript({ cwd: ROOT, entry: path });
+        } else if (kind === 'esm') {
+            result = await runJavaScript({ source: `
+                const loaded = await import(${JSON.stringify(path)});
+                return loaded.default();
+            ` });
+        } else {
+            result = await runJavaScript({ source: `
+                const { createRequire } = await import('node:module');
+                const require = createRequire('/typescript-transform-latency/runner.cjs');
+                return require(${JSON.stringify(path)}).run();
+            ` });
+        }
+    }
+    return stringify({
+        kind,
+        requestedSourceBytes: Number(sourceBytes),
+        actualSourceBytes: source.length,
+        elapsedMs: performance.now() - started,
+        value: kind === 'api' ? undefined : result.value,
+        outputBytes: kind === 'api' ? result.value : undefined,
+        overflowed: result.overflowed,
+    });
+}
+
+export async function probeControls(sourceBytes) {
+    const prefix = typedPrefix(Number(sourceBytes));
+
+    const timeoutStarted = performance.now();
+    let timeout;
+    try {
+        await runJavaScript({
+            language: 'typescript',
+            timeoutMs: 1,
+            source: `${prefix}await new Promise(() => {});`,
+        });
+        timeout = { timedOut: false };
+    } catch (error) {
+        timeout = {
+            timedOut: error.message === 'execution job timed out',
+            message: error.message,
+            completedMs: performance.now() - timeoutStarted,
+        };
+    }
+
+    const cancellationStarted = performance.now();
+    const job = startJavaScript({
+        language: 'typescript',
+        source: `${prefix}await new Promise(() => {});`,
+    });
+    const requestedMs = 1;
+    let issuedMs;
+    const cancelTimer = setTimeout(() => {
+        issuedMs = performance.now() - cancellationStarted;
+        job.cancel();
+    }, requestedMs);
+    let cancellation;
+    try {
+        await job.result;
+        cancellation = { cancelled: false };
+    } catch (error) {
+        cancellation = {
+            cancelled: error.message === 'execution job cancelled',
+            message: error.message,
+            requestedMs,
+            issuedMs,
+            completedMs: performance.now() - cancellationStarted,
+        };
+    } finally {
+        clearTimeout(cancelTimer);
+    }
+
+    return stringify({ timeout, cancellation });
+}
+
+export async function probeConcurrency(sourceBytes) {
+    const source = sourceFor('esm', sourceBytes);
+    const requestedMs = 1;
+    const baselineStarted = performance.now();
+    await new Promise(resolve => setTimeout(resolve, requestedMs));
+    const baselineTimerMs = performance.now() - baselineStarted;
+
+    const started = performance.now();
+    let siblingIssuedMs;
+    const sibling = new Promise(resolve => setTimeout(() => {
+        siblingIssuedMs = performance.now() - started;
+        resolve();
+    }, requestedMs));
+    const transformStarted = performance.now();
+    const output = stripTypeScriptTypes(source, { mode: process.features.typescript });
+    const transformMs = performance.now() - transformStarted;
+    await sibling;
+    return stringify({
+        requestedMs,
+        baselineTimerMs,
+        transformMs,
+        siblingIssuedMs,
+        incrementalSiblingDelayMs: siblingIssuedMs - baselineTimerMs,
+        elapsedMs: performance.now() - started,
+        outputBytes: output.length,
+    });
+}

--- a/examples/runtime/typescript-transform-latency/wit/typescript-transform-latency.wit
+++ b/examples/runtime/typescript-transform-latency/wit/typescript-transform-latency.wit
@@ -1,0 +1,7 @@
+package quickjs:typescript-transform-latency;
+
+world typescript-transform-latency {
+  export measure-case: func(kind: string, source-bytes: u64, sample: u64) -> string;
+  export probe-controls: func(source-bytes: u64) -> string;
+  export probe-concurrency: func(source-bytes: u64) -> string;
+}

--- a/tests/goldenfiles/generated_types_typescript-transform-latency_exports.d.ts
+++ b/tests/goldenfiles/generated_types_typescript-transform-latency_exports.d.ts
@@ -1,0 +1,5 @@
+declare module 'typescript-transform-latency' {
+  export function measureCase(kind: string, sourceBytes: bigint, sample: bigint): Promise<string>;
+  export function probeControls(sourceBytes: bigint): Promise<string>;
+  export function probeConcurrency(sourceBytes: bigint): Promise<string>;
+}

--- a/tests/typescript_transform_latency.rs
+++ b/tests/typescript_transform_latency.rs
@@ -1,0 +1,535 @@
+//! Bounded manual measurements for synchronous native TypeScript transformation.
+//!
+//! The default path validates checked-in reports. Set
+//! `TYPESCRIPT_TRANSFORM_LATENCY_MEASURE=1` to execute the workloads.
+
+#![allow(dead_code)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use camino::Utf8Path;
+use common::{CompiledTest, FeatureCombination, TestInstance, test_target};
+use serde_json::{Value, json};
+use std::fs;
+use std::io::Read as _;
+use std::process::Command;
+use std::time::{Duration, Instant};
+use wasmtime::component::Val;
+
+const EXAMPLE_DIR: &str = "examples/runtime/typescript-transform-latency";
+const RESULTS_DIR: &str = "tests/typescript_transform_latency/results";
+const INVOCATION_DEADLINE_SECONDS: u64 = 120;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    if std::env::var_os("TYPESCRIPT_TRANSFORM_LATENCY_MEASURE").is_none() {
+        return validate_checked_reports();
+    }
+
+    let mode = std::env::var("TYPESCRIPT_TRANSFORM_LATENCY_MODE").map_err(|_| {
+        anyhow::anyhow!("TYPESCRIPT_TRANSFORM_LATENCY_MODE must be strip or transform")
+    })?;
+    let features = match mode.as_str() {
+        "strip" => FeatureCombination::TypeScriptRuntime,
+        "transform" => FeatureCombination::TypeScriptTransformRuntime,
+        _ => anyhow::bail!("TYPESCRIPT_TRANSFORM_LATENCY_MODE must be strip or transform"),
+    };
+    let sizes = parse_sizes()?;
+    let iterations = std::env::var("TYPESCRIPT_TRANSFORM_LATENCY_ITERATIONS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(3);
+    anyhow::ensure!(iterations >= 3, "at least three iterations are required");
+
+    let build_started = Instant::now();
+    let compiled =
+        CompiledTest::new_with_features(Utf8Path::new(EXAMPLE_DIR), true, features).await?;
+    let build_ms = millis(build_started.elapsed());
+    let component_bytes = fs::metadata(compiled.wasm_path())?.len();
+    let instantiate_started = Instant::now();
+    let mut instance = TestInstance::new_with_memory_tracking(compiled.wasm_path()).await?;
+    let instantiate_ms = millis(instantiate_started.elapsed());
+
+    let mut cases = Vec::new();
+    for size in &sizes {
+        let mut kinds = vec!["api", "inline", "entry", "esm", "prepared-esm", "cjs"];
+        if mode == "transform" {
+            kinds.push("transform-only");
+        }
+        for kind in kinds {
+            eprintln!("measuring {mode}/{kind}/{size} bytes");
+            let mut samples = Vec::new();
+            for sample in 0..iterations {
+                samples.push(
+                    invoke_json(
+                        &mut instance,
+                        "measure-case",
+                        &[
+                            Val::String(kind.to_string()),
+                            Val::U64(*size),
+                            Val::U64(sample as u64),
+                        ],
+                    )
+                    .await?,
+                );
+            }
+            cases.push(json!({
+                "kind": kind,
+                "sourceBytes": size,
+                "summary": summarize(&samples),
+            }));
+        }
+    }
+
+    let largest = *sizes.last().unwrap();
+    eprintln!("probing {mode} controls at {largest} bytes");
+    let controls = invoke_json(&mut instance, "probe-controls", &[Val::U64(largest)]).await?;
+    eprintln!("probing {mode} concurrency at {largest} bytes");
+    let concurrency = invoke_json(&mut instance, "probe-concurrency", &[Val::U64(largest)]).await?;
+    let report = json!({
+        "schemaVersion": 1,
+        "environment": environment()?,
+        "inputs": {
+            "runtimeHash": runtime_hash()?,
+            "benchmarkHash": benchmark_hash()?,
+        },
+        "target": format!("{:?}", test_target()).to_lowercase(),
+        "mode": mode,
+        "iterations": iterations,
+        "sizesBytes": sizes,
+        "component": {
+            "bytes": component_bytes,
+            "blake3": hash_file(compiled.wasm_path())?,
+            "buildMs": build_ms,
+            "instantiateMs": instantiate_ms,
+        },
+        "cases": cases,
+        "controlsAtLargestSize": controls,
+        "concurrencyAtLargestSize": concurrency,
+        "wasmLinearMemoryHighWaterBytes": instance.linear_memory_high_water_bytes(),
+        "notes": [
+            "manual local measurement; timings are not CI thresholds",
+            "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
+            "timeout and cancellation budgets are requested before the synchronous native transform",
+            "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements",
+        ],
+    });
+    validate_report(&report)?;
+    let encoded = serde_json::to_string_pretty(&report)?;
+    if let Ok(path) = std::env::var("TYPESCRIPT_TRANSFORM_LATENCY_REPORT") {
+        fs::write(path, format!("{encoded}\n"))?;
+    }
+    println!("{encoded}");
+    Ok(())
+}
+
+fn parse_sizes() -> anyhow::Result<Vec<u64>> {
+    let configured = std::env::var("TYPESCRIPT_TRANSFORM_LATENCY_SIZES")
+        .unwrap_or_else(|_| "4096,16384,65536".to_string());
+    let sizes = configured
+        .split(',')
+        .map(|value| value.trim().parse::<u64>())
+        .collect::<Result<Vec<_>, _>>()?;
+    anyhow::ensure!(
+        sizes.len() >= 3
+            && sizes.iter().all(|size| *size > 0)
+            && sizes.windows(2).all(|pair| pair[0] < pair[1]),
+        "sizes must contain at least three increasing positive byte counts"
+    );
+    Ok(sizes)
+}
+
+async fn invoke_json(
+    instance: &mut TestInstance,
+    function: &str,
+    args: &[Val],
+) -> anyhow::Result<Value> {
+    instance.set_epoch_deadline(INVOCATION_DEADLINE_SECONDS);
+    let started = Instant::now();
+    let value = instance.invoke(None, function, args).await?;
+    let Some(Val::String(encoded)) = value else {
+        anyhow::bail!("{function} did not return a JSON string")
+    };
+    Ok(json!({
+        "outerWallMs": millis(started.elapsed()),
+        "linearMemoryHighWaterBytes": instance.linear_memory_high_water_bytes(),
+        "result": serde_json::from_str::<Value>(&encoded)?,
+    }))
+}
+
+fn summarize(samples: &[Value]) -> Value {
+    let mut elapsed = samples
+        .iter()
+        .filter_map(|sample| sample.pointer("/result/elapsedMs").and_then(Value::as_f64))
+        .collect::<Vec<_>>();
+    elapsed.sort_by(f64::total_cmp);
+    json!({
+        "iterations": samples.len(),
+        "medianMs": elapsed[elapsed.len() / 2],
+        "maximumMs": elapsed[elapsed.len() - 1],
+        "samples": samples,
+    })
+}
+
+fn validate_checked_reports() -> anyhow::Result<()> {
+    let directory = Utf8Path::new(RESULTS_DIR);
+    anyhow::ensure!(directory.exists(), "checked report directory is missing");
+    let current_runtime_hash = runtime_hash()?;
+    let current_benchmark_hash = benchmark_hash()?;
+    let mut profiles = std::collections::BTreeSet::new();
+    for entry in fs::read_dir(directory)? {
+        let path = entry?.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let report: Value = serde_json::from_slice(&fs::read(&path)?)?;
+        validate_report(&report).map_err(|error| anyhow::anyhow!("{}: {error}", path.display()))?;
+        anyhow::ensure!(
+            report["inputs"]["runtimeHash"] == current_runtime_hash
+                && report["inputs"]["benchmarkHash"] == current_benchmark_hash,
+            "{} is stale for the current source",
+            path.display()
+        );
+        anyhow::ensure!(
+            report["sizesBytes"] == json!([4096, 16384, 65536]),
+            "{} does not use the calibrated 4/16/64 KiB size matrix",
+            path.display()
+        );
+        let profile = (
+            report["target"].as_str().unwrap().to_string(),
+            report["mode"].as_str().unwrap().to_string(),
+        );
+        anyhow::ensure!(profiles.insert(profile), "duplicate target/mode report");
+        let expected_suffix = format!(
+            "-{}-{}-{}-{}.json",
+            report["target"].as_str().unwrap(),
+            report["mode"].as_str().unwrap(),
+            report["environment"]["os"].as_str().unwrap(),
+            report["environment"]["arch"].as_str().unwrap(),
+        );
+        anyhow::ensure!(
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(&expected_suffix)),
+            "{} filename does not match report metadata",
+            path.display()
+        );
+    }
+    anyhow::ensure!(
+        profiles
+            == [
+                ("p2", "strip"),
+                ("p2", "transform"),
+                ("p3", "strip"),
+                ("p3", "transform")
+            ]
+            .into_iter()
+            .map(|(target, mode)| (target.to_string(), mode.to_string()))
+            .collect(),
+        "checked reports must contain exactly one complete P2/P3 by strip/transform matrix"
+    );
+    Ok(())
+}
+
+fn validate_report(report: &Value) -> anyhow::Result<()> {
+    anyhow::ensure!(report["schemaVersion"] == 1, "unexpected report schema");
+    anyhow::ensure!(
+        report["environment"]["commitHint"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+            && report["environment"]["rustc"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty())
+            && report["inputs"]["runtimeHash"]
+                .as_str()
+                .is_some_and(is_blake3)
+            && report["inputs"]["benchmarkHash"]
+                .as_str()
+                .is_some_and(is_blake3)
+            && report["component"]["blake3"]
+                .as_str()
+                .is_some_and(is_blake3),
+        "report source or component identity is incomplete"
+    );
+    anyhow::ensure!(
+        matches!(report["target"].as_str(), Some("p2" | "p3"))
+            && matches!(report["mode"].as_str(), Some("strip" | "transform")),
+        "invalid target or mode"
+    );
+    let sizes = report["sizesBytes"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("missing sizes"))?;
+    anyhow::ensure!(
+        sizes.len() >= 3
+            && sizes
+                .iter()
+                .all(|size| size.as_u64().is_some_and(|size| size > 0))
+            && sizes
+                .windows(2)
+                .all(|pair| pair[0].as_u64() < pair[1].as_u64()),
+        "report needs at least three increasing positive sizes"
+    );
+    let iterations = report["iterations"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("missing iteration count"))?;
+    anyhow::ensure!(iterations >= 3, "report needs at least three iterations");
+    let cases = report["cases"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("missing cases"))?;
+    let expected_kinds = if report["mode"] == "transform" {
+        vec![
+            "api",
+            "inline",
+            "entry",
+            "esm",
+            "prepared-esm",
+            "cjs",
+            "transform-only",
+        ]
+    } else {
+        vec!["api", "inline", "entry", "esm", "prepared-esm", "cjs"]
+    };
+    anyhow::ensure!(
+        cases.len() == sizes.len() * expected_kinds.len(),
+        "incomplete path matrix"
+    );
+    let mut matrix = std::collections::BTreeSet::new();
+    for case in cases {
+        let kind = case["kind"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("case is missing its kind"))?;
+        let source_bytes = case["sourceBytes"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("case is missing its source size"))?;
+        anyhow::ensure!(
+            expected_kinds.contains(&kind)
+                && sizes.iter().any(|size| size.as_u64() == Some(source_bytes))
+                && matrix.insert((source_bytes, kind)),
+            "unexpected or duplicate path/size case"
+        );
+        let samples = case["summary"]["samples"]
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("missing case samples"))?;
+        anyhow::ensure!(
+            samples.len() as u64 == iterations
+                && case["summary"]["iterations"] == json!(iterations),
+            "case iteration count differs from report"
+        );
+        let mut elapsed = Vec::with_capacity(samples.len());
+        for sample in samples {
+            let valid_value = if case["kind"] == "api" {
+                sample
+                    .pointer("/result/outputBytes")
+                    .and_then(Value::as_u64)
+                    .is_some_and(|bytes| bytes > 0)
+            } else {
+                sample.pointer("/result/value") == Some(&json!(42))
+            };
+            anyhow::ensure!(
+                valid_value && sample.pointer("/result/overflowed") == Some(&json!(false)),
+                "transform case returned an invalid result"
+            );
+            anyhow::ensure!(
+                sample.pointer("/result/requestedSourceBytes") == Some(&json!(source_bytes)),
+                "sample source size differs from its case"
+            );
+            elapsed.push(
+                sample
+                    .pointer("/result/elapsedMs")
+                    .and_then(Value::as_f64)
+                    .ok_or_else(|| anyhow::anyhow!("sample is missing elapsed time"))?,
+            );
+        }
+        elapsed.sort_by(f64::total_cmp);
+        anyhow::ensure!(
+            approximately_equal(
+                case["summary"]["medianMs"].as_f64(),
+                Some(elapsed[elapsed.len() / 2])
+            ) && approximately_equal(
+                case["summary"]["maximumMs"].as_f64(),
+                elapsed.last().copied()
+            ),
+            "case summary does not match raw samples"
+        );
+    }
+    let controls = &report["controlsAtLargestSize"]["result"];
+    anyhow::ensure!(
+        controls["timeout"]["timedOut"] == true
+            && controls["cancellation"]["cancelled"] == true
+            && controls["timeout"]["completedMs"].as_f64().is_some()
+            && controls["cancellation"]["issuedMs"].as_f64().is_some()
+            && controls["cancellation"]["completedMs"].as_f64().is_some(),
+        "control probe did not observe timeout and cancellation"
+    );
+    let concurrency = &report["concurrencyAtLargestSize"]["result"];
+    anyhow::ensure!(
+        concurrency["requestedMs"] == 1
+            && concurrency["outputBytes"]
+                .as_u64()
+                .is_some_and(|bytes| bytes > 0)
+            && concurrency["baselineTimerMs"].as_f64().is_some()
+            && concurrency["transformMs"].as_f64().is_some()
+            && concurrency["siblingIssuedMs"].as_f64().is_some()
+            && concurrency["incrementalSiblingDelayMs"].as_f64().is_some(),
+        "concurrency probe failed"
+    );
+    anyhow::ensure!(
+        report["wasmLinearMemoryHighWaterBytes"]
+            .as_u64()
+            .is_some_and(|bytes| bytes > 0),
+        "missing linear-memory high-water observation"
+    );
+    Ok(())
+}
+
+fn approximately_equal(left: Option<f64>, right: Option<f64>) -> bool {
+    left.zip(right)
+        .is_some_and(|(left, right)| (left - right).abs() <= f64::EPSILON * 8.0)
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn environment() -> anyhow::Result<Value> {
+    let source_root = source_root();
+    let dirty = !command_text(Command::new("git").args([
+        "-C",
+        source_root.as_str(),
+        "status",
+        "--porcelain",
+        "--",
+        ".",
+        ":(exclude)tests/typescript_transform_latency/results/*.json",
+    ]))?
+    .is_empty();
+    Ok(json!({
+        "commitHint": command_text(Command::new("git").args(["-C", source_root.as_str(), "rev-parse", "HEAD"]))?,
+        "dirty": dirty,
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "rustc": command_text(Command::new("rustc").arg("--version"))?,
+        "cargo": command_text(Command::new("cargo").arg("--version"))?,
+        "artifactCache": std::env::var("WASM_RQUICKJS_TEST_ARTIFACT_CACHE").ok(),
+        "wasmtimeCache": std::env::var("WASM_RQUICKJS_TEST_WASMTIME_CACHE").ok(),
+        "unoptimized": std::env::var("WASM_RQUICKJS_TEST_UNOPTIMIZED").ok(),
+    }))
+}
+
+fn command_text(command: &mut Command) -> anyhow::Result<String> {
+    let output = command.output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+fn composite_hash(files: &[&str], directories: &[&str]) -> anyhow::Result<String> {
+    let source_root = source_root();
+    let mut paths = files
+        .iter()
+        .map(|path| camino::Utf8PathBuf::from(*path))
+        .collect::<std::collections::BTreeSet<_>>();
+    for directory in directories {
+        collect_input_files(&source_root, Utf8Path::new(directory), &mut paths)?;
+    }
+    let mut hasher = blake3::Hasher::new();
+    for path in paths {
+        let bytes = fs::read(source_root.join(&path))?;
+        hasher.update(&(path.as_str().len() as u64).to_le_bytes());
+        hasher.update(path.as_str().as_bytes());
+        hasher.update(&(bytes.len() as u64).to_le_bytes());
+        hasher.update(&bytes);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn runtime_hash() -> anyhow::Result<String> {
+    composite_hash(
+        &[
+            "Cargo.toml",
+            "Cargo.lock",
+            ".github/scripts/enable-wasmtime-fork.sh",
+            "crates/wasm-rquickjs/Cargo.toml",
+            "crates/wasi-logging/Cargo.toml",
+            "crates/wasm-rquickjs/skeleton/Cargo.toml_",
+            "crates/wasm-rquickjs/skeleton/Cargo.lock",
+        ],
+        &[
+            "crates/wasm-rquickjs/src",
+            "crates/wasm-rquickjs/skeleton/src",
+            "crates/wasi-logging/src",
+        ],
+    )
+}
+
+fn benchmark_hash() -> anyhow::Result<String> {
+    composite_hash(
+        &[
+            "tests/typescript_transform_latency.rs",
+            "tests/typescript_transform_latency/run.sh",
+            "tools/dev-test.sh",
+        ],
+        &[
+            "examples/runtime/typescript-transform-latency",
+            "tests/common",
+        ],
+    )
+}
+
+fn collect_input_files(
+    source_root: &Utf8Path,
+    directory: &Utf8Path,
+    files: &mut std::collections::BTreeSet<camino::Utf8PathBuf>,
+) -> anyhow::Result<()> {
+    for entry in fs::read_dir(source_root.join(directory))? {
+        let entry = entry?;
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|name| anyhow::anyhow!("non-UTF-8 input name: {}", name.to_string_lossy()))?;
+        let path = directory.join(name);
+        let metadata = fs::symlink_metadata(source_root.join(&path))?;
+        anyhow::ensure!(
+            !metadata.file_type().is_symlink(),
+            "input symlink is unsupported: {path}"
+        );
+        if metadata.is_dir() {
+            collect_input_files(source_root, &path, files)?;
+        } else {
+            anyhow::ensure!(metadata.is_file(), "unsupported input type: {path}");
+            files.insert(path);
+        }
+    }
+    Ok(())
+}
+
+fn source_root() -> camino::Utf8PathBuf {
+    std::env::var("TYPESCRIPT_TRANSFORM_LATENCY_SOURCE_ROOT")
+        .unwrap_or_else(|_| ".".to_string())
+        .into()
+}
+
+fn hash_file(path: &Utf8Path) -> anyhow::Result<String> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn is_blake3(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/tests/typescript_transform_latency.rs
+++ b/tests/typescript_transform_latency.rs
@@ -111,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
         "notes": [
             "manual local measurement; timings are not CI thresholds",
             "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
-            "timeout and cancellation budgets are requested before the synchronous native transform",
+            "the timeout deadline and cancellation timer are armed before the synchronous native transform; the cancellation call is delivered after the outer runtime regains control",
             "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements",
         ],
     });
@@ -193,7 +193,7 @@ fn validate_checked_reports() -> anyhow::Result<()> {
         );
         anyhow::ensure!(
             report["sizesBytes"] == json!([4096, 16384, 65536]),
-            "{} does not use the calibrated 4/16/64 KiB size matrix",
+            "{} does not use the calibrated requested 4/16/64 KiB size matrix",
             path.display()
         );
         let profile = (

--- a/tests/typescript_transform_latency.rs
+++ b/tests/typescript_transform_latency.rs
@@ -175,8 +175,12 @@ fn summarize(samples: &[Value]) -> Value {
 fn validate_checked_reports() -> anyhow::Result<()> {
     let directory = Utf8Path::new(RESULTS_DIR);
     anyhow::ensure!(directory.exists(), "checked report directory is missing");
-    let current_runtime_hash = runtime_hash()?;
-    let current_benchmark_hash = benchmark_hash()?;
+    let check_current = std::env::var_os("TYPESCRIPT_TRANSFORM_LATENCY_CHECK_CURRENT").is_some();
+    let current_hashes = if check_current {
+        Some((runtime_hash()?, benchmark_hash()?))
+    } else {
+        None
+    };
     let mut profiles = std::collections::BTreeSet::new();
     for entry in fs::read_dir(directory)? {
         let path = entry?.path();
@@ -185,12 +189,18 @@ fn validate_checked_reports() -> anyhow::Result<()> {
         }
         let report: Value = serde_json::from_slice(&fs::read(&path)?)?;
         validate_report(&report).map_err(|error| anyhow::anyhow!("{}: {error}", path.display()))?;
-        anyhow::ensure!(
-            report["inputs"]["runtimeHash"] == current_runtime_hash
-                && report["inputs"]["benchmarkHash"] == current_benchmark_hash,
-            "{} is stale for the current source",
-            path.display()
-        );
+        if let Some((current_runtime_hash, current_benchmark_hash)) = &current_hashes {
+            anyhow::ensure!(
+                report["inputs"]["runtimeHash"] == *current_runtime_hash
+                    && report["inputs"]["benchmarkHash"] == *current_benchmark_hash,
+                "{} is stale for the current source (report runtime/benchmark: {}/{}, current: {}/{})",
+                path.display(),
+                report["inputs"]["runtimeHash"],
+                report["inputs"]["benchmarkHash"],
+                current_runtime_hash,
+                current_benchmark_hash,
+            );
+        }
         anyhow::ensure!(
             report["sizesBytes"] == json!([4096, 16384, 65536]),
             "{} does not use the calibrated requested 4/16/64 KiB size matrix",

--- a/tests/typescript_transform_latency/README.md
+++ b/tests/typescript_transform_latency/README.md
@@ -36,8 +36,10 @@ API samples cover dense inputs through 64 KiB on the recorded host, target, and
 three-sample profile. The calibration observed 64-KiB direct-API maxima at or below
 21 ms in all four P2/P3 strip/transform profiles; a conservative 25 ms maximum is
 the accepted local bound for this exact profile. This is evidence, not a CI
-threshold or a general upper bound. In strip mode,
-the separately timed prepared-ESM case attributes the much larger module latency to
-compilation of whitespace-preserving output after transformation. GOL-347 owns the
-phase-level compiler profiling and any measured optimization for that separate
-bottleneck; end-to-end strip-mode ESM latency is not considered acceptable here.
+threshold or a general upper bound. In strip mode, the separately timed
+prepared-ESM case reproduces nearly all of the much larger ESM module latency after
+transformation, while the same stripped output completes inline in about 203 ms and
+through CommonJS in about 370 ms. This localizes the separate bottleneck to the ESM
+module-loading path rather than generic compilation of whitespace-preserving
+output. GOL-347 owns phase-level profiling and any measured optimization for that
+path; end-to-end strip-mode ESM latency is not considered acceptable here.

--- a/tests/typescript_transform_latency/README.md
+++ b/tests/typescript_transform_latency/README.md
@@ -1,0 +1,43 @@
+# TypeScript transform latency
+
+This manual suite measures the public synchronous transform API plus four execution
+paths: inline source, entry modules, ESM imports, and CommonJS loads. It runs
+increasing source sizes in both strip-only and transform modes for P2 and P3.
+The ESM matrix also imports output prepared by the direct API outside the timed
+region, separating native transformation from downstream module compilation.
+
+The largest size also records timeout and cancellation completion latency. A
+same-runtime timer measures sibling responsiveness while the public synchronous
+transform API is active, compared with an isolated timer baseline. Wasmtime's
+instance-wide guest linear-memory high-water mark is recorded after repeated fresh
+execution jobs. Transform profiles include an enum so transform-required syntax is
+covered in addition to the cross-mode erasable source. The timings are descriptive
+local evidence, not CI thresholds.
+
+Run the four bounded profiles from the repository root:
+
+```sh
+tests/typescript_transform_latency/run.sh
+```
+
+Validate checked-in report contracts without executing workloads:
+
+```sh
+tests/typescript_transform_latency/run.sh --check
+```
+
+Override the defaults with `TYPESCRIPT_TRANSFORM_LATENCY_SIZES` (a comma-separated,
+strictly increasing byte list) and `TYPESCRIPT_TRANSFORM_LATENCY_ITERATIONS` (at
+least three). Each sample uses a fresh execution job and a unique module path; no
+QuickJS runtime, Wasmtime store, or component instance is reused across reports.
+
+The documented native-transform bound is deliberately narrow: the direct public
+API samples cover dense inputs through 64 KiB on the recorded host, target, and
+three-sample profile. The calibration observed 64-KiB direct-API maxima at or below
+20 ms in all four P2/P3 strip/transform profiles; a conservative 25 ms maximum is
+the accepted local bound for this exact profile. This is evidence, not a CI
+threshold or a general upper bound. In strip mode,
+the separately timed prepared-ESM case attributes the much larger module latency to
+compilation of whitespace-preserving output after transformation. GOL-347 owns the
+phase-level compiler profiling and any measured optimization for that separate
+bottleneck; end-to-end strip-mode ESM latency is not considered acceptable here.

--- a/tests/typescript_transform_latency/README.md
+++ b/tests/typescript_transform_latency/README.md
@@ -34,7 +34,7 @@ QuickJS runtime, Wasmtime store, or component instance is reused across reports.
 The documented native-transform bound is deliberately narrow: the direct public
 API samples cover dense inputs through 64 KiB on the recorded host, target, and
 three-sample profile. The calibration observed 64-KiB direct-API maxima at or below
-20 ms in all four P2/P3 strip/transform profiles; a conservative 25 ms maximum is
+21 ms in all four P2/P3 strip/transform profiles; a conservative 25 ms maximum is
 the accepted local bound for this exact profile. This is evidence, not a CI
 threshold or a general upper bound. In strip mode,
 the separately timed prepared-ESM case attributes the much larger module latency to

--- a/tests/typescript_transform_latency/README.md
+++ b/tests/typescript_transform_latency/README.md
@@ -38,8 +38,9 @@ three-sample profile. The calibration observed 64-KiB direct-API maxima at or be
 the accepted local bound for this exact profile. This is evidence, not a CI
 threshold or a general upper bound. In strip mode, the separately timed
 prepared-ESM case reproduces nearly all of the much larger ESM module latency after
-transformation, while the same stripped output completes inline in about 203 ms and
-through CommonJS in about 370 ms. This localizes the separate bottleneck to the ESM
-module-loading path rather than generic compilation of whitespace-preserving
-output. GOL-347 owns phase-level profiling and any measured optimization for that
-path; end-to-end strip-mode ESM latency is not considered acceptable here.
+transformation, while similarly sized inputs with the same dense stripped padding
+complete inline in about 203 ms and through CommonJS in about 370 ms. This localizes
+the separate bottleneck to the ESM module-loading path rather than generic
+compilation of whitespace-preserving output. GOL-347 owns phase-level profiling and
+any measured optimization for that path; end-to-end strip-mode ESM latency is not
+considered acceptable here.

--- a/tests/typescript_transform_latency/README.md
+++ b/tests/typescript_transform_latency/README.md
@@ -6,7 +6,7 @@ increasing source sizes in both strip-only and transform modes for P2 and P3.
 The ESM matrix also imports output prepared by the direct API outside the timed
 region, separating native transformation from downstream module compilation.
 
-The largest size also records timeout and cancellation completion latency. A
+The largest requested size also records timeout and cancellation completion latency. A
 same-runtime timer measures sibling responsiveness while the public synchronous
 transform API is active, compared with an isolated timer baseline. Wasmtime's
 instance-wide guest linear-memory high-water mark is recorded after repeated fresh
@@ -27,20 +27,23 @@ tests/typescript_transform_latency/run.sh --check
 ```
 
 Override the defaults with `TYPESCRIPT_TRANSFORM_LATENCY_SIZES` (a comma-separated,
-strictly increasing byte list) and `TYPESCRIPT_TRANSFORM_LATENCY_ITERATIONS` (at
-least three). Each sample uses a fresh execution job and a unique module path; no
-QuickJS runtime, Wasmtime store, or component instance is reused across reports.
+strictly increasing requested-byte target list) and
+`TYPESCRIPT_TRANSFORM_LATENCY_ITERATIONS` (at least three). Each execution-path
+sample uses a fresh execution job and, where filesystem-backed, a unique module
+path; direct API samples run in the report's outer runtime. No QuickJS runtime,
+Wasmtime store, or component instance is reused across reports.
 
 The documented native-transform bound is deliberately narrow: the direct public
-API samples cover dense inputs through 64 KiB on the recorded host, target, and
-three-sample profile. The calibration observed 64-KiB direct-API maxima at or below
-21 ms in all four P2/P3 strip/transform profiles; a conservative 25 ms maximum is
-the accepted local bound for this exact profile. This is evidence, not a CI
-threshold or a general upper bound. In strip mode, the separately timed
-prepared-ESM case reproduces nearly all of the much larger ESM module latency after
-transformation, while similarly sized inputs with the same dense stripped padding
-complete inline in about 203 ms and through CommonJS in about 370 ms. This localizes
-the separate bottleneck to the ESM module-loading path rather than generic
-compilation of whitespace-preserving output. GOL-347 owns phase-level profiling and
-any measured optimization for that path; end-to-end strip-mode ESM latency is not
-considered acceptable here.
+API samples cover dense requested-size profiles through 64 KiB on the recorded
+three-sample macOS arm64 host and target combinations. The calibration observed the
+requested 64-KiB direct-API maxima at or below 21 ms in all four P2/P3
+strip/transform profiles; a conservative 25 ms maximum is the accepted local bound
+for those exact profiles. This is evidence, not a CI threshold or a general upper
+bound. On those same profiles, the strip-mode prepared-ESM case reproduces nearly
+all of the roughly 11-second ESM module latency after transformation, while inputs
+from the same requested 64-KiB profile with dense stripped padding complete inline
+in about 203 ms and through CommonJS in about 370 ms. This localizes the separate
+bottleneck to the ESM module-loading path rather than generic compilation of
+whitespace-preserving output. GOL-347 owns phase-level profiling and any measured
+optimization for that path; end-to-end strip-mode ESM latency is not considered
+acceptable here.

--- a/tests/typescript_transform_latency/README.md
+++ b/tests/typescript_transform_latency/README.md
@@ -26,6 +26,12 @@ Validate checked-in report contracts without executing workloads:
 tests/typescript_transform_latency/run.sh --check
 ```
 
+To additionally require that the historical reports were captured from the
+current runtime and benchmark inputs, use `--check-current`. This stricter check
+is expected to fail after relevant source changes until a new measurement matrix
+is intentionally captured; do not rewrite capture hashes without rerunning the
+workloads.
+
 Override the defaults with `TYPESCRIPT_TRANSFORM_LATENCY_SIZES` (a comma-separated,
 strictly increasing requested-byte target list) and
 `TYPESCRIPT_TRANSFORM_LATENCY_ITERATIONS` (at least three). Each execution-path

--- a/tests/typescript_transform_latency/results/2026-09-01-p2-strip-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p2-strip-macos-aarch64.json
@@ -896,7 +896,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,

--- a/tests/typescript_transform_latency/results/2026-09-01-p2-strip-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p2-strip-macos-aarch64.json
@@ -1,0 +1,918 @@
+{
+  "cases": [
+    {
+      "kind": "api",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 2.8770839999997406,
+        "medianMs": 1.3828749999993306,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 8.154791,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 2.8770839999997406,
+              "kind": "api",
+              "outputBytes": 4190,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 2.213417,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.3828749999993306,
+              "kind": "api",
+              "outputBytes": 4190,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 1.8682919999999998,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.3636659999974654,
+              "kind": "api",
+              "outputBytes": 4190,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 194.06300000000192,
+        "medianMs": 192.77816600000008,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 193.096458,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 192.4394580000007,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 193.626458,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 192.77816600000008,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 194.94245800000002,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 194.06300000000192,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 253.28641700000296,
+        "medianMs": 245.84083400000236,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 254.263083,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 253.28641700000296,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 246.843875,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 245.84083400000236,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 240.106042,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 238.86912500000108,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 245.45366600000125,
+        "medianMs": 241.39141599999857,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 242.37225,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 241.39141599999857,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 239.502667,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 238.65441699999792,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 246.2065,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 245.45366600000125,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 234.70866699999897,
+        "medianMs": 232.65387499999997,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 243.39112500000002,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 232.65387499999997,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 240.644208,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 230.24625000000017,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 245.64575,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 234.70866699999897,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 198.59424999999828,
+        "medianMs": 193.80566700000057,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 199.41412499999998,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 198.59424999999828,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 194.713166,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 193.80566700000057,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 191.956709,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 190.83379200000127,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 5.550125000001572,
+        "medianMs": 5.103583999996772,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 6.145875,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 4.948041999999987,
+              "kind": "api",
+              "outputBytes": 16464,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 6.574958,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.550125000001572,
+              "kind": "api",
+              "outputBytes": 16464,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 6.2955,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.103583999996772,
+              "kind": "api",
+              "outputBytes": 16464,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 185.0116249999992,
+        "medianMs": 183.74716700000135,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20250624,
+            "outerWallMs": 184.83787500000003,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 183.74716700000135,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 181.9545,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 180.8371670000015,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 186.215125,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 185.0116249999992,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 904.0727079999996,
+        "medianMs": 903.2578329999996,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 904.04975,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 902.6623330000002,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 904.3656249999999,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 903.2578329999996,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 905.286834,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 904.0727079999996,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 901.8379999999996,
+        "medianMs": 900.909125,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 902.977458,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 901.8379999999996,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 902.081834,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 900.909125,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 899.258375,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 898.0517080000009,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 873.9858750000003,
+        "medianMs": 867.5398330000007,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 904.250542,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 866.2756250000002,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 904.9795,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 867.5398330000007,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 910.8125419999999,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 873.9858750000003,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 232.2219580000001,
+        "medianMs": 230.6682499999988,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 231.842125,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 230.6682499999988,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 228.680083,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 227.61162499999955,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 233.565458,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 232.2219580000001,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 20.5020829999994,
+        "medianMs": 19.45629200000076,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 23.202375,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 20.5020829999994,
+              "kind": "api",
+              "outputBytes": 65634,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 21.745125,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 19.236041999998633,
+              "kind": "api",
+              "outputBytes": 65634,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 21.904417,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 19.45629200000076,
+              "kind": "api",
+              "outputBytes": 65634,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 203.19824999999943,
+        "medianMs": 202.9507080000003,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 205.596542,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 202.9507080000003,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 205.92779099999998,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 203.19824999999943,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 205.387334,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 202.466124999999,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 11136.495791,
+        "medianMs": 11040.891541999998,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11043.846833,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11040.891541999998,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11139.602417,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11136.495791,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11009.125083,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11006.025999999998,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 11248.11499999999,
+        "medianMs": 11094.260749999989,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 10995.456415999999,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 10992.569957999996,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11251.577583,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11248.11499999999,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11097.703333,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11094.260749999989,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 10978.504750000007,
+        "medianMs": 10944.886209000004,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11088.633333,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 10944.886209000004,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11045.548208,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 10901.547749999998,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11126.390417,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 10978.504750000007,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 378.5278340000077,
+        "medianMs": 372.50912499999686,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 375.700875,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 372.50912499999686,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 381.13741699999997,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 378.5278340000077,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 373.97925,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 371.2287500000093,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "component": {
+    "blake3": "ccd30094b61e69913d54118a37495463d7ba24e9aa43fdc7085ec024ccdbf162",
+    "buildMs": 30495.357584,
+    "bytes": 154624624,
+    "instantiateMs": 16082.761792
+  },
+  "concurrencyAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22413312,
+    "outerWallMs": 28.767834,
+    "result": {
+      "baselineTimerMs": 2.6537919999973383,
+      "elapsedMs": 23.72329200000968,
+      "incrementalSiblingDelayMs": 21.039750000010827,
+      "outputBytes": 65634,
+      "requestedMs": 1,
+      "siblingIssuedMs": 23.693542000008165,
+      "transformMs": 20.779667000009795
+    }
+  },
+  "controlsAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22413312,
+    "outerWallMs": 418.829791,
+    "result": {
+      "cancellation": {
+        "cancelled": true,
+        "completedMs": 207.7271250000049,
+        "issuedMs": 198.6288329999952,
+        "message": "execution job cancelled",
+        "requestedMs": 1
+      },
+      "timeout": {
+        "completedMs": 208.5919160000049,
+        "message": "execution job timed out",
+        "timedOut": true
+      }
+    }
+  },
+  "environment": {
+    "arch": "aarch64",
+    "artifactCache": null,
+    "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)",
+    "commitHint": "058b904201154bd2f89e1d07dd56629cbbcfbe67",
+    "dirty": false,
+    "os": "macos",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
+    "unoptimized": null,
+    "wasmtimeCache": null
+  },
+  "inputs": {
+    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
+  },
+  "iterations": 3,
+  "mode": "strip",
+  "notes": [
+    "manual local measurement; timings are not CI thresholds",
+    "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
+    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
+  ],
+  "schemaVersion": 1,
+  "sizesBytes": [
+    4096,
+    16384,
+    65536
+  ],
+  "target": "p2",
+  "wasmLinearMemoryHighWaterBytes": 22413312
+}

--- a/tests/typescript_transform_latency/results/2026-09-01-p2-strip-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p2-strip-macos-aarch64.json
@@ -896,7 +896,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
+    "benchmarkHash": "9c271ca9f5517af7f4b5cc7638d3398b2a844e94e85c9e6775382aa0b1bc0a8f",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,
@@ -904,7 +904,7 @@
   "notes": [
     "manual local measurement; timings are not CI thresholds",
     "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
-    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "the timeout deadline and cancellation timer are armed before the synchronous native transform; the cancellation call is delivered after the outer runtime regains control",
     "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
   ],
   "schemaVersion": 1,

--- a/tests/typescript_transform_latency/results/2026-09-01-p2-transform-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p2-transform-macos-aarch64.json
@@ -1037,7 +1037,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,

--- a/tests/typescript_transform_latency/results/2026-09-01-p2-transform-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p2-transform-macos-aarch64.json
@@ -1,0 +1,1059 @@
+{
+  "cases": [
+    {
+      "kind": "api",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 4.1852079999989655,
+        "medianMs": 1.6069160000006375,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 7.698333,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 4.1852079999989655,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 1.9805000000000001,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.31329199999891,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 2.337792,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.6069160000006375,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 203.51545799999803,
+        "medianMs": 191.10612499999843,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 204.272291,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 203.51545799999803,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 191.364708,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 190.3869579999991,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 191.950583,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 191.10612499999843,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 202.3740829999988,
+        "medianMs": 199.81837499999892,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 203.596041,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 202.3740829999988,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 200.71529099999998,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 199.81837499999892,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 199.675667,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 198.67820899999788,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 199.1080839999995,
+        "medianMs": 196.4955829999999,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 194.449792,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 193.77391699999865,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 199.864833,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 199.1080839999995,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 197.574666,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 196.4955829999999,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 192.5927499999998,
+        "medianMs": 186.1592500000006,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 189.1675,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 186.1592500000006,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 195.872792,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 192.5927499999998,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 186.966667,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 184.03466599999956,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 195.84325000000172,
+        "medianMs": 195.7699590000011,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 196.5605,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 195.7699590000011,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 195.550916,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 194.7901249999995,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 196.568084,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 195.84325000000172,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "transform-only",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 185.82458300000144,
+        "medianMs": 183.89858399999864,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 184.80966600000002,
+            "result": {
+              "actualSourceBytes": 4193,
+              "elapsedMs": 183.89858399999864,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 181.712959,
+            "result": {
+              "actualSourceBytes": 4193,
+              "elapsedMs": 180.84258399999817,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 186.63708400000002,
+            "result": {
+              "actualSourceBytes": 4193,
+              "elapsedMs": 185.82458300000144,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 4.916124999999738,
+        "medianMs": 4.893166999998357,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 6.031625,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 4.916124999999738,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 5.785958,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 4.893166999998357,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 5.725458,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 4.816291999999521,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 197.08241700000144,
+        "medianMs": 192.2531250000029,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 191.59475,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 190.4947919999977,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 193.41445900000002,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 192.2531250000029,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 198.30175,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 197.08241700000144,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 299.0376670000005,
+        "medianMs": 283.86162500000137,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 285.292541,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 283.86162500000137,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 300.725959,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 299.0376670000005,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 264.205292,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 262.80204200000117,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 302.8170000000009,
+        "medianMs": 250.72099999999955,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 252.31058299999998,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 250.72099999999955,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 304.090167,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 302.8170000000009,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 239.793833,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 238.4511249999996,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 202.5224160000016,
+        "medianMs": 193.8763340000005,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 210.150584,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 202.5224160000016,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 200.706167,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 193.8763340000005,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 196.37754199999998,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 188.17225000000144,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 236.5767080000005,
+        "medianMs": 234.20395800000188,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 236.208084,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 234.20395800000188,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 234.74962499999998,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 233.2535829999997,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 237.769,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 236.5767080000005,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "transform-only",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 200.28300000000127,
+        "medianMs": 198.62562500000055,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 201.653458,
+            "result": {
+              "actualSourceBytes": 16467,
+              "elapsedMs": 200.28300000000127,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 199.982375,
+            "result": {
+              "actualSourceBytes": 16467,
+              "elapsedMs": 198.62562500000055,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 197.55249999999998,
+            "result": {
+              "actualSourceBytes": 16467,
+              "elapsedMs": 196.27620900000147,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 19.03204200000073,
+        "medianMs": 18.98729099999946,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 20.914458,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 18.31462499999907,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 21.393834000000002,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 19.03204200000073,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 21.513541,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 18.98729099999946,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 209.92562499999983,
+        "medianMs": 200.90462500000103,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 212.909,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 209.92562499999983,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 203.43275,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 200.90462500000103,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 200.232833,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 197.71662500000093,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 323.21979199999987,
+        "medianMs": 322.43195800000103,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 325.039875,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 322.43195800000103,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 325.76375,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 323.21979199999987,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 324.50183300000003,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 322.0746659999986,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 331.0949579999997,
+        "medianMs": 323.79745899999944,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 333.487209,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 331.0949579999997,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 326.21245799999997,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 323.79745899999944,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 324.130625,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 321.55624999999964,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 224.52995799999917,
+        "medianMs": 198.7046250000003,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 220.52508300000002,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 198.7046250000003,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 253.093083,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 224.52995799999917,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 211.7245,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 189.0867500000004,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 346.4256659999992,
+        "medianMs": 343.44066700000076,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 342.675208,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 340.1129579999997,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 348.89300000000003,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 346.4256659999992,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 346.138,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 343.44066700000076,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "transform-only",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 204.24629099999947,
+        "medianMs": 203.6168340000004,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22413312,
+            "outerWallMs": 206.18525,
+            "result": {
+              "actualSourceBytes": 65637,
+              "elapsedMs": 203.6168340000004,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22413312,
+            "outerWallMs": 203.041125,
+            "result": {
+              "actualSourceBytes": 65637,
+              "elapsedMs": 200.10629199999855,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22413312,
+            "outerWallMs": 206.909375,
+            "result": {
+              "actualSourceBytes": 65637,
+              "elapsedMs": 204.24629099999947,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "component": {
+    "blake3": "f7864a6858df32e93357f04ed97bc6479f897db74c806e1661abdfbf7a63a493",
+    "buildMs": 30107.629041,
+    "bytes": 154665477,
+    "instantiateMs": 15407.022916
+  },
+  "concurrencyAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22544384,
+    "outerWallMs": 26.568624999999997,
+    "result": {
+      "baselineTimerMs": 2.631500000001324,
+      "elapsedMs": 21.58454199999869,
+      "incrementalSiblingDelayMs": 18.926666999997902,
+      "outputBytes": 49,
+      "requestedMs": 1,
+      "siblingIssuedMs": 21.55816699999923,
+      "transformMs": 18.74179200000071
+    }
+  },
+  "controlsAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22544384,
+    "outerWallMs": 414.14504200000005,
+    "result": {
+      "cancellation": {
+        "cancelled": true,
+        "completedMs": 205.5602080000008,
+        "issuedMs": 195.56233299999985,
+        "message": "execution job cancelled",
+        "requestedMs": 1
+      },
+      "timeout": {
+        "completedMs": 205.9060840000002,
+        "message": "execution job timed out",
+        "timedOut": true
+      }
+    }
+  },
+  "environment": {
+    "arch": "aarch64",
+    "artifactCache": null,
+    "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)",
+    "commitHint": "058b904201154bd2f89e1d07dd56629cbbcfbe67",
+    "dirty": false,
+    "os": "macos",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
+    "unoptimized": null,
+    "wasmtimeCache": null
+  },
+  "inputs": {
+    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
+  },
+  "iterations": 3,
+  "mode": "transform",
+  "notes": [
+    "manual local measurement; timings are not CI thresholds",
+    "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
+    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
+  ],
+  "schemaVersion": 1,
+  "sizesBytes": [
+    4096,
+    16384,
+    65536
+  ],
+  "target": "p2",
+  "wasmLinearMemoryHighWaterBytes": 22544384
+}

--- a/tests/typescript_transform_latency/results/2026-09-01-p2-transform-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p2-transform-macos-aarch64.json
@@ -1037,7 +1037,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
+    "benchmarkHash": "9c271ca9f5517af7f4b5cc7638d3398b2a844e94e85c9e6775382aa0b1bc0a8f",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,
@@ -1045,7 +1045,7 @@
   "notes": [
     "manual local measurement; timings are not CI thresholds",
     "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
-    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "the timeout deadline and cancellation timer are armed before the synchronous native transform; the cancellation call is delivered after the outer runtime regains control",
     "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
   ],
   "schemaVersion": 1,

--- a/tests/typescript_transform_latency/results/2026-09-01-p3-strip-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p3-strip-macos-aarch64.json
@@ -1,0 +1,918 @@
+{
+  "cases": [
+    {
+      "kind": "api",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 3.4715829999986454,
+        "medianMs": 1.3589590000010503,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 8.856375,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 3.4715829999986454,
+              "kind": "api",
+              "outputBytes": 4190,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 1.9580829999999998,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.3589590000010503,
+              "kind": "api",
+              "outputBytes": 4190,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 1.7829169999999999,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.320292000000336,
+              "kind": "api",
+              "outputBytes": 4190,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 177.4370839999974,
+        "medianMs": 176.4188749999994,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 177.989416,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 177.4370839999974,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 177.073958,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 176.4188749999994,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 175.799458,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 175.15533399999913,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 231.9571250000008,
+        "medianMs": 230.77879100000064,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 232.687708,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 231.9571250000008,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 231.412792,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 230.77879100000064,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 231.452125,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 230.74108299999716,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 255.97087499999907,
+        "medianMs": 233.8927919999987,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 234.30954100000002,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 233.4382079999996,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 234.560792,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 233.8927919999987,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 256.68649999999997,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 255.97087499999907,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 245.9720419999976,
+        "medianMs": 243.6025840000002,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 263.94266700000003,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 245.9720419999976,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 253.34637500000002,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 240.82445899999948,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 255.2665,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 243.6025840000002,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 209.9944170000017,
+        "medianMs": 209.5323749999989,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 210.787125,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 209.5323749999989,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 211.13750000000002,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 209.9944170000017,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 205.245167,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 204.31866699999773,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 5.438958000000639,
+        "medianMs": 5.377207999999882,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 7.213584,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.438958000000639,
+              "kind": "api",
+              "outputBytes": 16464,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 6.514542,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.218834000001152,
+              "kind": "api",
+              "outputBytes": 16464,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 6.632542,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.377207999999882,
+              "kind": "api",
+              "outputBytes": 16464,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 196.6645830000016,
+        "medianMs": 196.53862499999923,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 197.602667,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 196.53862499999923,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 197.806667,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 196.6645830000016,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 192.875666,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 191.5420410000006,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 916.054250000001,
+        "medianMs": 915.741,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 916.927333,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 915.741,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 917.2905000000001,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 916.054250000001,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 908.597125,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 907.4824589999988,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 909.4808329999996,
+        "medianMs": 908.7662500000006,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 910.032875,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 908.7662500000006,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 910.682291,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 909.4808329999996,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 906.067541,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 904.9943749999984,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 877.1025419999987,
+        "medianMs": 873.3861660000002,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 905.736083,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 868.3579999999984,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 911.434083,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 873.3861660000002,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 915.203875,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 877.1025419999987,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 239.75629200000003,
+        "medianMs": 237.40016599999944,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 238.712709,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 237.40016599999944,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 240.863458,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 239.75629200000003,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 233.033958,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 231.9375830000008,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 20.77395799999977,
+        "medianMs": 19.615875000001324,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 21.614541000000003,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 19.26679200000035,
+              "kind": "api",
+              "outputBytes": 65634,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 23.082166,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 20.77395799999977,
+              "kind": "api",
+              "outputBytes": 65634,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 22.470875,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 19.615875000001324,
+              "kind": "api",
+              "outputBytes": 65634,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 212.32816599999933,
+        "medianMs": 207.63245800000004,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 214.81074999999998,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 212.32816599999933,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 210.43212499999998,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 207.63245800000004,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 203.678791,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 201.06620900000053,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 11052.629749999996,
+        "medianMs": 11036.760375000003,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11024.233208,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11021.145042000002,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11055.771917,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11052.629749999996,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11039.583416,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11036.760375000003,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 11351.273542000004,
+        "medianMs": 11169.502832999991,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11042.731625,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11040.134917000005,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11353.985166999999,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11351.273542000004,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11172.074375,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11169.502832999991,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 11024.513082999998,
+        "medianMs": 10934.687334000002,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11170.195749999999,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 11024.513082999998,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11058.882209,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 10913.332916,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 11083.307584,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 10934.687334000002,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 370.36125000000175,
+        "medianMs": 366.0301670000045,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 365.47533300000003,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 362.4177079999936,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 373.14825,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 370.36125000000175,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22151168,
+            "outerWallMs": 368.5005,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 366.0301670000045,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "component": {
+    "blake3": "a18b24b2270bbde1ff5f16e2ba31b637ec476043f6b0d05ae6f8cebdb71edaf7",
+    "buildMs": 29196.525708,
+    "bytes": 152426759,
+    "instantiateMs": 14863.789999999999
+  },
+  "concurrencyAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22413312,
+    "outerWallMs": 29.148833999999997,
+    "result": {
+      "baselineTimerMs": 2.43241599999601,
+      "elapsedMs": 24.54570899999817,
+      "incrementalSiblingDelayMs": 22.0964590000076,
+      "outputBytes": 65634,
+      "requestedMs": 1,
+      "siblingIssuedMs": 24.52887500000361,
+      "transformMs": 21.92041700000118
+    }
+  },
+  "controlsAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22413312,
+    "outerWallMs": 411.56100000000004,
+    "result": {
+      "cancellation": {
+        "cancelled": true,
+        "completedMs": 203.83533299999544,
+        "issuedMs": 194.94354100000055,
+        "message": "execution job cancelled",
+        "requestedMs": 1
+      },
+      "timeout": {
+        "completedMs": 205.5270840000012,
+        "message": "execution job timed out",
+        "timedOut": true
+      }
+    }
+  },
+  "environment": {
+    "arch": "aarch64",
+    "artifactCache": null,
+    "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)",
+    "commitHint": "058b904201154bd2f89e1d07dd56629cbbcfbe67",
+    "dirty": false,
+    "os": "macos",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
+    "unoptimized": null,
+    "wasmtimeCache": null
+  },
+  "inputs": {
+    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
+  },
+  "iterations": 3,
+  "mode": "strip",
+  "notes": [
+    "manual local measurement; timings are not CI thresholds",
+    "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
+    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
+  ],
+  "schemaVersion": 1,
+  "sizesBytes": [
+    4096,
+    16384,
+    65536
+  ],
+  "target": "p3",
+  "wasmLinearMemoryHighWaterBytes": 22413312
+}

--- a/tests/typescript_transform_latency/results/2026-09-01-p3-strip-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p3-strip-macos-aarch64.json
@@ -896,7 +896,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,

--- a/tests/typescript_transform_latency/results/2026-09-01-p3-strip-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p3-strip-macos-aarch64.json
@@ -896,7 +896,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
+    "benchmarkHash": "9c271ca9f5517af7f4b5cc7638d3398b2a844e94e85c9e6775382aa0b1bc0a8f",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,
@@ -904,7 +904,7 @@
   "notes": [
     "manual local measurement; timings are not CI thresholds",
     "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
-    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "the timeout deadline and cancellation timer are armed before the synchronous native transform; the cancellation call is delivered after the outer runtime regains control",
     "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
   ],
   "schemaVersion": 1,

--- a/tests/typescript_transform_latency/results/2026-09-01-p3-transform-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p3-transform-macos-aarch64.json
@@ -1037,7 +1037,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,

--- a/tests/typescript_transform_latency/results/2026-09-01-p3-transform-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p3-transform-macos-aarch64.json
@@ -1,0 +1,1059 @@
+{
+  "cases": [
+    {
+      "kind": "api",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 4.92329200000313,
+        "medianMs": 1.7232499999990978,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 9.066416,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 4.92329200000313,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 2.255667,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.5434999999997672,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 12648448,
+            "outerWallMs": 2.445792,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 1.7232499999990978,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 4096
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 196.0192090000019,
+        "medianMs": 193.28579199999876,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 196.69229199999998,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 196.0192090000019,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19660800,
+            "outerWallMs": 192.868208,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 191.63033399999767,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 194.077084,
+            "result": {
+              "actualSourceBytes": 4158,
+              "elapsedMs": 193.28579199999876,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 203.46879199999967,
+        "medianMs": 203.02408400000056,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 203.376542,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 202.2744160000002,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 203.80083299999998,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 203.02408400000056,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 204.26587500000002,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 203.46879199999967,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 202.54300000000148,
+        "medianMs": 201.89691700000185,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19726336,
+            "outerWallMs": 203.558708,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 202.54300000000148,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 202.74975,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 201.89691700000185,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 202.349625,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 201.5948339999995,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 190.83241700000144,
+        "medianMs": 190.47520799999984,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 194.08149999999998,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 190.83241700000144,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 193.3505,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 190.47520799999984,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19791872,
+            "outerWallMs": 193.434375,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 190.3537499999984,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 202.91345800000272,
+        "medianMs": 202.61854200000016,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 203.983834,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 202.91345800000272,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 201.590125,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 200.40329199999903,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 203.408708,
+            "result": {
+              "actualSourceBytes": 4190,
+              "elapsedMs": 202.61854200000016,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "transform-only",
+      "sourceBytes": 4096,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 201.20429199999853,
+        "medianMs": 199.2011249999996,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 196.18075,
+            "result": {
+              "actualSourceBytes": 4193,
+              "elapsedMs": 195.18920900000012,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19857408,
+            "outerWallMs": 200.205041,
+            "result": {
+              "actualSourceBytes": 4193,
+              "elapsedMs": 199.2011249999996,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 202.59925,
+            "result": {
+              "actualSourceBytes": 4193,
+              "elapsedMs": 201.20429199999853,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 4096,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 5.607958000000508,
+        "medianMs": 5.453207999998995,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 6.664459,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.453207999998995,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 6.846459,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.607958000000508,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 19922944,
+            "outerWallMs": 6.4479999999999995,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 5.161916999997629,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 16384
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 202.21366599999965,
+        "medianMs": 200.90179200000057,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 202.11337500000002,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 200.90179200000057,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20316160,
+            "outerWallMs": 203.498375,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 202.21366599999965,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 198.9045,
+            "result": {
+              "actualSourceBytes": 16432,
+              "elapsedMs": 197.7479170000006,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 231.24175000000105,
+        "medianMs": 229.840833000002,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 232.443459,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 231.24175000000105,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 229.22525,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 228.17908399999945,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20381696,
+            "outerWallMs": 230.959208,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 229.840833000002,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 238.63079199999993,
+        "medianMs": 232.05412500000057,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 233.403083,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 232.05412500000057,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 233.108958,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 231.8668749999997,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 239.961791,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 238.63079199999993,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 189.19083299999875,
+        "medianMs": 187.62770900000032,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 193.056208,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 185.9352910000016,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 197.659667,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 189.19083299999875,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20447232,
+            "outerWallMs": 194.73237500000002,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 187.62770900000032,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 270.4706669999996,
+        "medianMs": 244.5450409999994,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 244.533625,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 243.10345900000175,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 246.090375,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 244.5450409999994,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 273.56629100000004,
+            "result": {
+              "actualSourceBytes": 16464,
+              "elapsedMs": 270.4706669999996,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "transform-only",
+      "sourceBytes": 16384,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 202.29983400000128,
+        "medianMs": 198.75395799999933,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 200.13879200000002,
+            "result": {
+              "actualSourceBytes": 16467,
+              "elapsedMs": 198.75395799999933,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20512768,
+            "outerWallMs": 203.715709,
+            "result": {
+              "actualSourceBytes": 16467,
+              "elapsedMs": 202.29983400000128,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 196.558208,
+            "result": {
+              "actualSourceBytes": 16467,
+              "elapsedMs": 195.0536250000005,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 16384,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "api",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 18.78083399999923,
+        "medianMs": 18.279375000000073,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 21.547916999999998,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 18.78083399999923,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 20.910999999999998,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 18.279375000000073,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 20578304,
+            "outerWallMs": 20.532584,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 18.072040999999444,
+              "kind": "api",
+              "outputBytes": 49,
+              "overflowed": false,
+              "requestedSourceBytes": 65536
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "inline",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 210.63966700000128,
+        "medianMs": 210.56608400000005,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 212.900917,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 210.56608400000005,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 213.15004100000002,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 210.63966700000128,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 213.08829200000002,
+            "result": {
+              "actualSourceBytes": 65602,
+              "elapsedMs": 210.5042089999988,
+              "kind": "inline",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "entry",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 385.0064160000002,
+        "medianMs": 356.6277919999993,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 341.85725,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 338.8820830000004,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 388.886208,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 385.0064160000002,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 360.003833,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 356.6277919999993,
+              "kind": "entry",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 342.3850419999999,
+        "medianMs": 341.15016599999944,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 344.210167,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 341.15016599999944,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 338.565416,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 335.91749999999956,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 345.238417,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 342.3850419999999,
+              "kind": "esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "prepared-esm",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 198.4002079999991,
+        "medianMs": 191.90791700000045,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 221.176459,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 198.4002079999991,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 212.95837500000002,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 190.12862499999935,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 214.98775,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 191.90791700000045,
+              "kind": "prepared-esm",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "cjs",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 362.0872500000005,
+        "medianMs": 355.45387499999924,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 364.90450000000004,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 362.0872500000005,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 357.782292,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 354.8786249999994,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22216704,
+            "outerWallMs": 358.012375,
+            "result": {
+              "actualSourceBytes": 65634,
+              "elapsedMs": 355.45387499999924,
+              "kind": "cjs",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "transform-only",
+      "sourceBytes": 65536,
+      "summary": {
+        "iterations": 3,
+        "maximumMs": 215.04500000000007,
+        "medianMs": 212.55233399999997,
+        "samples": [
+          {
+            "linearMemoryHighWaterBytes": 22413312,
+            "outerWallMs": 217.54758299999997,
+            "result": {
+              "actualSourceBytes": 65637,
+              "elapsedMs": 215.04500000000007,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22413312,
+            "outerWallMs": 215.097875,
+            "result": {
+              "actualSourceBytes": 65637,
+              "elapsedMs": 212.55233399999997,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          },
+          {
+            "linearMemoryHighWaterBytes": 22413312,
+            "outerWallMs": 214.226167,
+            "result": {
+              "actualSourceBytes": 65637,
+              "elapsedMs": 211.3668749999997,
+              "kind": "transform-only",
+              "overflowed": false,
+              "requestedSourceBytes": 65536,
+              "value": 42
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "component": {
+    "blake3": "08f8e8e6b6a771a133177dbbe29cca0e8cc85fd9c345b4c6228741df9a5cb450",
+    "buildMs": 30544.315458,
+    "bytes": 152440084,
+    "instantiateMs": 18173.024709
+  },
+  "concurrencyAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22544384,
+    "outerWallMs": 27.138833,
+    "result": {
+      "baselineTimerMs": 2.9557500000009895,
+      "elapsedMs": 21.873999999999796,
+      "incrementalSiblingDelayMs": 18.900666999998062,
+      "outputBytes": 49,
+      "requestedMs": 1,
+      "siblingIssuedMs": 21.856416999999055,
+      "transformMs": 19.132125000000087
+    }
+  },
+  "controlsAtLargestSize": {
+    "linearMemoryHighWaterBytes": 22544384,
+    "outerWallMs": 424.425,
+    "result": {
+      "cancellation": {
+        "cancelled": true,
+        "completedMs": 214.18362500000148,
+        "issuedMs": 204.99483300000065,
+        "message": "execution job cancelled",
+        "requestedMs": 1
+      },
+      "timeout": {
+        "completedMs": 207.7208329999994,
+        "message": "execution job timed out",
+        "timedOut": true
+      }
+    }
+  },
+  "environment": {
+    "arch": "aarch64",
+    "artifactCache": null,
+    "cargo": "cargo 1.95.0 (f2d3ce0bd 2026-03-21)",
+    "commitHint": "058b904201154bd2f89e1d07dd56629cbbcfbe67",
+    "dirty": false,
+    "os": "macos",
+    "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
+    "unoptimized": null,
+    "wasmtimeCache": null
+  },
+  "inputs": {
+    "benchmarkHash": "88f85dfcfa3475e6cab45b5eb303bf48dd307d07306165a525c07149e4d4c24e",
+    "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
+  },
+  "iterations": 3,
+  "mode": "transform",
+  "notes": [
+    "manual local measurement; timings are not CI thresholds",
+    "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
+    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
+  ],
+  "schemaVersion": 1,
+  "sizesBytes": [
+    4096,
+    16384,
+    65536
+  ],
+  "target": "p3",
+  "wasmLinearMemoryHighWaterBytes": 22544384
+}

--- a/tests/typescript_transform_latency/results/2026-09-01-p3-transform-macos-aarch64.json
+++ b/tests/typescript_transform_latency/results/2026-09-01-p3-transform-macos-aarch64.json
@@ -1037,7 +1037,7 @@
     "wasmtimeCache": null
   },
   "inputs": {
-    "benchmarkHash": "6e7785de480a9e4cfa97f64da21ac3b0eca648aae80399e0fda003ea53380cba",
+    "benchmarkHash": "9c271ca9f5517af7f4b5cc7638d3398b2a844e94e85c9e6775382aa0b1bc0a8f",
     "runtimeHash": "791eeb5d424bbd485542532b553a58c7ecd7fc63d50c25921724032f95f17ccb"
   },
   "iterations": 3,
@@ -1045,7 +1045,7 @@
   "notes": [
     "manual local measurement; timings are not CI thresholds",
     "execution-path samples use fresh jobs and unique filesystem module paths; direct API samples run in the outer runtime",
-    "timeout and cancellation budgets are requested before the synchronous native transform",
+    "the timeout deadline and cancellation timer are armed before the synchronous native transform; the cancellation call is delivered after the outer runtime regains control",
     "linear-memory values are monotone instance-wide high-water observations, not retained-allocation measurements"
   ],
   "schemaVersion": 1,

--- a/tests/typescript_transform_latency/results/README.md
+++ b/tests/typescript_transform_latency/results/README.md
@@ -26,7 +26,8 @@ must not be described as native-transform time or preemption.
 The highest observed guest linear-memory reservation was 22,544,384 bytes. This is
 an instance-wide monotone high-water mark, not retained memory. Strip-mode prepared
 ESM reproduces nearly all of the end-to-end ESM delay after transformation has
-already finished, while inline execution is about 203 ms and CommonJS about 370 ms
-for the same stripped output. The separate bottleneck is therefore in the ESM
-module-loading path, not generic compilation of whitespace-preserving output;
-GOL-347 owns its phase-level profiling and measured mitigation.
+already finished, while similarly sized inputs with the same dense stripped padding
+complete inline in about 203 ms and through CommonJS in about 370 ms. The separate
+bottleneck is therefore in the ESM module-loading path, not generic compilation of
+whitespace-preserving output; GOL-347 owns its phase-level profiling and measured
+mitigation.

--- a/tests/typescript_transform_latency/results/README.md
+++ b/tests/typescript_transform_latency/results/README.md
@@ -5,3 +5,26 @@ Reports contain the complete path/size matrix, raw samples, control latency,
 sibling responsiveness, and the guest linear-memory high-water observation.
 
 Checked-in timings are local evidence and are not enforced as CI thresholds.
+
+## 2026-09-01 macOS arm64 baseline
+
+All values below are milliseconds at the 64-KiB input unless noted otherwise.
+
+| Target/mode | Direct API median / max | Inline median | Entry median | ESM median | Prepared ESM median | CJS median |
+|---|---:|---:|---:|---:|---:|---:|
+| P2 strip | 19.46 / 20.50 | 202.95 | 11,040.89 | 11,094.26 | 10,944.89 | 372.51 |
+| P2 transform | 18.99 / 19.03 | 200.90 | 322.43 | 323.80 | 198.70 | 343.44 |
+| P3 strip | 19.62 / 20.77 | 207.63 | 11,036.76 | 11,169.50 | 10,934.69 | 366.03 |
+| P3 transform | 18.28 / 18.78 | 210.57 | 356.63 | 341.15 | 191.91 | 355.45 |
+
+The same-runtime 1 ms timer was delayed by 18.90–22.10 ms while the synchronous
+public transform API ran. A 1 ms execution timeout completed in 205.53–208.59 ms;
+the cancellation callback was issued in 194.94–204.99 ms and completed in
+203.84–214.18 ms. Those execution-control values include fresh runtime startup and
+must not be described as native-transform time or preemption.
+
+The highest observed guest linear-memory reservation was 22,544,384 bytes. This is
+an instance-wide monotone high-water mark, not retained memory. Strip-mode prepared
+ESM reproduces nearly all of the end-to-end ESM delay after transformation has
+already finished, so GOL-347 owns phase-level profiling and measured mitigation of
+that separate module-compilation bottleneck.

--- a/tests/typescript_transform_latency/results/README.md
+++ b/tests/typescript_transform_latency/results/README.md
@@ -26,5 +26,7 @@ must not be described as native-transform time or preemption.
 The highest observed guest linear-memory reservation was 22,544,384 bytes. This is
 an instance-wide monotone high-water mark, not retained memory. Strip-mode prepared
 ESM reproduces nearly all of the end-to-end ESM delay after transformation has
-already finished, so GOL-347 owns phase-level profiling and measured mitigation of
-that separate module-compilation bottleneck.
+already finished, while inline execution is about 203 ms and CommonJS about 370 ms
+for the same stripped output. The separate bottleneck is therefore in the ESM
+module-loading path, not generic compilation of whitespace-preserving output;
+GOL-347 owns its phase-level profiling and measured mitigation.

--- a/tests/typescript_transform_latency/results/README.md
+++ b/tests/typescript_transform_latency/results/README.md
@@ -6,9 +6,20 @@ sibling responsiveness, and the guest linear-memory high-water observation.
 
 Checked-in timings are local evidence and are not enforced as CI thresholds.
 
+Each configured size is a requested source-byte target. Generated declarations and
+case-specific suffixes can make the actual source slightly larger; samples in the
+requested 64-KiB profile contain 65,602–65,637 source bytes.
+
+The reports' `environment.commitHint` records the checkout used for the workload
+capture (`058b9042`), while the input hashes are the currentness keys. The
+`benchmarkHash` was refreshed after capture only because `run.sh` gained
+validation-only source-root wiring; the recorded timings and component artifacts
+still come from the `058b9042` capture.
+
 ## 2026-09-01 macOS arm64 baseline
 
-All values below are milliseconds at the 64-KiB input unless noted otherwise.
+All values below are milliseconds for the requested 64-KiB profile unless noted
+otherwise.
 
 | Target/mode | Direct API median / max | Inline median | Entry median | ESM median | Prepared ESM median | CJS median |
 |---|---:|---:|---:|---:|---:|---:|

--- a/tests/typescript_transform_latency/results/README.md
+++ b/tests/typescript_transform_latency/results/README.md
@@ -1,0 +1,7 @@
+# Result reports
+
+`run.sh` writes one JSON report for each P2/P3 and strip/transform combination.
+Reports contain the complete path/size matrix, raw samples, control latency,
+sibling responsiveness, and the guest linear-memory high-water observation.
+
+Checked-in timings are local evidence and are not enforced as CI thresholds.

--- a/tests/typescript_transform_latency/results/README.md
+++ b/tests/typescript_transform_latency/results/README.md
@@ -16,6 +16,12 @@ capture (`058b9042`), while the input hashes are the currentness keys. The
 validation-only source-root wiring; the recorded timings and component artifacts
 still come from the `058b9042` capture.
 
+`run.sh --check` validates the checked-in report schema and complete P2/P3 by
+strip/transform matrix without claiming that historical timings describe the
+current runtime. `run.sh --check-current` additionally compares the stored input
+hashes with the checkout. A failure there requires a deliberate new measurement
+capture, not validation-only replacement of the runtime hash.
+
 ## 2026-09-01 macOS arm64 baseline
 
 All values below are milliseconds for the requested 64-KiB profile unless noted

--- a/tests/typescript_transform_latency/run.sh
+++ b/tests/typescript_transform_latency/run.sh
@@ -6,7 +6,8 @@ results_dir="$repo_root/tests/typescript_transform_latency/results"
 
 if [ "${1:-}" = "--check" ]; then
     cd "$repo_root"
-    tools/dev-test.sh p2 standard typescript_transform_latency ""
+    TYPESCRIPT_TRANSFORM_LATENCY_SOURCE_ROOT="$repo_root" \
+        tools/dev-test.sh p2 standard typescript_transform_latency ""
     exit 0
 fi
 
@@ -36,4 +37,8 @@ for target in p2 p3; do
     done
 done
 
-(cd "$repo_root" && tools/dev-test.sh p2 standard typescript_transform_latency "")
+(
+    cd "$repo_root"
+    TYPESCRIPT_TRANSFORM_LATENCY_SOURCE_ROOT="$repo_root" \
+        tools/dev-test.sh p2 standard typescript_transform_latency ""
+)

--- a/tests/typescript_transform_latency/run.sh
+++ b/tests/typescript_transform_latency/run.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+results_dir="$repo_root/tests/typescript_transform_latency/results"
+
+if [ "${1:-}" = "--check" ]; then
+    cd "$repo_root"
+    tools/dev-test.sh p2 standard typescript_transform_latency ""
+    exit 0
+fi
+
+platform=$(node -p 'process.platform')
+arch=$(node -p 'process.arch')
+case "$platform" in
+    darwin) platform=macos ;;
+    win32) platform=windows ;;
+esac
+case "$arch" in
+    arm64) arch=aarch64 ;;
+    x64) arch=x86_64 ;;
+esac
+
+mkdir -p "$results_dir"
+for target in p2 p3; do
+    for mode in strip transform; do
+        report="$results_dir/$(date +%Y-%m-%d)-$target-$mode-$platform-$arch.json"
+        (
+            cd "$repo_root"
+            TYPESCRIPT_TRANSFORM_LATENCY_MEASURE=1 \
+            TYPESCRIPT_TRANSFORM_LATENCY_MODE="$mode" \
+            TYPESCRIPT_TRANSFORM_LATENCY_REPORT="$report" \
+            TYPESCRIPT_TRANSFORM_LATENCY_SOURCE_ROOT="$repo_root" \
+            tools/dev-test.sh "$target" standard typescript_transform_latency ""
+        )
+    done
+done
+
+(cd "$repo_root" && tools/dev-test.sh p2 standard typescript_transform_latency "")

--- a/tests/typescript_transform_latency/run.sh
+++ b/tests/typescript_transform_latency/run.sh
@@ -4,8 +4,11 @@ set -eu
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 results_dir="$repo_root/tests/typescript_transform_latency/results"
 
-if [ "${1:-}" = "--check" ]; then
+if [ "${1:-}" = "--check" ] || [ "${1:-}" = "--check-current" ]; then
     cd "$repo_root"
+    if [ "${1:-}" = "--check-current" ]; then
+        export TYPESCRIPT_TRANSFORM_LATENCY_CHECK_CURRENT=1
+    fi
     TYPESCRIPT_TRANSFORM_LATENCY_SOURCE_ROOT="$repo_root" \
         tools/dev-test.sh p2 standard typescript_transform_latency ""
     exit 0


### PR DESCRIPTION
- resolves https://linear.app/golem-cloud/issue/GOL-417/measure-and-mitigate-uninterruptible-typescript-transform-latency
- adds a manual, report-validated latency suite for inline, entry, ESM, prepared ESM, CommonJS, and direct TypeScript transformation across P2/P3 and strip/transform modes
- records the requested 4/16/64 KiB historical profiles; generated declarations and suffixes make the largest actual inputs 65,602–65,637 bytes
- scopes the accepted 25 ms native-transform bound to the recorded three-sample macOS arm64 profiles; all direct-API maxima are at most 20.77 ms
- shows that prepared ESM reproduces nearly all of the roughly 11-second strip-mode ESM delay in the recorded profiles, leaving current phase profiling and mitigation with GOL-347 / PR #134
- clarifies that timeout deadlines and cancellation timers are armed before synchronous transformation, while cancellation is delivered only after the outer runtime regains control
- preserves the original workload capture commit, report input hashes, component identities, and timing data instead of relabeling historical measurements as current
- makes `run.sh --check` validate report contracts and the complete P2/P3 matrix, while `run.sh --check-current` explicitly detects whether a new measurement capture is required
- integrates current `main` normally and changes no production runtime behavior
