### PR TITLE
Fix falsy HTTP port defaults

### DIFF
--- a/crates/wasm-rquickjs/skeleton/src/builtin/node_http.js
+++ b/crates/wasm-rquickjs/skeleton/src/builtin/node_http.js
@@ -1455,7 +1455,7 @@ export class ClientRequest extends OutgoingMessage {
         const port = options.port;
         const defaultPort = options.defaultPort || (this.agent && this.agent.defaultPort);
         const protocolDefault = this.protocol === 'https:' ? 443 : 80;
-        const effectivePort = (port !== undefined && port !== null) ? Number(port) : (defaultPort || protocolDefault);
+        const effectivePort = Number(port || defaultPort || protocolDefault);
         this.path = options.path || '/';
         this.hostname = hostname;
         this.port = effectivePort;

--- a/examples/runtime/node-http/src/node-http.js
+++ b/examples/runtime/node-http/src/node-http.js
@@ -1,4 +1,5 @@
 import * as http from 'node:http';
+import * as https from 'node:https';
 import * as net from 'node:net';
 import { EventEmitter } from 'node:events';
 
@@ -2187,4 +2188,33 @@ export async function httpResponsePersistence() {
         if (!await runCase(options)) return false;
     }
     return true;
+}
+
+export async function httpFalsyPortUsesProtocolDefault() {
+    const httpAgent = new http.Agent();
+    httpAgent.defaultPort = 8081;
+    const httpsAgent = new https.Agent();
+    httpsAgent.defaultPort = 8443;
+    const cases = [
+        [http.request({ hostname: 'example.invalid', port: '' }), 80],
+        [https.request({ hostname: 'example.invalid', port: '' }), 443],
+        [http.request({ hostname: 'example.invalid', port: 0 }), 80],
+        [https.request({ hostname: 'example.invalid', port: 0 }), 443],
+        [http.request({ hostname: 'example.invalid', port: null }), 80],
+        [http.request({ hostname: 'example.invalid', port: false }), 80],
+        [http.request({ hostname: 'example.invalid', port: NaN }), 80],
+        [http.request({ hostname: 'example.invalid', port: '0' }), 0],
+        [https.request({ hostname: 'example.invalid', port: '0' }), 0],
+        [http.request({ hostname: 'example.invalid', port: '', defaultPort: 8080 }), 8080],
+        [http.request({ hostname: 'example.invalid', port: '', agent: httpAgent }), 8081],
+        [https.request({ hostname: 'example.invalid', port: '', agent: httpsAgent }), 8443],
+    ];
+
+    const matches = cases.every(([request, expectedPort]) => request.port === expectedPort);
+    await Promise.all(cases.map(([request]) => new Promise((resolve) => {
+        request.on('error', () => {});
+        request.once('close', resolve);
+        request.destroy();
+    })));
+    return matches;
 }

--- a/examples/runtime/node-http/wit/node-http.wit
+++ b/examples/runtime/node-http/wit/node-http.wit
@@ -29,4 +29,5 @@ world node-http {
   export http-pipelined-max-requests: func() -> bool;
   export http-custom-connection-rejected: func() -> bool;
   export http-response-persistence: func() -> bool;
+  export http-falsy-port-uses-protocol-default: func() -> bool;
 }

--- a/tests/goldenfiles/generated_types_node-http_exports.d.ts
+++ b/tests/goldenfiles/generated_types_node-http_exports.d.ts
@@ -27,4 +27,5 @@ declare module 'node-http' {
   export function httpPipelinedMaxRequests(): Promise<boolean>;
   export function httpCustomConnectionRejected(): Promise<boolean>;
   export function httpResponsePersistence(): Promise<boolean>;
+  export function httpFalsyPortUsesProtocolDefault(): Promise<boolean>;
 }

--- a/tests/node_compat/report.md
+++ b/tests/node_compat/report.md
@@ -8,21 +8,21 @@ This report is generated from `config.jsonc` only. It does **not** run the vendo
 
 Primary compatibility is measured over the public API surface we can provide: CI-enforced passing (`runnable`) plus `known-gap`. WASI-impossible tests, engine differences, unevaluated tests, and Node.js-internals tests are acknowledged separately and excluded from the primary percentage.
 
-**Primary compatibility (CI-enforced):** 3177/4387 (72.4%)
+**Primary compatibility (CI-enforced):** 3180/4387 (72.5%)
 
 When comparing revisions, read the runnable count and secondary full-public percentage alongside the primary percentage. Reclassifying a test into an excluded category can increase the primary percentage without increasing runnable coverage.
 
 | Classification | Count | Primary % | Public inventory % | All listed % |
 |----------------|-------|-----------|--------------------|--------------|
-| ✅ passing (runnable) | 3177 | 72.4% | 55.3% | 46.2% |
-| 🧩 known gap | 1210 | 27.6% | 21.0% | 17.6% |
+| ✅ passing (runnable) | 3180 | 72.5% | 55.3% | 46.3% |
+| 🧩 known gap | 1207 | 27.5% | 21.0% | 17.6% |
 | 🚫 WASI-impossible (excluded) | 1195 | — | 20.8% | 17.4% |
 | ⚙️ engine difference (excluded) | 168 | — | 2.9% | 2.4% |
 | ❔ unevaluated (excluded) | 0 | — | 0.0% | 0.0% |
 | 🔒 Node.js internals (excluded) | 1123 | — | — | 16.3% |
 | **Total** | **6873** |  |  | **100.0%** |
 
-Secondary full-public compatibility, including public tests that are currently excluded from primary: **3177/5750 (55.3%)**.
+Secondary full-public compatibility, including public tests that are currently excluded from primary: **3180/5750 (55.3%)**.
 
 ## Inventory by Module
 
@@ -686,7 +686,7 @@ Secondary full-public compatibility, including public tests that are currently e
 
 ## Classified Non-Runnable Tests
 
-### known gap (1210)
+### known gap (1207)
 
 | Reason | Count | Example entries |
 |--------|-------|-----------------|

--- a/tests/runtime/node_http.rs
+++ b/tests/runtime/node_http.rs
@@ -479,6 +479,22 @@ async fn node_http_custom_connection_rejected(
 }
 
 #[test]
+async fn node_http_falsy_port_uses_protocol_default(
+    #[tagged_as("node_http")] compiled: &CompiledTest,
+) -> anyhow::Result<()> {
+    let (result, output) = invoke_and_capture_output(
+        compiled.wasm_path(),
+        None,
+        "http-falsy-port-uses-protocol-default",
+        &[],
+    )
+    .await;
+    println!("{output}");
+    assert_eq!(result?, Some(Val::Bool(true)));
+    Ok(())
+}
+
+#[test]
 async fn node_http_response_persistence(
     #[tagged_as("node_http")] compiled: &CompiledTest,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
- resolves https://linear.app/golem-cloud/issue/GOL-550
- matches Node.js v22.14 HTTP request normalization by treating falsy numeric/coercible port inputs as absent while preserving the explicit string port `"0"`
- falls back through the configured request or agent default port before the HTTP/HTTPS protocol default
- adds focused runtime coverage for HTTP and HTTPS defaults, custom defaults, and falsy port variants, plus the generated export declaration
- refreshes the stale generated Node compatibility summary inherited from `main`
- validated by full review and focused P2/P3 runtime, report-currentness, and generated-definition checks

### Node compatibility

- runnable configuration and classifications are unchanged
- generated primary CI-enforced summary: `3177/4387 (72.4%)` → `3180/4387 (72.5%)`
- generated full-public summary: `3177/5750 (55.3%)` → `3180/5750 (55.3%)`
- the count change corrects the report already implied by the inherited configuration; it does not enable three tests in this PR
- the covered port cases match the observed Node.js v22.14 behavior
