### PR TITLE
Fix merge-aware Agentic TypeScript report validation

### DIFF
--- a/.github/scripts/select-agentic-ts-currentness.sh
+++ b/.github/scripts/select-agentic-ts-currentness.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+event_name=${1:?usage: select-agentic-ts-currentness.sh <event-name> <push-before> [pr-head]}
+push_before=${2:-}
+expected_pr_head=${3:-}
+source_ref=$(git rev-parse HEAD)
+diff_base=
+
+case "$event_name" in
+    pull_request)
+        if [[ -z "$expected_pr_head" ]]; then
+            echo "pull-request head SHA is missing" >&2
+            exit 1
+        fi
+        read -r -a head_commit <<<"$(git rev-list --parents -n 1 HEAD)"
+        if [[ ${#head_commit[@]} -ne 3 ]]; then
+            echo "pull-request checkout is not a two-parent synthetic merge" >&2
+            exit 1
+        fi
+        source_ref=$(git rev-parse HEAD^2)
+        if [[ "$source_ref" != "$(git rev-parse "$expected_pr_head")" ]]; then
+            echo "synthetic merge second parent does not match the pull-request head" >&2
+            exit 1
+        fi
+        diff_base=HEAD^1
+        ;;
+    push)
+        if [[ -n "$push_before" && ! "$push_before" =~ ^0+$ ]]; then
+            if ! git cat-file -e "$push_before^{commit}" 2>/dev/null; then
+                git fetch --no-tags --depth=1 origin "$push_before" >&2 || true
+            fi
+            if ! git cat-file -e "$push_before^{commit}" 2>/dev/null; then
+                echo "push before commit is unavailable after fetch: $push_before" >&2
+                exit 1
+            fi
+            diff_base=$push_before
+
+            read -r -a head_commit <<<"$(git rev-list --parents -n 1 HEAD)"
+            if [[ ${#head_commit[@]} -eq 3 \
+                && "$(git rev-parse HEAD^1)" == "$(git rev-parse "$push_before")" ]]; then
+                # A normal PR merge combines an already-advanced main tree with
+                # the exact measured PR tree. Validate newly introduced reports
+                # against that PR tree, not unrelated first-parent changes.
+                diff_base=HEAD^1
+                source_ref=$(git rev-parse HEAD^2)
+            fi
+        fi
+        ;;
+    *)
+        echo "unsupported GitHub event: $event_name" >&2
+        exit 1
+        ;;
+esac
+
+reports_to_check=()
+reports_count=0
+if [[ -n "$diff_base" ]]; then
+    report_list=$(mktemp)
+    trap 'rm -f "$report_list"' EXIT
+    if ! git diff --name-only --diff-filter=ACMR "$diff_base" HEAD \
+        -- 'tests/agentic_ts/results/*.json' >"$report_list"; then
+        echo "failed to select changed agentic TypeScript reports" >&2
+        exit 1
+    fi
+    while IFS= read -r report; do
+        reports_to_check+=("$report")
+        reports_count=$((reports_count + 1))
+    done <"$report_list"
+fi
+
+if [[ "$event_name" == push && $reports_count -gt 0 ]]; then
+    read -r -a head_commit <<<"$(git rev-list --parents -n 1 HEAD)"
+    if [[ ${#head_commit[@]} -gt 2 \
+        && "$(git rev-parse HEAD^1)" != "$(git rev-parse "$push_before")" ]]; then
+        echo "changed reports span a push whose merge source is ambiguous" >&2
+        exit 1
+    fi
+fi
+
+echo "source-ref=$source_ref"
+echo "reports-to-check<<AGENTIC_TS_REPORTS"
+if [[ $reports_count -gt 0 ]]; then
+    printf '%s\n' "${reports_to_check[@]}"
+fi
+echo "AGENTIC_TS_REPORTS"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,13 +59,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          # The PR checkout is a synthetic merge commit. Its first parent is
-          # needed only to select changed reports; report currentness uses the
-          # reports' BLAKE3 content hashes rather than Git identity.
+          # PR checkouts and ordinary main pushes need both merge parents:
+          # the first selects newly introduced reports, while the second is
+          # the exact source tree against which those reports were measured.
           fetch-depth: 2
       - uses: ./.github/actions/setup
+      - name: Test agentic TypeScript CI currentness selection
+        run: tests/agentic_ts/test-select-ci-currentness.sh
+      - name: Select agentic TypeScript currentness inputs
+        id: agentic-ts-currentness
+        shell: bash
+        env:
+          PUSH_BEFORE: ${{ github.event.before }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: .github/scripts/select-agentic-ts-currentness.sh "$GITHUB_EVENT_NAME" "$PUSH_BEFORE" "$PR_HEAD" >> "$GITHUB_OUTPUT"
       - name: Prepare pristine agentic TypeScript hash inputs
-        run: git worktree add --detach "$RUNNER_TEMP/agentic-ts-source" HEAD
+        run: git worktree add --detach "$RUNNER_TEMP/agentic-ts-source" "${{ steps.agentic-ts-currentness.outputs.source-ref }}"
       - name: Enable Golem wasmtime fork
         run: bash .github/scripts/enable-wasmtime-fork.sh
       # Validation mode checks committed report contracts and changed-report
@@ -74,19 +83,9 @@ jobs:
         shell: bash
         env:
           AGENTIC_TS_SOURCE_ROOT: ${{ runner.temp }}/agentic-ts-source
-          PUSH_BEFORE: ${{ github.event.before }}
+          AGENTIC_TS_REPORTS_TO_CHECK: ${{ steps.agentic-ts-currentness.outputs.reports-to-check }}
         run: |
-          reports_to_check=""
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            reports_to_check=$(git diff --name-only --diff-filter=ACMR HEAD^1 HEAD -- 'tests/agentic_ts/results/*.json')
-          elif [[ -n "$PUSH_BEFORE" && ! "$PUSH_BEFORE" =~ ^0+$ ]]; then
-            if ! git cat-file -e "$PUSH_BEFORE^{commit}" 2>/dev/null; then
-              git fetch --no-tags --depth=1 origin "$PUSH_BEFORE"
-            fi
-            reports_to_check=$(git diff --name-only --diff-filter=ACMR "$PUSH_BEFORE" HEAD -- 'tests/agentic_ts/results/*.json')
-          fi
           AGENTIC_TS_VALIDATE_REPORTS=1 \
-          AGENTIC_TS_REPORTS_TO_CHECK="$reports_to_check" \
             cargo test --test agentic_ts $CI_WASMTIME_FORK_FEATURES
       - name: Compilation, DTS and error tests
         run: cargo test --test compilation --test dts --test errors $CI_WASMTIME_FORK_FEATURES -- --report-time --format ctrf --logfile target/ctrf.json

--- a/tests/agentic_ts/results/README.md
+++ b/tests/agentic_ts/results/README.md
@@ -26,8 +26,13 @@ that both targets used the same build and benchmark inputs.
 `run.sh --check` validates every historical report and requires each P2/P3 pair
 to share the input hashes without resolving Git history. `run.sh
 --check-current` additionally compares selected reports with the current
-checkout. With five samples, the reported p95 is the observed maximum; it is
-descriptive evidence rather than a stable tail-latency estimate.
+checkout. CI performs that currentness check against the exact report-bearing
+tree. For a pull-request synthetic merge or an ordinary two-parent merge push,
+that tree is the second parent; unrelated first-parent changes must not rewrite
+a historical measurement. Direct and squash pushes are checked against their
+resulting `HEAD`, while ambiguous merge pushes fail closed. With five samples,
+the reported p95 is the observed maximum; it is descriptive evidence rather
+than a stable tail-latency estimate.
 
 ## GOL-350 CommonJS graph probe evidence
 

--- a/tests/agentic_ts/test-select-ci-currentness.sh
+++ b/tests/agentic_ts/test-select-ci-currentness.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+selector="$repo_root/.github/scripts/select-agentic-ts-currentness.sh"
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+
+git -C "$fixture" init -q -b main
+git -C "$fixture" config user.email ci-test@example.invalid
+git -C "$fixture" config user.name 'CI contract test'
+mkdir -p "$fixture/tests/agentic_ts/results"
+printf 'base\n' >"$fixture/build-input.txt"
+git -C "$fixture" add build-input.txt
+git -C "$fixture" commit -qm base
+base=$(git -C "$fixture" rev-parse HEAD)
+
+git -C "$fixture" switch -qc report-branch
+printf '{}\n' >"$fixture/tests/agentic_ts/results/report.json"
+git -C "$fixture" add tests/agentic_ts/results/report.json
+git -C "$fixture" commit -qm report
+report_head=$(git -C "$fixture" rev-parse HEAD)
+
+git -C "$fixture" switch -q main
+printf 'concurrent main change\n' >>"$fixture/build-input.txt"
+git -C "$fixture" commit -qam concurrent-main
+main_parent=$(git -C "$fixture" rev-parse HEAD)
+git -C "$fixture" merge -q --no-ff report-branch -m merge
+
+assert_plan() {
+    local event_name=$1
+    local before=$2
+    local expected_source=$3
+    local expected_report=$4
+    local expected_pr_head=${5:-}
+    local plan
+    plan=$(cd "$fixture" && "$selector" "$event_name" "$before" "$expected_pr_head")
+    grep -Fxq "source-ref=$expected_source" <<<"$plan"
+    grep -Fxq "$expected_report" <<<"$plan"
+}
+
+assert_plan pull_request '' "$report_head" tests/agentic_ts/results/report.json "$report_head"
+assert_plan push "$main_parent" "$report_head" tests/agentic_ts/results/report.json
+[[ "$(git -C "$fixture" rev-parse HEAD^2)" == "$report_head" ]]
+if (cd "$fixture" && "$selector" pull_request '' "$base") >/dev/null 2>&1; then
+    echo "mismatched pull-request head unexpectedly passed" >&2
+    exit 1
+fi
+if (cd "$fixture" && "$selector" pull_request '') >/dev/null 2>&1; then
+    echo "missing pull-request head unexpectedly passed" >&2
+    exit 1
+fi
+
+previous=$(git -C "$fixture" rev-parse HEAD)
+printf '{}\n' >"$fixture/tests/agentic_ts/results/direct.json"
+git -C "$fixture" add tests/agentic_ts/results/direct.json
+git -C "$fixture" commit -qm direct-push
+direct_head=$(git -C "$fixture" rev-parse HEAD)
+assert_plan push "$previous" "$direct_head" tests/agentic_ts/results/direct.json
+
+zero_plan=$(cd "$fixture" && "$selector" push 0000000000000000000000000000000000000000)
+grep -Fqx "source-ref=$(git -C "$fixture" rev-parse HEAD)" <<<"$zero_plan"
+if grep -Fqx tests/agentic_ts/results/direct.json <<<"$zero_plan"; then
+    echo "zero-before push unexpectedly selected a current report" >&2
+    exit 1
+fi
+
+git -C "$fixture" branch ambiguous-side "$previous"
+git -C "$fixture" switch -q ambiguous-side
+printf 'side\n' >"$fixture/side.txt"
+git -C "$fixture" add side.txt
+git -C "$fixture" commit -qm side
+git -C "$fixture" switch -q main
+git -C "$fixture" merge -q --no-ff ambiguous-side -m ambiguous-merge
+if (cd "$fixture" && "$selector" push "$previous") >/dev/null 2>&1; then
+    echo "ambiguous merge push unexpectedly selected a source" >&2
+    exit 1
+fi
+
+fake_bin="$fixture/fake-bin"
+mkdir "$fake_bin"
+real_git=$(command -v git)
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'if [[ ${1:-} == fetch ]]; then exit 74; fi' \
+    'if [[ ${1:-} == diff ]]; then exit 73; fi' >"$fake_bin/git"
+printf 'exec %q "$@"\n' "$real_git" >>"$fake_bin/git"
+chmod +x "$fake_bin/git"
+if (cd "$fixture" && PATH="$fake_bin:$PATH" "$selector" push HEAD^1) >/dev/null 2>&1; then
+    echo "failed git diff unexpectedly produced a validation plan" >&2
+    exit 1
+fi
+missing_before=0000000000000000000000000000000000000001
+if missing_error=$(cd "$fixture" && PATH="$fake_bin:$PATH" \
+    "$selector" push "$missing_before" 2>&1); then
+    echo "unresolvable push-before commit unexpectedly passed" >&2
+    exit 1
+fi
+grep -Fq "push before commit is unavailable after fetch: $missing_before" <<<"$missing_error"
+
+[[ "$base" != "$main_parent" ]]


### PR DESCRIPTION
- validates newly introduced Agentic TypeScript reports against the exact report-bearing source tree for pull-request merges and ordinary two-parent main merges
- keeps direct and squash pushes strict against their resulting `HEAD`, while missing history, mismatched PR heads, failed Git selection, and ambiguous merge pushes fail closed
- adds a temporary-Git-repository contract test covering merge, direct-push, creation-event, and failure-path behavior
- preserves the historical September 7 reports instead of remeasuring them for an unrelated first-parent source change
- documents the merge-aware report-currentness contract
