### PR TITLE
Fail closed on missing node-compat suite inputs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,7 @@ jobs:
         run: bash tests/node_compat/vendor.sh
       - name: Module inventory contracts
         if: matrix.shard == 0
-        run: cargo test --test node_compat_report $CI_WASMTIME_FORK_FEATURES -- module_related_node_compat_entries_are_configured module_related_known_gaps_are_deferred_or_covered module_known_gap_deferrals_require_an_exact_reason node_compat_config_report_is_current vm_split_fixtures_include_top_level_executable_statements --report-time
+        run: cargo test --test node_compat_report $CI_WASMTIME_FORK_FEATURES -- module_related_node_compat_entries_are_configured module_related_known_gaps_are_deferred_or_covered module_known_gap_deferrals_require_an_exact_reason node_compat_config_report_is_current node_compat_config_requires_vendored_suite node_compat_config_requires_matching_vendored_version node_compat_config_requires_source_for_implicit_classification node_compat_config_classifies_from_vendored_source vm_split_fixtures_include_top_level_executable_statements --report-time
       - name: Node compat tests (shard ${{ matrix.shard }}/8)
         run: cargo test --test node_compat $CI_WASMTIME_FORK_FEATURES -- --report-time --format ctrf --logfile target/ctrf.json ':tag:shard${{ matrix.shard }}'
       - name: Publish Test Report

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3073,6 +3073,7 @@ fn node_compat_category_from_entry(
     path: &str,
     entry: &serde_json::Value,
     inherited: Option<NodeCompatCategory>,
+    suite_root: &std::path::Path,
 ) -> anyhow::Result<NodeCompatCategory> {
     if let Some(category) = entry.get("category").and_then(|v| v.as_str()) {
         return NodeCompatCategory::from_config_value(category);
@@ -3090,7 +3091,7 @@ fn node_compat_category_from_entry(
         let reason = entry.get("reason").and_then(|v| v.as_str()).unwrap_or("");
         return Ok(if is_unevaluated_node_compat_reason(reason) {
             NodeCompatCategory::Unevaluated
-        } else if uses_node_internals(path) {
+        } else if uses_node_internals(suite_root, path)? {
             NodeCompatCategory::NodeInternals
         } else {
             NodeCompatCategory::KnownGap
@@ -3103,7 +3104,7 @@ fn node_compat_category_from_entry(
         return Ok(category);
     }
 
-    if uses_node_internals(path) {
+    if uses_node_internals(suite_root, path)? {
         Ok(NodeCompatCategory::NodeInternals)
     } else {
         Ok(NodeCompatCategory::Runnable)
@@ -3111,9 +3112,27 @@ fn node_compat_category_from_entry(
 }
 
 pub fn load_node_compat_config(path: &str) -> anyhow::Result<Vec<NodeCompatTestEntry>> {
+    let config_path = std::path::Path::new(path);
+    let suite_root = config_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("suite");
+    load_node_compat_config_with_suite_root(path, &suite_root)
+}
+
+pub fn load_node_compat_config_with_suite_root(
+    path: &str,
+    suite_root: &std::path::Path,
+) -> anyhow::Result<Vec<NodeCompatTestEntry>> {
     let content = fs::read_to_string(path)?;
     let json_str = strip_jsonc_comments(&content);
     let value: serde_json::Value = serde_json::from_str(&json_str)?;
+
+    let expected_node_version = value
+        .get("nodeVersion")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| anyhow!("config.jsonc missing string 'nodeVersion'"))?;
+    validate_node_compat_suite(suite_root, expected_node_version)?;
 
     let tests_obj = value
         .get("tests")
@@ -3122,7 +3141,7 @@ pub fn load_node_compat_config(path: &str) -> anyhow::Result<Vec<NodeCompatTestE
 
     let mut tests = Vec::new();
     for (path, opts) in tests_obj {
-        let category = node_compat_category_from_entry(path, opts, None)?;
+        let category = node_compat_category_from_entry(path, opts, None, suite_root)?;
         let reason = opts
             .get("reason")
             .and_then(|v| v.as_str())
@@ -3145,8 +3164,12 @@ pub fn load_node_compat_config(path: &str) -> anyhow::Result<Vec<NodeCompatTestE
         let mut subtests = Vec::new();
         if let Some(subtests_obj) = opts.get("subtests").and_then(|v| v.as_object()) {
             for (subtest_name, subtest_opts) in subtests_obj {
-                let sub_category =
-                    node_compat_category_from_entry(path, subtest_opts, Some(category))?;
+                let sub_category = node_compat_category_from_entry(
+                    path,
+                    subtest_opts,
+                    Some(category),
+                    suite_root,
+                )?;
                 let sub_reason = subtest_opts
                     .get("reason")
                     .and_then(|v| v.as_str())
@@ -3181,6 +3204,27 @@ pub fn load_node_compat_config(path: &str) -> anyhow::Result<Vec<NodeCompatTestE
     }
 
     Ok(tests)
+}
+
+fn validate_node_compat_suite(
+    suite_root: &std::path::Path,
+    expected_node_version: &str,
+) -> anyhow::Result<()> {
+    let version_path = suite_root.join("NODE_VERSION");
+    let actual_node_version = fs::read_to_string(&version_path).map_err(|error| {
+        anyhow!(
+            "vendored Node.js test suite is unavailable at {}: {error}; run ./tests/node_compat/vendor.sh {expected_node_version}",
+            version_path.display()
+        )
+    })?;
+    let actual_node_version = actual_node_version.trim();
+    if actual_node_version != expected_node_version {
+        return Err(anyhow!(
+            "vendored Node.js test suite version mismatch at {}: config requires {expected_node_version}, found {actual_node_version:?}; run ./tests/node_compat/vendor.sh {expected_node_version}",
+            version_path.display()
+        ));
+    }
+    Ok(())
 }
 
 pub fn load_node_modules_apps_config(path: &str) -> anyhow::Result<Vec<NodeModulesAppEntry>> {
@@ -5182,19 +5226,21 @@ pub fn classify_test(filename: &str) -> &str {
 ///
 /// Detects patterns like `// Flags: --expose-internals`, `require('internal/...')`,
 /// and `internalBinding(...)` in the test source code.
-pub fn uses_node_internals(test_path: &str) -> bool {
-    let file_path = format!("tests/node_compat/suite/{test_path}");
-    let content = match fs::read_to_string(&file_path) {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
+fn uses_node_internals(suite_root: &std::path::Path, test_path: &str) -> anyhow::Result<bool> {
+    let file_path = suite_root.join(test_path);
+    let content = fs::read_to_string(&file_path).map_err(|error| {
+        anyhow!(
+            "cannot classify node-compat entry {test_path:?}: vendored source {} is unavailable: {error}; re-run ./tests/node_compat/vendor.sh",
+            file_path.display()
+        )
+    })?;
     // Only check the first 50 lines for the Flags comment (it's always near the top)
     let header: String = content.lines().take(50).collect::<Vec<_>>().join("\n");
     if header.contains("--expose-internals") {
-        return true;
+        return Ok(true);
     }
     // Check the full file for internal requires/bindings
-    content.contains("require('internal/")
+    Ok(content.contains("require('internal/")
         || content.contains("require(\"internal/")
-        || content.contains("internalBinding(")
+        || content.contains("internalBinding("))
 }

--- a/tests/node_compat/README.md
+++ b/tests/node_compat/README.md
@@ -38,6 +38,12 @@ This sparse-checkouts `test/parallel/`, `test/sequential/`, `test/es-module/`,
 specified tag. The `suite/` directory is gitignored — each
 developer runs the vendor script to populate it.
 
+Configuration loading and report generation inspect these pinned sources to
+distinguish public API coverage from tests that rely on Node.js internals. They
+fail when the suite is absent, a source required for implicit classification is
+missing, or the vendored version differs from `config.jsonc`; this prevents
+missing classification inputs from silently changing the compatibility totals.
+
 ## Config Format
 
 `config.jsonc` is an allowlist of tests expected to pass. Only listed tests

--- a/tests/node_compat/generate-report.sh
+++ b/tests/node_compat/generate-report.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SUITE_DIR="${SCRIPT_DIR}/suite"
 
-if [ ! -d "${SUITE_DIR}" ]; then
+if [ ! -f "${SUITE_DIR}/NODE_VERSION" ]; then
   echo "Error: vendored test suite not found at ${SUITE_DIR}"
   echo "Run ./tests/node_compat/vendor.sh first."
   exit 1
@@ -23,7 +23,7 @@ fi
 
 cd "${REPO_ROOT}"
 
-echo "==> Generating report from config.jsonc..."
-cargo test --release --test node_compat_report -- --nocapture
+echo "==> Generating report from config.jsonc and pinned vendored Node.js sources..."
+cargo test --release --test node_compat_report -- generate_node_compat_config_report --nocapture
 
 echo "==> Report written to tests/node_compat/report.md"

--- a/tests/node_compat/report.md
+++ b/tests/node_compat/report.md
@@ -2,7 +2,7 @@
 
 Source: `tests/node_compat/config.jsonc` | Engine: wasm-rquickjs (QuickJS)
 
-This report is generated from `config.jsonc` only. It does **not** run the vendored tests itself. Entries classified as `runnable` are reported as passing because the `node_compat` PR test executes runnable entries and fails CI if any of them fail.
+This report is generated from `config.jsonc` and the pinned vendored Node.js sources used to detect tests that rely on Node internals. It does **not** run the vendored tests itself. Entries classified as `runnable` are reported as passing because the `node_compat` PR test executes runnable entries and fails CI if any of them fail.
 
 ## Summary
 

--- a/tests/node_compat_config_report.rs
+++ b/tests/node_compat_config_report.rs
@@ -1,8 +1,9 @@
 //! Node.js compatibility inventory report generator.
 //!
-//! This report is generated only from tests/node_compat/config.jsonc. It does not compile or run
-//! the node compatibility runner itself. Entries classified as `runnable` are treated as passing
-//! because the node compatibility PR test runs them and fails CI if any of them fail.
+//! This report is generated from tests/node_compat/config.jsonc plus the pinned vendored Node.js
+//! sources used to detect tests that rely on Node internals. It does not compile or run the node
+//! compatibility runner itself. Entries classified as `runnable` are treated as passing because
+//! the node compatibility PR test runs them and fails CI if any of them fail.
 //!
 //! Usage:
 //!   cargo test --test node_compat_report -- --nocapture
@@ -14,10 +15,11 @@ test_r::enable!();
 #[allow(dead_code)]
 mod common;
 
+use camino_tempfile::Utf8TempDir;
 use common::js_subtest_parser::{BlockKind, SubtestDiscovery, discover_subtests_with_options};
 use common::{
     NodeCompatCategory, NodeCompatTestEntry, classify_test, load_node_compat_config,
-    strip_jsonc_comments,
+    load_node_compat_config_with_suite_root, strip_jsonc_comments,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -145,8 +147,9 @@ fn render_node_compat_config_report() -> anyhow::Result<(String, CategoryCounts)
         "Source: `{CONFIG_PATH}` | Engine: wasm-rquickjs (QuickJS)\n\n"
     ));
     report.push_str(
-        "This report is generated from `config.jsonc` only. It does **not** run the vendored \
-         tests itself. Entries classified as `runnable` are reported as passing because the \
+        "This report is generated from `config.jsonc` and the pinned vendored Node.js sources \
+         used to detect tests that rely on Node internals. It does **not** run the vendored tests \
+         itself. Entries classified as `runnable` are reported as passing because the \
          `node_compat` PR test executes runnable entries and fails CI if any of them fail.\n\n",
     );
 
@@ -157,6 +160,110 @@ fn render_node_compat_config_report() -> anyhow::Result<(String, CategoryCounts)
     push_missing_reasons(&mut report, &missing_reasons);
 
     Ok((report, counts))
+}
+
+#[test]
+fn node_compat_config_requires_vendored_suite() -> anyhow::Result<()> {
+    let fixture = NodeCompatConfigFixture::new()?;
+    let error = fixture.load().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("vendored Node.js test suite is unavailable"),
+        "{error:#}"
+    );
+    Ok(())
+}
+
+#[test]
+fn node_compat_config_requires_matching_vendored_version() -> anyhow::Result<()> {
+    let fixture = NodeCompatConfigFixture::new()?;
+    fixture.write_suite_version("22.13.0")?;
+    let error = fixture.load().unwrap_err();
+    assert!(error.to_string().contains("version mismatch"), "{error:#}");
+    assert!(error.to_string().contains("22.14.0"), "{error:#}");
+    Ok(())
+}
+
+#[test]
+fn node_compat_config_requires_source_for_implicit_classification() -> anyhow::Result<()> {
+    let fixture = NodeCompatConfigFixture::with_implicit_entry()?;
+    fixture.write_suite_version("22.14.0")?;
+    let error = fixture.load().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("cannot classify node-compat entry"),
+        "{error:#}"
+    );
+    Ok(())
+}
+
+#[test]
+fn node_compat_config_classifies_from_vendored_source() -> anyhow::Result<()> {
+    let fixture = NodeCompatConfigFixture::with_implicit_entry()?;
+    fixture.write_suite_version("22.14.0")?;
+    fixture.write_source("// Flags: --expose-internals\n'use strict';\n")?;
+    let entries = fixture.load()?;
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].category, NodeCompatCategory::NodeInternals);
+    Ok(())
+}
+
+struct NodeCompatConfigFixture {
+    _temp: Utf8TempDir,
+    config_path: camino::Utf8PathBuf,
+    suite_root: camino::Utf8PathBuf,
+}
+
+impl NodeCompatConfigFixture {
+    fn new() -> anyhow::Result<Self> {
+        Self::create(false)
+    }
+
+    fn with_implicit_entry() -> anyhow::Result<Self> {
+        Self::create(true)
+    }
+
+    fn create(with_implicit_entry: bool) -> anyhow::Result<Self> {
+        let temp = Utf8TempDir::new()?;
+        let config_path = temp.path().join("config.jsonc");
+        let suite_root = temp.path().join("suite");
+        let tests = if with_implicit_entry {
+            r#"{"parallel/test-internal.js": {}}"#
+        } else {
+            "{}"
+        };
+        fs::write(
+            &config_path,
+            format!(r#"{{"nodeVersion": "22.14.0", "tests": {tests}}}"#),
+        )?;
+        Ok(Self {
+            _temp: temp,
+            config_path,
+            suite_root,
+        })
+    }
+
+    fn write_suite_version(&self, version: &str) -> anyhow::Result<()> {
+        fs::create_dir_all(&self.suite_root)?;
+        fs::write(self.suite_root.join("NODE_VERSION"), format!("{version}\n"))?;
+        Ok(())
+    }
+
+    fn write_source(&self, source: &str) -> anyhow::Result<()> {
+        let source_path = self.suite_root.join("parallel/test-internal.js");
+        fs::create_dir_all(source_path.parent().unwrap())?;
+        fs::write(source_path, source)?;
+        Ok(())
+    }
+
+    fn load(&self) -> anyhow::Result<Vec<NodeCompatTestEntry>> {
+        load_node_compat_config_with_suite_root(
+            self.config_path.as_str(),
+            self.suite_root.as_std_path(),
+        )
+    }
 }
 
 #[test]


### PR DESCRIPTION
- makes node-compat configuration and report loading fail when the pinned vendored suite is absent, its Node version differs from `config.jsonc`, or a source required for implicit Node-internals classification is missing
- replaces the silent missing-source fallback that could misclassify Node-internal tests as runnable
- documents the vendored-source dependency in the generator, checked-in report, and node-compat workflow
- adds four CI-enforced regression cases for missing, mismatched, and valid suite inputs
- narrows the report generator helper to the writing test so it cannot race report generation against currentness validation

### Node compatibility

- primary CI-enforced: `3180/4387 (72.5%)` → `3180/4387 (72.5%)`
- full public: `3180/5750 (55.3%)` → `3180/5750 (55.3%)`
- no compatibility classifications or runnable cases change; this makes the existing inventory fail closed when its required inputs are unavailable
